### PR TITLE
Better support and tools for multiple exported components per file

### DIFF
--- a/loaders/examples.loader.js
+++ b/loaders/examples.loader.js
@@ -24,7 +24,7 @@ function examplesLoader(source) {
 	source = source.replace(COMPONENT_PLACEHOLDER_REGEXP, componentName);
 
 	// Load examples
-	let examples = chunkify(source);
+	let examples = chunkify(source, { section: query.section });
 
 	// We're analysing the examples' source code to figure out the require statements. We do it manually with regexes,
 	// because webpack unfortunately doesn't expose its smart logic for rewriting requires

--- a/loaders/styleguide.loader.js
+++ b/loaders/styleguide.loader.js
@@ -32,6 +32,7 @@ function processComponent(filepath, config) {
 		module: requireIt(filepath),
 		props: requireIt('!!props!' + filepath),
 		examples: getExamples(examplesFile, nameFallback, config.defaultExample),
+		examplesFileName: JSON.stringify(examplesFile),
 	});
 }
 

--- a/loaders/utils/getRequires.js
+++ b/loaders/utils/getRequires.js
@@ -7,7 +7,21 @@
 const REQUIRE_ANYTHING_BASE = 'require\\s*\\(([^)]+)\\)';
 const REQUIRE_ANYTHING_REGEX = new RegExp(REQUIRE_ANYTHING_BASE, 'g');
 
+const IMPORT_ANYTHING_BASE = 'import .+ from (.+)';
+const IMPORT_ANYTHING_REGEX = new RegExp(IMPORT_ANYTHING_BASE, 'g');
+
 const SIMPLE_STRING_REGEX = /^"([^"]+)"$|^'([^']+)'$/;
+
+function getRequiresWithRegex(code, regex, requires) {
+	code.replace(regex, function(requireExprMatch, requiredExpr) {
+		const requireStrMatch = SIMPLE_STRING_REGEX.exec(requiredExpr.trim());
+		if (!requireStrMatch) {
+			throw new Error(`Requires using expressions are not supported in examples. (Used: ${requireExprMatch})`);
+		}
+		const requiredString = requireStrMatch[1] ? requireStrMatch[1] : requireStrMatch[2];
+		requires[requiredString] = true;
+	});
+}
 
 /**
  * Returns a list of all strings used in require(...) calls in the given source code.
@@ -18,14 +32,9 @@ const SIMPLE_STRING_REGEX = /^"([^"]+)"$|^'([^']+)'$/;
  */
 module.exports = function getRequires(code) {
 	const requires = {};
-	code.replace(REQUIRE_ANYTHING_REGEX, function(requireExprMatch, requiredExpr) {
-		const requireStrMatch = SIMPLE_STRING_REGEX.exec(requiredExpr.trim());
-		if (!requireStrMatch) {
-			throw new Error(`Requires using expressions are not supported in examples. (Used: ${requireExprMatch})`);
-		}
-		const requiredString = requireStrMatch[1] ? requireStrMatch[1] : requireStrMatch[2];
-		requires[requiredString] = true;
-	});
+	getRequiresWithRegex(code, REQUIRE_ANYTHING_REGEX, requires);
+	getRequiresWithRegex(code, IMPORT_ANYTHING_REGEX, requires);
+
 	return Object.keys(requires);
 };
 

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -10,7 +10,7 @@ export default function Components({
 }) {
 	const componentsJsx = components.map(component => (
 		<ReactComponent
-			key={component.filepath}
+			key={`${component.filepath}|${component.name}`}
 			component={component}
 			sidebar={sidebar}
 		/>

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -10,7 +10,7 @@ const compileCode = code => transform(code, {
 	objectAssign: 'Object.assign',
 }).code;
 
-const IMPORT_REGEX = /(import )(.+)( from )(.+)/g;
+const IMPORT_REGEX = /(import )(.+)( from )(["'`].+["'`])/g;
 const TRANSPILED_CONST_DESTRUCTURE_REGEX = /(\w+) as (\w+)/g;
 const TRANSPILED_CONST_DESTRUCTURE_REPLACEMENT = '$1: $2';
 const JSX_REGEX = /(<(.|\s)+>)/m;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -26,7 +26,10 @@ export function globalizeComponents(components) {
 
 export function promoteInlineExamples(components) {
 	components.map(c => {
-		if (c.props.example) {
+		if (c.props.example && c.props.exampleFileName === c.examplesFileName) {
+			c.examples = c.props.example;
+		}
+		else if (c.props.example) {
 			c.examples = (c.examples || []).concat(c.props.example);
 		}
 	});


### PR DESCRIPTION
This is more of an experiment but I'd like to know what your thoughts are on this.

There's a few things going on in this PR:

- [x] Fix multiple components from same file causing a duplicate React keys error
- [x] Allow for import statements in examples and for importing components
- [x] Allow for adjacent JSX by wrapping example JSX in an enclosing `<div />`
- [x] Add ability to import `@example` markdown by section

A few notes on a couple of things mentioned above:

### Allow for import statements in examples

When you export named components from a module, Styleguidist will require you to reference them within the module e.g

```js
// Header.jsx

export const H1 = props => (...)
export const H2 = props => (...)
```

```js
// Example
<Header.H1>Hello, world</Header.H1>
```

By allowing the use of import, the example can have an example of how the component might actually be imported in real world usage, and of course it is then able to correctly locate the component:

```js
// Example
import {H1} from 'components';

<H1>Hello, world!</H1>
```

Unfortunately, as you can see in the PR, the way I have done this is with some major hackery. I am more interested however with whether you think this is a good idea, and if so we can then look into refactoring.

### Ability to import `@example` by section

Just like wanting to have multiple small components per file, it might be desirable to have all of the documentation for these components in one file as well. This is difficult because if you create a `Readme.md`, it will be displayed for every component in the single file.

I've solved this by taking advantage of the existing ability to import an external example with `@example`, but now you can reference a section/anchor in that markdown file.

e.g:

```markdown
// Readme.md

This is an example README.

# H1

This is the documentation for `<H1 />`.

    <H1>Hello, world!</H1>

# H2

You get the idea...
```

```js
// Header.jsx

/** @example ./Readme.md#H1 */
export const H1 = props => (...)

/** @example ./Readme.md#H2 */
export const H2 = props => (...)
```

This enables all of the documentation for relevant components to be in one place, which is great for small components with a minimal API.

Let me know what your thoughts are, thanks!