### PR TITLE
evaluate examples from JS-code blocks

### DIFF
--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -23,7 +23,7 @@ module.exports = function chunkify(markdown) {
 	function processCode() {
 		return (ast) => {
 			visit(ast, 'code', node => {
-				if (node.lang && node.lang !== 'example') {
+				if (node.lang && node.lang !== 'example' && node.lang !== 'js') {
 					let highlighted;
 					try {
 						highlighted = hljs.highlight(node.lang, node.value).value;

--- a/test/loaders.utils.chunkify.spec.js
+++ b/test/loaders.utils.chunkify.spec.js
@@ -27,6 +27,10 @@ This is the same as above:
 <h3>Hello Markdown!</h3>
 \`\`\`
 
+\`\`\`js
+<Component>Hello Markdown!</Component>
+\`\`\`
+
 This should be highlighted:
 
 \`\`\`html
@@ -57,6 +61,14 @@ This should be highlighted:
 		{
 			type: 'code',
 			content: '<h3>Hello Markdown!</h3>',
+		},
+		{
+			type: 'markdown',
+			content: '\n\n',
+		},
+		{
+			type: 'code',
+			content: '<Component>Hello Markdown!</Component>',
 		},
 		{
 			type: 'markdown',


### PR DESCRIPTION
Some code editors, (Atom and WebStorm as I know), understand code block language definition and are able to highlight code inside. Look at the screenshot bellow:

![image](https://cloud.githubusercontent.com/assets/812240/21350077/bdfef1a6-c6b5-11e6-8de3-f28ec3929f13.png)

I'd like to mark my code examples as `js`, but currently React-Styleguidist doesn't make them live.