### PR TITLE
bind config context to props parser

### DIFF
--- a/loaders/props-loader.js
+++ b/loaders/props-loader.js
@@ -24,7 +24,7 @@ module.exports = function(source) {
 
 	let props = {};
 	try {
-		props = propsParser(file, source);
+		props = propsParser.bind(config)(file, source);
 	}
 	/* istanbul ignore next */
 	catch (err) {


### PR DESCRIPTION
In examples i see that default propsParser is require('react-doc-gen').parse(content);
but here i see that you passed config.resolver, config.handlers(file) to docGen.
Now i need to call react-doc-gen in my custom propsParser, but i havent access to handlers and resolver