### PR TITLE
Add mobile styles to improve display on narrow screens

### DIFF
--- a/src/rsg-components/ComponentsList/ComponentsList.css
+++ b/src/rsg-components/ComponentsList/ComponentsList.css
@@ -1,6 +1,5 @@
 .list {
-	margin: 0;
-	padding: 15px;
+	margin: 15px;
 }
 
 .item {
@@ -18,7 +17,7 @@
 }
 
 @media (max-width: 600px) {
-	.item .item {
+	:not(.isParent).item {
 		display: inline-block;
 		margin: 0 7px 0 0;
 	}

--- a/src/rsg-components/ComponentsList/ComponentsList.css
+++ b/src/rsg-components/ComponentsList/ComponentsList.css
@@ -16,3 +16,10 @@
 .heading {
 	font-weight: bold;
 }
+
+@media (max-width: 600px) {
+	.item .item {
+		display: inline-block;
+		margin: 0 7px 0 0;
+	}
+}

--- a/src/rsg-components/ComponentsList/ComponentsListRenderer.js
+++ b/src/rsg-components/ComponentsList/ComponentsListRenderer.js
@@ -7,7 +7,7 @@ const ComponentsListRenderer = ({ items }) => (
 	items.length ? (
 		<div className={s.list}>
 			{items.map(({ heading, name, content }) => (
-				<div className={s.item} key={name}>
+				<div className={cx(s.item, content && content.props.items.length && s.isParent)} key={name}>
 					<a className={cx(s.link, heading && s.heading)} href={'#' + name}>{name}</a>
 					{content}
 				</div>

--- a/src/rsg-components/StyleGuide/StyleGuide.css
+++ b/src/rsg-components/StyleGuide/StyleGuide.css
@@ -20,7 +20,7 @@
 	left: 0;
 	bottom: 0;
 	width: 200px;
-	overflow: scroll;
+	overflow: auto;
 }
 
 .components {
@@ -42,4 +42,22 @@
 	composes: font from "../../styles/common.css";
 	composes: light from "../../styles/colors.css";
 	font-size: 12px;
+}
+
+@media (max-width: 600px) {
+	.root.hasSidebar {
+		padding-left: 0;
+		display: flex;
+		flex-direction: column;
+	}
+	.content {
+		padding: 15px;
+		order: 2;
+	}
+	.sidebar {
+		position: static;
+		width: auto;
+		border-width: 0 0 1px 0;
+		order: 1;
+	}
 }

--- a/src/rsg-components/TableOfContents/TableOfContents.css
+++ b/src/rsg-components/TableOfContents/TableOfContents.css
@@ -7,7 +7,7 @@
 	display: block;
 	box-sizing: border-box;
 	width: 170px;
-	margin: 15px 0 0 15px;
+	margin: 15px;
 	padding: 6px 12px;
 	font-size: 15px;
 	border-radius: 2px;


### PR DESCRIPTION
On screens narrower than 600px the sidebar will be moved to the top of the page and displayed as a static element to allow content column to take up all of the space. 