### PR TITLE
Publish public methods

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -253,6 +253,11 @@ Button.defaultProps = {
 };
 ```
 
+## How do I list public methods of my components?
+
+Tag your method with [`@public`](http://usejsdoc.org/tags-public.html) tag and it will be displayed in the guide.
+Use [`@param`](http://usejsdoc.org/tags-param.html) tag to document the method parameters and [`@returns`](http://usejsdoc.org/tags-returns.html) tag to document the return value.
+
 ## Are there any other projects like this?
 
 * [Atellier](https://github.com/scup/atellier), a React components emulator.

--- a/examples/basic/lib/components/CounterButton/CounterButton.css
+++ b/examples/basic/lib/components/CounterButton/CounterButton.css
@@ -1,0 +1,12 @@
+.root {
+	padding: .5em 1.5em;
+	color: #666;
+	background-color: #fff;
+	border: 1px solid currentColor;
+	border-radius: .3em;
+	font-size: 16px;
+	font-weight: bold;
+	text-align: center;
+	vertical-align: middle;
+	cursor: pointer;
+}

--- a/examples/basic/lib/components/CounterButton/CounterButton.js
+++ b/examples/basic/lib/components/CounterButton/CounterButton.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+
+import s from './CounterButton.css';
+
+/**
+ * Button that counts how many times it was pressed and exposes a `@public` method to reset itself.
+ */
+export default class CounterButton extends Component {
+	constructor() {
+		super();
+		this.state = {
+			value: 0,
+		};
+	}
+
+	/**
+	 * Sets the counter to a particular value.
+	 *
+	 * @public
+	 * @param {Number} newValue - New value for the counter.
+	 */
+	set(newValue) {
+		this.setState({
+			value: parseInt(newValue, 10),
+		});
+	}
+
+	increment() {
+		this.setState({
+			value: this.state.value + 1,
+		});
+	}
+
+	render() {
+		return (
+			<button className={s.root} onClick={this.increment.bind(this)}>{this.state.value}</button>
+		);
+	}
+}

--- a/examples/basic/lib/components/CounterButton/CounterButton.js
+++ b/examples/basic/lib/components/CounterButton/CounterButton.js
@@ -25,6 +25,9 @@ export default class CounterButton extends Component {
 		});
 	}
 
+	/**
+	 * Increments the counter. This method is not marked @public and is not visible in the styleguide.
+	 */
 	increment() {
 		this.setState({
 			value: this.state.value + 1,

--- a/examples/basic/lib/components/CounterButton/Readme.md
+++ b/examples/basic/lib/components/CounterButton/Readme.md
@@ -1,0 +1,1 @@
+    <CounterButton/>

--- a/examples/basic/lib/components/CounterButton/index.js
+++ b/examples/basic/lib/components/CounterButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './CounterButton.js';

--- a/loaders/props.loader.js
+++ b/loaders/props.loader.js
@@ -53,6 +53,12 @@ function propsToCode(doc) {
 		doc.doclets = {};
 	}
 
+	if (doc.methods) {
+		doc.methods.forEach((method, index) => {
+			doc.methods[index].doclets = reactDocs.utils.docblock.getDoclets(method.docblock);
+		});
+	}
+
 	const code = JSON.stringify(doc);
 
 	if (doc.doclets.example) {

--- a/loaders/props.loader.js
+++ b/loaders/props.loader.js
@@ -54,8 +54,9 @@ function propsToCode(doc) {
 	}
 
 	if (doc.methods) {
-		doc.methods.forEach((method, index) => {
-			doc.methods[index].doclets = reactDocs.utils.docblock.getDoclets(method.docblock);
+		doc.methods = doc.methods.filter((method) => {
+			const doclets = reactDocs.utils.docblock.getDoclets(method.docblock);
+			return doclets && doclets.public;
 		});
 	}
 

--- a/src/rsg-components/Methods/Methods.css
+++ b/src/rsg-components/Methods/Methods.css
@@ -1,0 +1,36 @@
+.table {
+	width: 100%;
+	border-collapse: collapse;
+}
+.tableHead {
+	composes: border from "../../styles/colors.css";
+	border-width: 0 0 1px 0;
+}
+.tableBody {
+}
+.cell {
+	padding-right: 15px;
+	padding-top: 6px;
+	vertical-align: top;
+	font-size: 13px;
+}
+.cellHeading {
+	padding-right: 15px;
+	padding-bottom: 6px;
+	text-align: left;
+	font-size: 13px;
+}
+.cellDesc {
+	padding-left: 15px;
+}
+
+.methodParam {
+	min-width: 200px;
+}
+
+.name {
+	composes: name from "../../styles/colors.css";
+}
+.type {
+	composes: type from "../../styles/colors.css";
+}

--- a/src/rsg-components/Methods/Methods.spec.js
+++ b/src/rsg-components/Methods/Methods.spec.js
@@ -1,0 +1,60 @@
+import test from 'ava';
+import React from 'react';
+import { parse } from 'react-docgen';
+import Group from 'react-group';
+import Code from '../Code';
+import Markdown from '../Markdown';
+import MethodsRenderer from './MethodsRenderer';
+
+function render(methods) {
+	const parsed = parse(`
+		import { Component, PropTypes } from 'react';
+		export default class Cmpnt extends Component {
+			${methods.join('\n')}
+			render() {
+			}
+		}
+	`);
+	return shallow(<MethodsRenderer methods={parsed.methods} />);
+}
+
+test('should render public method', () => {
+	const actual = render(['/**\n * Public\n * @public\n */\nmethod() {}']);
+
+	expect(actual.node, 'to contain',
+		<tr>
+			<td><Code>method()</Code></td>
+			<td></td>
+			<td><Group><Markdown text="Public" /></Group></td>
+		</tr>
+	);
+});
+
+test('should render parameters', () => {
+	const actual = render(['/**\n * Public\n * @public\n * @param {Number} value - Description\n */\nmethod(value) {}']);
+
+	expect(actual.node, 'to contain',
+		<tr>
+			<td><Code>method()</Code></td>
+			<td>
+				<div>
+					<Code>value</Code>: <Code>Number</Code> — <Markdown text="Description" />
+				</div>
+			</td>
+			<td><Group><Markdown text="Public" /></Group></td>
+		</tr>
+	);
+});
+
+test('should render returns', () => {
+	const actual = render(['/**\n * @public\n * @returns {Number} - Description\n */\nmethod() {}']);
+
+	expect(actual.node, 'to contain',
+		<tr>
+			<td><Code>method()</Code></td>
+			<td></td>
+			<td><Group /><span>Returns <Code>Number</Code> — <Markdown text="Description" /></span></td>
+		</tr>
+	);
+});
+

--- a/src/rsg-components/Methods/MethodsRenderer.js
+++ b/src/rsg-components/Methods/MethodsRenderer.js
@@ -1,0 +1,83 @@
+import React, { PropTypes } from 'react';
+import Code from 'rsg-components/Code';
+import Markdown from 'rsg-components/Markdown';
+import Group from 'react-group';
+
+import s from './methods.css';
+
+function renderRows(methods) {
+	const rows = [];
+	methods.map((method) => {
+		rows.push(
+			<tr key={method.name}>
+				<td className={s.cell}><Code className={s.name}>{method.name}()</Code></td>
+				<td className={s.cell}>{renderParameters(method)}</td>
+				<td className={s.cell + ' ' + s.cellDesc}>
+					{renderDescription(method)}
+					{renderReturns(method)}
+				</td>
+			</tr>
+		);
+	});
+	return rows;
+}
+
+function renderParameters(prop) {
+	const { params } = prop;
+	const rows = [];
+	params.map((param) => {
+		const { description, name, type } = param;
+		rows.push(
+			<div key={name} className={s.methodParam}>
+				<Code className={s.name}>{name}</Code>
+				{type && ': '}
+				{type && <Code className={s.type}>{type.name}</Code>}
+				{description && ' — '}
+				{description && <Markdown text={description} inline />}
+			</div>
+		);
+	});
+	return rows;
+}
+
+function renderReturns(prop) {
+	const { returns } = prop;
+	return returns ? (
+		<span>
+			Returns{' '}
+			<Code className={s.type}>{returns.type.name}</Code>
+			{returns.description && ' — '}
+			{returns.description && <Markdown text={returns.description} inline />}
+		</span>
+	) : false;
+}
+
+function renderDescription(prop) {
+	const { description } = prop;
+	return (
+		<Group>
+			{description && <Markdown text={description} inline />}
+		</Group>
+	);
+}
+
+export default function MethodsRenderer({ methods }) {
+	return (
+		<table className={s.table}>
+			<thead className={s.tableHead}>
+				<tr>
+					<th className={s.cellHeading}>Name</th>
+					<th className={s.cellHeading}>Parameters</th>
+					<th className={s.cellHeading + ' ' + s.cellDesc}>Description</th>
+				</tr>
+			</thead>
+			<tbody className={s.tableBody}>
+				{renderRows(methods)}
+			</tbody>
+		</table>
+	);
+}
+
+MethodsRenderer.propTypes = {
+	methods: PropTypes.array.isRequired,
+};

--- a/src/rsg-components/Methods/MethodsRenderer.js
+++ b/src/rsg-components/Methods/MethodsRenderer.js
@@ -2,8 +2,9 @@ import React, { PropTypes } from 'react';
 import Code from 'rsg-components/Code';
 import Markdown from 'rsg-components/Markdown';
 import Group from 'react-group';
+import cx from 'classnames';
 
-import s from './methods.css';
+import s from './Methods.css';
 
 function renderRows(methods) {
 	const rows = [];
@@ -12,7 +13,7 @@ function renderRows(methods) {
 			<tr key={method.name}>
 				<td className={s.cell}><Code className={s.name}>{method.name}()</Code></td>
 				<td className={s.cell}>{renderParameters(method)}</td>
-				<td className={s.cell + ' ' + s.cellDesc}>
+				<td className={cx(s.cell, s.cellDesc)}>
 					{renderDescription(method)}
 					{renderReturns(method)}
 				</td>
@@ -68,7 +69,7 @@ export default function MethodsRenderer({ methods }) {
 				<tr>
 					<th className={s.cellHeading}>Name</th>
 					<th className={s.cellHeading}>Parameters</th>
-					<th className={s.cellHeading + ' ' + s.cellDesc}>Description</th>
+					<th className={cx(s.cellHeading, s.cellDesc)}>Description</th>
 				</tr>
 			</thead>
 			<tbody className={s.tableBody}>

--- a/src/rsg-components/Methods/index.js
+++ b/src/rsg-components/Methods/index.js
@@ -1,0 +1,1 @@
+export { default } from './MethodsRenderer.js';

--- a/src/rsg-components/ReactComponent/ReactComponent.css
+++ b/src/rsg-components/ReactComponent/ReactComponent.css
@@ -53,3 +53,9 @@
 	margin-bottom: 30px;
 	font-size: 13px;
 }
+
+.methods {
+	composes: reset font from "../../styles/common.css";
+	margin-bottom: 30px;
+	font-size: 13px;
+}

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import Markdown from 'rsg-components/Markdown';
 import Props from 'rsg-components/Props';
+import Methods from 'rsg-components/Methods';
 import Examples from 'rsg-components/Examples';
 import ReactComponentRenderer from 'rsg-components/ReactComponent/ReactComponentRenderer';
 
@@ -10,12 +11,16 @@ export default function ReactComponent({
 }) {
 	const { name, pathLine, examples } = component;
 	const { description, props } = component.props;
+	const methods = component.props.methods ? component.props.methods.filter((method) => {
+		return method && method.doclets.public;
+	}) : [];
 	return (
 		<ReactComponentRenderer
 			name={name}
 			pathLine={pathLine}
 			description={description && <Markdown text={description} />}
 			props={props && <Props props={props} />}
+			methods={methods.length && <Methods methods={methods} />}
 			examples={examples && <Examples examples={examples} name={name} />}
 			sidebar={sidebar}
 		/>

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -10,17 +10,14 @@ export default function ReactComponent({
 	sidebar,
 }) {
 	const { name, pathLine, examples } = component;
-	const { description, props } = component.props;
-	const methods = component.props.methods ? component.props.methods.filter((method) => {
-		return method && method.doclets.public;
-	}) : [];
+	const { description, props, methods } = component.props;
 	return (
 		<ReactComponentRenderer
 			name={name}
 			pathLine={pathLine}
 			description={description && <Markdown text={description} />}
 			props={props && <Props props={props} />}
-			methods={methods.length && <Methods methods={methods} />}
+			methods={methods && <Methods methods={methods} />}
 			examples={examples && <Examples examples={examples} name={name} />}
 			sidebar={sidebar}
 		/>

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 
 const s = require('./ReactComponent.css');
 
-const ReactComponentRenderer = ({ name, pathLine, description, props, examples, sidebar }) => {
+const ReactComponentRenderer = ({ name, pathLine, description, props, methods, examples, sidebar }) => {
 	return (
 		<div className={s.root} id={name + '-container'}>
 			<header className={s.header}>
@@ -27,6 +27,14 @@ const ReactComponentRenderer = ({ name, pathLine, description, props, examples, 
 					</div>
 				)
 			}
+			{
+				methods ? (
+					<div className={s.methods}>
+						<h3 className={s.heading}>Methods</h3>
+						{methods}
+					</div>
+				) : false
+			}
 			{examples}
 		</div>
 	);
@@ -37,6 +45,7 @@ ReactComponentRenderer.propTypes = {
 	pathLine: PropTypes.string.isRequired,
 	description: PropTypes.node,
 	props: PropTypes.node,
+	methods: PropTypes.node,
 	examples: PropTypes.node,
 	sidebar: PropTypes.bool,
 };


### PR DESCRIPTION
This change adds (basic) support for documenting public methods of components using jsdoc tags `@public`, `@param` and `@returns`. 