### PR TITLE
Fix: Style update to code toggle button

### DIFF
--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -16,7 +16,6 @@
 	composes: border link from "../../styles/colors.css";
 	position: absolute;
 	right: -1px;
-	bottom: -27px;
 	cursor: pointer;
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -24,6 +24,7 @@
 	padding: 6px 8px;
 	font-size: 14px;
 	line-height: 1;
+	margin: 0;
 }
 
 .showCode {


### PR DESCRIPTION
The border around the show/hide code area doesn't quite line up with the border around the component in Safari on Mac OS 10.12.1. Fixed by adding margin: 0 to button.

<img width="152" alt="screen shot 2017-01-04 at 14 00 06" src="https://cloud.githubusercontent.com/assets/743582/21643441/8719afbc-d288-11e6-8c2d-9f384b4dfc73.png">
