### PR TITLE
Support hot reloading for new example files

### DIFF
--- a/loaders/styleguide.loader.js
+++ b/loaders/styleguide.loader.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 const prettyjson = require('prettyjson');
 const pick = require('lodash/pick');
 const utils = require('./utils/js');
 const requireIt = utils.requireIt;
+const requireMaybe = utils.requireMaybe;
 const toCode = utils.toCode;
 
 /* eslint-disable no-console */
@@ -53,15 +53,11 @@ function getNameFallback(filepath) {
  * @returns {string}
  */
 function getExamples(examplesFile, nameFallback, defaultExample) {
-	if (fs.existsSync(examplesFile)) {
-		return requireIt('examples!' + examplesFile);
-	}
+	const alternate = defaultExample
+		? 'examples?componentName=' + nameFallback + '!' + defaultExample
+		: null;
 
-	if (defaultExample) {
-		return requireIt('examples?componentName=' + nameFallback + '!' + defaultExample);
-	}
-
-	return null;
+	return requireMaybe('examples!' + examplesFile, alternate);
 }
 
 /**
@@ -90,10 +86,6 @@ function processComponentsSource(components, config) {
 		console.log('Loading components:');
 		console.log(prettyjson.render(componentFiles));
 		console.log();
-	}
-
-	if (config.skipComponentsWithoutExample) {
-		componentFiles = componentFiles.filter(filepath => fs.existsSync(config.getExampleFilename(filepath)));
 	}
 
 	return toCode(componentFiles.map(filepath => processComponent(filepath, config)));
@@ -142,6 +134,7 @@ module.exports.pitch = function() {
 		'highlightTheme',
 		'showCode',
 		'previewDelay',
+		'skipComponentsWithoutExample',
 	]);
 
 	const code = toCode({

--- a/loaders/utils/js.js
+++ b/loaders/utils/js.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const map = require('lodash/map');
+const path = require('path');
+const escapeRegExp = require('lodash/escapeRegExp');
 
 /**
  * Convert plain JavaScript objects and arrays to text representation: WITHOUT any escaping.
@@ -31,7 +33,22 @@ function requireIt(name) {
 	return 'require(' + JSON.stringify(name) + ')';
 }
 
+function requireMaybe(name, alternate) {
+	const dir = JSON.stringify(path.dirname(name));
+	const file = JSON.stringify(`./${path.basename(name)}`);
+	const fileRegexp = `/\\/${escapeRegExp(path.basename(name))}$/`;
+	const requireAlternate = alternate ? requireIt(alternate) : JSON.stringify(null);
+
+	return [
+		'(function () {',
+		`var req = require.context(${dir}, false, ${fileRegexp});`,
+		`return req.keys().indexOf(${file}) >= 0 ? req(${file}) : ${requireAlternate}`,
+		'})()',
+	].join('\n');
+}
+
 module.exports = {
 	toCode,
 	requireIt,
+	requireMaybe,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,8 @@ let codeKey = 0;
 function renderStyleguide() {
 	const styleguide = require('styleguide!index.js');
 
-	let components = processComponents(styleguide.components);
-	let sections = processSections(styleguide.sections || []);
+	let components = processComponents(styleguide.components, styleguide.config);
+	let sections = processSections(styleguide.sections || [], styleguide.config);
 	let sidebar = true;
 	let singleExample = false;
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -43,18 +43,25 @@ export function flattenChildren(components) {
 	});
 }
 
-export function processComponents(components) {
+function removeComponentsWithoutExample(components) {
+	return components && components.filter(component => component.examples);
+}
+
+export function processComponents(components, config) {
 	components = flattenChildren(components);
 	components = promoteInlineExamples(components);
 	components = setComponentsNames(components);
+	if (config.skipComponentsWithoutExample) {
+		components = removeComponentsWithoutExample(components);
+	}
 	globalizeComponents(components);
 	return components;
 }
 
-export function processSections(sections) {
+export function processSections(sections, config) {
 	return sections.map(section => {
-		section.components = processComponents(section.components || []);
-		section.sections = processSections(section.sections || []);
+		section.components = processComponents(section.components || [], config);
+		section.sections = processSections(section.sections || [], config);
 		return section;
 	});
 }


### PR DESCRIPTION
I finally got around to getting this working. This uses webpack's context feature to essentially express your intent that you want to require something from a particular directory, so rather than having to check in loader code we can check in the actual webpack compiled code.

This makes hot reloading work for new example files and I'm hoping it'll fix our usage with hard-source-webpack-plugin