### PR TITLE
Feat: Hide errors while typing in code editor

### DIFF
--- a/src/rsg-components/Editor/Editor.css
+++ b/src/rsg-components/Editor/Editor.css
@@ -1,14 +1,31 @@
 /* Tweak CodeMirror styles */
-.root :global .CodeMirror {
+.root :global .CodeMirror,
+.root_err :global .CodeMirror,
+.root_edit :global .CodeMirror {
 	height: auto;
 	padding: 5px 12px;
 	font-size: 12px;
 }
-.root :global .CodeMirror-scroll {
+.root_err {
+	border-left: red 4px solid;
+}
+.root_edit {
+	border-left: #1978c8 4px solid;
+}
+.root {
+	border-left: rgb(245, 245, 245) 4px solid;
+}
+.root :global .CodeMirror-scroll,
+.root_err :global .CodeMirror-scroll,
+.root_edit :global .CodeMirror-scroll
+ {
 	height: auto;
 	overflow-y: hidden;
 	overflow-x: auto;
 }
-.root :global .cm-error {
+.root :global .cm-error,
+.root_err :global .cm-error,
+.root_edit :global .cm-error
+ {
 	background: none !important;
 }

--- a/src/rsg-components/Editor/Editor.js
+++ b/src/rsg-components/Editor/Editor.js
@@ -23,6 +23,9 @@ export default class Editor extends Component {
 	static propTypes = {
 		code: PropTypes.string.isRequired,
 		onChange: PropTypes.func.isRequired,
+		onCodeTyping: PropTypes.func.isRequired,
+		isCodeValid: PropTypes.bool.isRequired,
+		isCodeTyping: PropTypes.bool.isRequired,
 	};
 	static contextTypes = {
 		config: PropTypes.object.isRequired,
@@ -33,8 +36,11 @@ export default class Editor extends Component {
 		this.handleChange = debounce(this.handleChange.bind(this), UPDATE_DELAY);
 	}
 
-	shouldComponentUpdate() {
-		return false;
+	shouldComponentUpdate(nextProps) {
+		return (
+			this.props.isCodeValid !== nextProps.isCodeValid ||
+			this.props.isCodeTyping !== nextProps.isCodeTyping
+		);
 	}
 
 	handleChange(newCode) {
@@ -42,15 +48,23 @@ export default class Editor extends Component {
 	}
 
 	render() {
-		const { code } = this.props;
+		const { code, onCodeTyping, isCodeValid, isCodeTyping } = this.props;
 		const { highlightTheme } = this.context.config;
 		const options = {
 			...codemirrorOptions,
 			theme: highlightTheme,
 		};
 		return (
-			<EditorRenderer>
-				<Codemirror value={code} onChange={this.handleChange} options={options} />
+			<EditorRenderer
+				isValid={isCodeValid}
+				isTyping={isCodeTyping}
+			>
+				<Codemirror
+					value={code}
+					onChange={this.handleChange}
+					options={options}
+					onFocusChange={onCodeTyping}
+				/>
 			</EditorRenderer>
 		);
 	}

--- a/src/rsg-components/Editor/EditorRenderer.js
+++ b/src/rsg-components/Editor/EditorRenderer.js
@@ -2,14 +2,18 @@ import React, { PropTypes } from 'react';
 
 import s from './Editor.css';
 
-const EditorRenderer = ({ children }) => (
-	<div className={s.root}>
-		{children}
-	</div>
-);
+const EditorRenderer = ({ children, isValid, isTyping }) => {
+	const typingStyle = isTyping ? s.root_edit : s.root;
+	return (
+		<div className={isValid ? typingStyle : s.root_err}>
+			{children}
+		</div>);
+};
 
 EditorRenderer.propTypes = {
 	children: PropTypes.node.isRequired,
+	isValid: PropTypes.bool.isRequired,
+	isTyping: PropTypes.bool.isRequired,
 };
 
 export default EditorRenderer;

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -22,6 +22,8 @@ export default class Playground extends Component {
 		this.state = {
 			code,
 			showCode,
+			isCodeValid: true,
+			isCodeTyping: false,
 		};
 	}
 
@@ -35,7 +37,9 @@ export default class Playground extends Component {
 	shouldComponentUpdate(nextProps, nextState) {
 		return (
 			nextState.code !== this.state.code ||
-			nextState.showCode !== this.state.showCode
+			nextState.showCode !== this.state.showCode ||
+			nextState.isCodeValid !== this.state.isCodeValid ||
+			nextState.isCodeTyping !== this.state.isCodeTyping
 		);
 	}
 
@@ -76,20 +80,40 @@ export default class Playground extends Component {
 		});
 	}
 
+	handleCodeValid(isValid) {
+		if (this.state.isCodeValid !== isValid) {
+			this.setState({
+				isCodeValid: isValid,
+			});
+		}
+	}
+
+	handleCodeTyping(isTyping) {
+		if (this.state.isCodeTyping !== isTyping) {
+			this.setState({
+				isCodeTyping: isTyping,
+			});
+		}
+	}
+
 	render() {
-		const { code, showCode } = this.state;
+		const { code, showCode, isCodeTyping, isCodeValid } = this.state;
 		const { evalInContext, index, name } = this.props;
 		const { singleExample } = this.context;
 		return (
 			<PlaygroundRenderer
 				code={code}
 				showCode={showCode}
+				isCodeTyping={isCodeTyping}
+				isCodeValid={isCodeValid}
 				index={index}
 				name={name}
 				singleExample={singleExample}
 				evalInContext={evalInContext}
 				onChange={code => this.handleChange(code)}
 				onCodeToggle={() => this.handleCodeToggle()}
+				onCodeValid={isValid => this.handleCodeValid(isValid)}
+				onCodeTyping={isTyping => this.handleCodeTyping(isTyping)}
 			/>
 		);
 	}

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -7,12 +7,16 @@ const s = require('./Playground.css');
 const PlaygroundRenderer = ({
 	code,
 	showCode,
+	isCodeTyping,
+	isCodeValid,
 	name,
 	index,
 	singleExample,
 	evalInContext,
 	onChange,
 	onCodeToggle,
+	onCodeValid,
+	onCodeTyping,
 }) => (
 	<div className={s.root}>
 		<div className={s.preview + ' rsg--example-preview'}>
@@ -21,11 +25,22 @@ const PlaygroundRenderer = ({
 			) : (
 				<a className={s.isolatedLink} href={'#!/' + name + '/' + index}>Open isolated ⇢</a>
 			)}
-			<Preview code={code} evalInContext={evalInContext} />
+			<Preview
+				code={code}
+				evalInContext={evalInContext}
+				onCodeValid={onCodeValid}
+				isCodeTyping={isCodeTyping}
+			/>
 		</div>
 		{showCode ? (
 			<div>
-				<Editor code={code} onChange={onChange} />
+				<Editor
+					code={code}
+					onChange={onChange}
+					isCodeTyping={isCodeTyping}
+					isCodeValid={isCodeValid}
+					onCodeTyping={onCodeTyping}
+				/>
 				<button type="button" className={s.hideCode} onClick={onCodeToggle}>
 					Hide code
 				</button>
@@ -41,12 +56,16 @@ const PlaygroundRenderer = ({
 PlaygroundRenderer.propTypes = {
 	code: PropTypes.string.isRequired,
 	showCode: PropTypes.bool.isRequired,
+	isCodeTyping: PropTypes.bool.isRequired,
+	isCodeValid: PropTypes.bool.isRequired,
 	name: PropTypes.string.isRequired,
 	index: PropTypes.number.isRequired,
 	evalInContext: PropTypes.func.isRequired,
 	onChange: PropTypes.func.isRequired,
 	onCodeToggle: PropTypes.func.isRequired,
 	singleExample: PropTypes.bool,
+	onCodeValid: PropTypes.func.isRequired,
+	onCodeTyping: PropTypes.func.isRequired,
 };
 
 export default PlaygroundRenderer;

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -25,29 +25,29 @@ export default class Preview extends Component {
 	}
 
 	componentDidMount() {
-		this.executeCode();
+		this.executeCode(this.props.code);
 	}
 
 	componentDidUpdate(prevProps) {
-		if (this.props.code !== prevProps.code) {
-			this.executeCode();
+		const { code } = this.props;
+		if (code !== prevProps.code) {
+			this.executeCode(code);
 		}
 	}
 
-	executeCode() {
+	executeCode(code) {
 		ReactDOM.unmountComponentAtNode(this.mountNode);
 
 		this.setState({
 			error: null,
 		});
 
-		const { code } = this.props;
 		if (!code) {
 			return;
 		}
 
 		try {
-			const compiledCode = compileCode(this.props.code);
+			const compiledCode = compileCode(code);
 
 			// Initiate state and set with the callback in the bottom component;
 			// Workaround for https://github.com/styleguidist/react-styleguidist/issues/155 - missed props on first render


### PR DESCRIPTION
Hi! First of all, thank you for a great project. I used storybook for my projects, and now I really like styleguidist and I'd like to spend some time for working on using these two projects together

Regarding this PR, I noticed that while typing in the code editor some errors can appear in the component preview. It could be a bit annoying in case if you just haven't a bracket closed for example. So this PR will change it to show an error only if you remove focus from the editor and if you still in editor only red marker will appear (it can be customized via css). If there was an error before you focus the code editor, it behaves as usual

[screenview](http://recordit.co/tHF1tlv7nj)
