### PR TITLE
Update examples deps, add webpack as dep

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -16,14 +16,15 @@
     "node": ">=4"
   },
   "dependencies": {
-    "babel-preset-es2015": "6.14.0",
-    "babel-preset-react": "6.11.1",
-    "babel-preset-stage-0": "6.5.0",
-    "dog-names": "~1.0.2",
-    "react-styleguidist": ">=3.0.0",
-    "react": "~15.3.2",
-    "react-dom": "~15.3.2",
-    "react-modal": "~1.4.0"
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "dog-names": "^1.0.2",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
+    "react-modal": "^1.6.3",
+    "react-styleguidist": "^4.4.1",
+    "webpack": "^1.14.0"
   },
   "scripts": {
     "styleguide-server": "styleguidist server",

--- a/examples/customised/package.json
+++ b/examples/customised/package.json
@@ -16,14 +16,15 @@
     "node": ">=4"
   },
   "dependencies": {
-    "babel-preset-es2015": "6.14.0",
-    "babel-preset-react": "6.11.1",
-    "babel-preset-stage-0": "6.5.0",
-    "dog-names": "~1.0.2",
-    "react-styleguidist": ">=3.0.0",
-    "react": "~15.3.2",
-    "react-dom": "~15.3.2",
-    "react-modal": "~1.4.0"
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "dog-names": "^1.0.2",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
+    "react-modal": "^1.6.3",
+    "react-styleguidist": "^4.4.1",
+    "webpack": "^1.14.0"
   },
   "scripts": {
     "styleguide-server": "styleguidist server",

--- a/examples/sections/package.json
+++ b/examples/sections/package.json
@@ -16,14 +16,15 @@
     "node": ">=4"
   },
   "dependencies": {
-    "babel-preset-es2015": "6.14.0",
-    "babel-preset-react": "6.11.1",
-    "babel-preset-stage-0": "6.5.0",
-    "dog-names": "~1.0.2",
-    "react-styleguidist": ">=3.0.0",
-    "react": "~15.3.2",
-    "react-dom": "~15.3.2",
-    "react-modal": "~1.4.0"
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "dog-names": "^1.0.2",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
+    "react-modal": "^1.6.3",
+    "react-styleguidist": "^4.4.1",
+    "webpack": "^1.14.0"
   },
   "scripts": {
     "styleguide-server": "styleguidist server",


### PR DESCRIPTION
Decided to add webpack as dependency for examples, since it is a peer dependency for styleguidist now. Easier to install everything in one go.
Also bumped up other deps, everything seems working correctly.