### PR TITLE
Replacing hasSidebar instead of sidebar in Cookbox

### DIFF
--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -247,7 +247,7 @@ module.exports = {
 
 // lib/styleguide/StyleGuideRenderer.js
 import React from 'react';
-const StyleGuideRenderer = ({ title, homepageUrl, components, toc, sidebar }) => (
+const StyleGuideRenderer = ({ title, homepageUrl, components, toc, hasSidebar }) => (
   <div className="root">
     <h1>{title}</h1>
     <main className="wrapper">
@@ -257,7 +257,7 @@ const StyleGuideRenderer = ({ title, homepageUrl, components, toc, sidebar }) =>
           <Markdown text={`Generated with [React Styleguidist](${homepageUrl})`} />
         </footer>
       </div>
-      {sidebar &&
+      {hasSidebar &&
         <div className="sidebar">
           {toc}
         </div>


### PR DESCRIPTION
While I was checking out the new cookbook(btw this new version is amazing) I realized that https://github.com/styleguidist/react-styleguidist/blob/master/docs/Cookbook.md#how-to-change-the-layout-of-a-style-guide is using `sidebar` prop instead `hasSidebar`. I'm fixing that because I feel is confusing have a example with the wrong prop. So:

**Before**
```javascript
// lib/styleguide/StyleGuideRenderer.js
import React from 'react';
const StyleGuideRenderer = ({ title, homepageUrl, components, toc, sidebar }) => (
  <div className="root">
    <h1>{title}</h1>
    <main className="wrapper">
      <div className="content">
        {components}
        <footer className="footer">
          <Markdown text={`Generated with [React Styleguidist](${homepageUrl})`} />
        </footer>
      </div>
      {sidebar &&
        <div className="sidebar">
          {toc}
        </div>
      }
    </main>
  </div>
);
```

**Now:**

```javascript
// lib/styleguide/StyleGuideRenderer.js
import React from 'react';
const StyleGuideRenderer = ({ title, homepageUrl, components, toc, hasSidebar }) => (
  <div className="root">
    <h1>{title}</h1>
    <main className="wrapper">
      <div className="content">
        {components}
        <footer className="footer">
          <Markdown text={`Generated with [React Styleguidist](${homepageUrl})`} />
        </footer>
      </div>
      {hasSidebar &&
        <div className="sidebar">
          {toc}
        </div>
      }
    </main>
  </div>
);
```