### PR TITLE
Don't display sidebar and search field if there are no components found

### DIFF
--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -64,7 +64,7 @@ export default class StyleGuide extends Component {
 				components={this.renderComponents(components, sections, sidebar, singleExample)}
 				sections={sections}
 				toc={this.renderTableOfContents(components, sections)}
-				sidebar={!isEmpty(components) || !isEmpty(sections)}
+				sidebar={(isEmpty(components) && isEmpty(sections)) ? false : sidebar}
 			/>
 		);
 	}

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -64,7 +64,7 @@ export default class StyleGuide extends Component {
 				components={this.renderComponents(components, sections, sidebar, singleExample)}
 				sections={sections}
 				toc={this.renderTableOfContents(components, sections)}
-				sidebar={sidebar}
+				sidebar={!isEmpty(components) || !isEmpty(sections)}
 			/>
 		);
 	}


### PR DESCRIPTION
There is a search field on the "no components found" page (can be encountered in `customised` example before [PR #246](https://github.com/styleguidist/react-styleguidist/pull/246) It is lonely and somewhat useless, and probably shouldn't be there in the first place.