### PR TITLE
Better display of very long component names in the sidebar

### DIFF
--- a/src/rsg-components/ComponentsList/ComponentsListRenderer.js
+++ b/src/rsg-components/ComponentsList/ComponentsListRenderer.js
@@ -14,6 +14,8 @@ const styles = ({ font, small }) => ({
 		fontFamily: font,
 		fontSize: 15,
 		listStyle: 'none',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
 	},
 	isChild: {
 		[small]: {


### PR DESCRIPTION
This PR adds a little bit of extra styling to improve display of very long component names in the sidebar.

Before:
<img width="214" alt="screen shot 2017-03-29 at 14 15 00" src="https://cloud.githubusercontent.com/assets/632081/24441037/57f42638-148a-11e7-9743-fdcf2d81c3a7.png">

After:
<img width="214" alt="screen shot 2017-03-29 at 14 14 29" src="https://cloud.githubusercontent.com/assets/632081/24441040/5a3fcaa0-148a-11e7-87e0-28476bba62dc.png">
