### PR TITLE
Fix path and styles in "customised" example

### DIFF
--- a/examples/customised/styleguide.config.js
+++ b/examples/customised/styleguide.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
 	title: 'Style guide example',
-	components: './components/**/[A-Z]*.js',
+	components: './lib/components/**/[A-Z]*.js',
 	updateWebpackConfig(webpackConfig) {
 		const dirs = [
 			path.resolve(__dirname, 'lib'),

--- a/examples/customised/styleguide/components/ReactComponent/ReactComponent.css
+++ b/examples/customised/styleguide/components/ReactComponent/ReactComponent.css
@@ -18,6 +18,7 @@
 	padding: 10px;
 	font-weight: normal;
 	background: #efefef;
+	overflow: hidden;
 }
 
 .heading {
@@ -63,6 +64,8 @@
 	composes: light from "../../styles/colors.css";
 	margin-top: 5px;
 	font-size: 14px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .props {


### PR DESCRIPTION
This PR fixes two issues with `customised` example:
- wrong path to components (so running `npm run start:customised` doesn't show a "no components found" page)
- unrestricted width of component path string (so the headers and prop tables don't get wider than the enclosing container, [before](https://cloud.githubusercontent.com/assets/632081/20463341/6d95d4b6-af6b-11e6-8c97-f9ae3341f1bd.png)/[after](https://cloud.githubusercontent.com/assets/632081/20463344/7354c114-af6b-11e6-93e9-e3dd63889197.png))