### PR TITLE
Fix eslint errors

### DIFF
--- a/examples/basic/lib/components/Button/Button.js
+++ b/examples/basic/lib/components/Button/Button.js
@@ -10,7 +10,7 @@ export default function Button({
 	size,
 	children,
 }) {
-	let styles = {
+	const styles = {
 		color,
 		fontSize: Button.sizes[size],
 	};

--- a/examples/basic/lib/components/Modal/Modal.js
+++ b/examples/basic/lib/components/Modal/Modal.js
@@ -11,8 +11,8 @@ export default class Modal extends Component {
 	};
 
 	render() {
-		let { isOpen, children } = this.props;
-		let style = {
+		const { isOpen, children } = this.props;
+		const style = {
 			overlay: {
 				zIndex: 999,
 			},

--- a/examples/basic/lib/components/Placeholder/Placeholder.js
+++ b/examples/basic/lib/components/Placeholder/Placeholder.js
@@ -19,8 +19,8 @@ export default class Placeholder extends Component {
 	};
 
 	getImageUrl() {
-		let { type, width, height } = this.props;
-		let types = {
+		const { type, width, height } = this.props;
+		const types = {
 			animal: `http://placeimg.com/${width}/${height}/animals`,
 			bacon: `http://baconmockup.com/${width}/${height}`,
 			bear: `http://www.placebear.com/${width}/${height}`,
@@ -35,7 +35,7 @@ export default class Placeholder extends Component {
 	}
 
 	render() {
-		let { width, height } = this.props;
+		const { width, height } = this.props;
 		return (
 			<img className={s.root} src={this.getImageUrl()} width={width} height={height} />
 		);

--- a/examples/basic/lib/components/PushButton/PushButton.js
+++ b/examples/basic/lib/components/PushButton/PushButton.js
@@ -10,7 +10,7 @@ export default function PushButton({
 	size,
 	children,
 }) {
-	let styles = {
+	const styles = {
 		color,
 		fontSize: PushButton.sizes[size],
 	};

--- a/examples/basic/lib/components/WrappedButton/WrappedButton.js
+++ b/examples/basic/lib/components/WrappedButton/WrappedButton.js
@@ -10,7 +10,7 @@ const WrappedButton = ({
 	size,
 	children,
 }) => {
-	let styles = {
+	const styles = {
 		color,
 		fontSize: WrappedButton.sizes[size],
 	};

--- a/examples/customised/lib/components/Button/Button.js
+++ b/examples/customised/lib/components/Button/Button.js
@@ -10,7 +10,7 @@ export default function Button({
 	size,
 	children,
 }) {
-	let styles = {
+	const styles = {
 		color,
 		fontSize: Button.sizes[size],
 	};

--- a/examples/customised/lib/components/Modal/Modal.js
+++ b/examples/customised/lib/components/Modal/Modal.js
@@ -11,8 +11,8 @@ export default class Modal extends Component {
 	};
 
 	render() {
-		let { isOpen, children } = this.props;
-		let style = {
+		const { isOpen, children } = this.props;
+		const style = {
 			overlay: {
 				zIndex: 999,
 			},

--- a/examples/customised/lib/components/Placeholder/Placeholder.js
+++ b/examples/customised/lib/components/Placeholder/Placeholder.js
@@ -19,8 +19,8 @@ export default class Placeholder extends Component {
 	};
 
 	getImageUrl() {
-		let { type, width, height } = this.props;
-		let types = {
+		const { type, width, height } = this.props;
+		const types = {
 			animal: `http://placeimg.com/${width}/${height}/animals`,
 			bacon: `http://baconmockup.com/${width}/${height}`,
 			bear: `http://www.placebear.com/${width}/${height}`,
@@ -35,7 +35,7 @@ export default class Placeholder extends Component {
 	}
 
 	render() {
-		let { width, height } = this.props;
+		const { width, height } = this.props;
 		return (
 			<img className={s.root} src={this.getImageUrl()} width={width} height={height} />
 		);

--- a/examples/sections/lib/components/Button/Button.js
+++ b/examples/sections/lib/components/Button/Button.js
@@ -10,7 +10,7 @@ export default function Button({
 	size,
 	children,
 }) {
-	let styles = {
+	const styles = {
 		color,
 		fontSize: Button.sizes[size],
 	};

--- a/examples/sections/lib/components/Modal/Modal.js
+++ b/examples/sections/lib/components/Modal/Modal.js
@@ -11,8 +11,8 @@ export default class Modal extends Component {
 	};
 
 	render() {
-		let { isOpen, children } = this.props;
-		let style = {
+		const { isOpen, children } = this.props;
+		const style = {
 			overlay: {
 				zIndex: 999,
 			},

--- a/examples/sections/lib/components/Placeholder/Placeholder.js
+++ b/examples/sections/lib/components/Placeholder/Placeholder.js
@@ -19,8 +19,8 @@ export default class Placeholder extends Component {
 	};
 
 	getImageUrl() {
-		let { type, width, height } = this.props;
-		let types = {
+		const { type, width, height } = this.props;
+		const types = {
 			animal: `http://placeimg.com/${width}/${height}/animals`,
 			bacon: `http://baconmockup.com/${width}/${height}`,
 			bear: `http://www.placebear.com/${width}/${height}`,
@@ -35,7 +35,7 @@ export default class Placeholder extends Component {
 	}
 
 	render() {
-		let { width, height } = this.props;
+		const { width, height } = this.props;
 		return (
 			<img className={s.root} src={this.getImageUrl()} width={width} height={height} />
 		);

--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -13,7 +13,7 @@ const CODE_PLACEHOLDER = '<%{#code#}%>';
  * @returns {Array}
  */
 module.exports = function chunkify(markdown) {
-	let codeChunks = [];
+	const codeChunks = [];
 
 	/*
 	 * - Highlight code in fenced code blocks with defined language (```html) if the language is not `example`.
@@ -48,7 +48,7 @@ module.exports = function chunkify(markdown) {
 		.contents
 	;
 
-	let chunks = [];
+	const chunks = [];
 	const textChunks = rendered.split(CODE_PLACEHOLDER);
 	textChunks.forEach(chunk => {
 		if (chunk) {

--- a/loaders/utils/getRequires.js
+++ b/loaders/utils/getRequires.js
@@ -17,7 +17,7 @@ const SIMPLE_STRING_REGEX = /^"([^"]+)"$|^'([^']+)'$/;
  * @returns {Array}
  */
 module.exports = function getRequires(code) {
-	let requires = {};
+	const requires = {};
 	code.replace(REQUIRE_ANYTHING_REGEX, function(requireExprMatch, requiredExpr) {
 		const requireStrMatch = SIMPLE_STRING_REGEX.exec(requiredExpr.trim());
 		if (!requireStrMatch) {

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -41,7 +41,7 @@ export default class Preview extends Component {
 			error: null,
 		});
 
-		let { code } = this.props;
+		const { code } = this.props;
 		if (!code) {
 			return;
 		}

--- a/src/rsg-components/Props/Props.spec.js
+++ b/src/rsg-components/Props/Props.spec.js
@@ -8,7 +8,7 @@ import PropsRenderer from './PropsRenderer';
 import { unquote, getType } from './util';
 
 function render(propTypes, defaultProps = []) {
-	let props = parse(`
+	const props = parse(`
 		import { Component, PropTypes } from 'react';
 		export default class Cmpnt extends Component {
 			static propTypes = {

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -7,9 +7,9 @@ import { unquote, getType, showSpaces } from './util';
 import s from './Props.css';
 
 function renderRows(props) {
-	let rows = [];
-	for (let name in props) {
-		let prop = props[name];
+	const rows = [];
+	for (const name in props) {
+		const prop = props[name];
 		rows.push(
 			<tr key={name}>
 				<td className={s.cell}><Code className={s.name}>{name}</Code></td>
@@ -27,7 +27,7 @@ function renderType(type) {
 		return 'unknown';
 	}
 
-	let { name } = type;
+	const { name } = type;
 
 	switch (name) {
 		case 'arrayOf':
@@ -54,8 +54,8 @@ function renderDefault(prop) {
 }
 
 function renderDescription(prop) {
-	let { description } = prop;
-	let extra = renderExtra(prop);
+	const { description } = prop;
+	const extra = renderExtra(prop);
 	return (
 		<Group>
 			{description && <Markdown text={description} inline />}
@@ -115,11 +115,11 @@ function renderUnion(prop) {
 }
 
 function renderShape(props) {
-	let rows = [];
-	for (let name in props) {
-		let prop = props[name];
-		let defaultValue = renderDefault(prop);
-		let description = prop.description;
+	const rows = [];
+	for (const name in props) {
+		const prop = props[name];
+		const defaultValue = renderDefault(prop);
+		const description = prop.description;
 		rows.push(
 			<div key={name}>
 				<Code className={s.name}>{name}</Code>{': '}

--- a/src/utils/markdown-to-jsx.js
+++ b/src/utils/markdown-to-jsx.js
@@ -412,9 +412,6 @@ function coalesceInlineHTML(ast) {
 }
 
 export default function markdownToJSX(markdown, { overrides = {} } = {}) {
-	let definitions;
-	let footnotes;
-
 	function astToJSX(ast, index) { /* `this` is the dictionary of definitions */
 		if (TEXT_AST_TYPES.indexOf(ast.type) !== -1) {
 			return ast.value;
@@ -600,8 +597,8 @@ export default function markdownToJSX(markdown, { overrides = {} } = {}) {
 
 	const extracted = extractDefinitionsFromASTTree(remarkAST, astToJSX);
 
-	definitions = extracted.definitions;
-	footnotes = extracted.footnotes;
+	const definitions = extracted.definitions;
+	const footnotes = extracted.footnotes;
 
 	coalesceInlineHTML(remarkAST);
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -6,7 +6,7 @@ import isNaN from 'lodash/isNaN';
 export function setComponentsNames(components) {
 	components.map((component) => {
 		// Try to detect component name or fallback to file name or directory name.
-		let { module } = component;
+		const { module } = component;
 		component.name = (component.props && component.props.displayName) || (
 			module.default
 				? (module.default.displayName || module.default.name)
@@ -104,7 +104,7 @@ export function filterComponentsByExactName(componens, name) {
  * @return {Array}
  */
 export function filterComponentsInSectionsByExactName(sections, name) {
-	let components = [];
+	const components = [];
 	sections.forEach(section => {
 		if (section.components) {
 			components.push(...filterComponentsByExactName(section.components, name));

--- a/test/components/Button/Button.js
+++ b/test/components/Button/Button.js
@@ -8,7 +8,7 @@ export default function Button({
 	size,
 	children,
 }) {
-	let styles = {
+	const styles = {
 		color,
 		fontSize: Button.sizes[size],
 	};

--- a/test/components/Placeholder/Placeholder.js
+++ b/test/components/Placeholder/Placeholder.js
@@ -21,8 +21,8 @@ export default class Placeholder extends Component {
 	};
 
 	getImageUrl() {
-		let { type, width, height } = this.props;
-		let types = {
+		const { type, width, height } = this.props;
+		const types = {
 			animal: `http://placeimg.com/${width}/${height}/animals`,
 			bacon: `http://baconmockup.com/${width}/${height}`,
 			bear: `http://www.placebear.com/${width}/${height}`,
@@ -37,7 +37,7 @@ export default class Placeholder extends Component {
 	}
 
 	render() {
-		let { width, height } = this.props;
+		const { width, height } = this.props;
 		return (
 			<img className={s.root} src={this.getImageUrl()} width={width} height={height} />
 		);

--- a/test/loader.examples.spec.js
+++ b/test/loader.examples.spec.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import examplesLoader from '../loaders/examples.loader';
 
 test('should return valid, parsable JS', t => {
-	let exampleMarkdown = `
+	const exampleMarkdown = `
 # header
 
 	const _ = require('lodash');
@@ -14,7 +14,7 @@ text
 <span/>
 \`\`\`
 `;
-	let result = examplesLoader.call({}, exampleMarkdown);
+	const result = examplesLoader.call({}, exampleMarkdown);
 	t.truthy(result);
 	t.notThrows(() => new Function(result), SyntaxError);  // eslint-disable-line no-new-func
 });

--- a/test/utils.utils.spec.js
+++ b/test/utils.utils.spec.js
@@ -51,7 +51,7 @@ test.afterEach(() => {
 // setComponentsNames
 
 test('should set name property to each component', t => {
-	let result = utils.setComponentsNames([
+	const result = utils.setComponentsNames([
 		{
 			module: {
 				displayName: 'Foo',


### PR DESCRIPTION
Running `npm test` or `npm run lint` shows a bunch of "prefer-const" errors:

    .../react-styleguidist/examples/basic/lib/components/Placeholder/Placeholder.js
    22:9   error  'type' is never reassigned. Use 'const' instead    prefer-const
    22:15  error  'width' is never reassigned. Use 'const' instead   prefer-const
    22:22  error  'height' is never reassigned. Use 'const' instead  prefer-const
    ...etc

This PR fixes these errors.