### PR TITLE
Slight improvement to sidebar styling on small screens

### DIFF
--- a/src/rsg-components/StyleGuide/StyleGuideRenderer.js
+++ b/src/rsg-components/StyleGuide/StyleGuideRenderer.js
@@ -38,6 +38,7 @@ const styles = ({ font, base, light, border, baseBackground, codeBackground, sma
 			position: 'static',
 			width: 'auto',
 			borderWidth: [[1, 0, 0, 0]],
+			paddingBottom: 5,
 		},
 	},
 	logo: {


### PR DESCRIPTION
This PR adds a little bit of padding to the sidebar to "unglue" menu items off the bottom of the document on small screens.

Before:
<img width="552" alt="screen shot 2017-03-29 at 14 26 12" src="https://cloud.githubusercontent.com/assets/632081/24441462/47203c28-148c-11e7-8315-52c210c2d2c9.png">

After:
<img width="552" alt="screen shot 2017-03-29 at 14 26 35" src="https://cloud.githubusercontent.com/assets/632081/24441466/4a0d6dc0-148c-11e7-9c84-784aec2014cd.png">
