### PR TITLE
pass resolver and handlers to propsParser

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -199,8 +199,8 @@ Function that allows you to override the mechanism used to parse props from a so
 
 ```javascript
 module.exports = {
-  propsParser(filePath, source) {
-    return require('react-docgen').parse(source);
+  propsParser(filePath, source, resolver, handlers) {
+    return require('react-docgen').parse(source, resolver, handlers);
   }
 };
 ```

--- a/loaders/props-loader.js
+++ b/loaders/props-loader.js
@@ -19,12 +19,12 @@ module.exports = function(source) {
 	const file = this.request.split('!').pop();
 	const config = this._styleguidist;
 
-	const defaultParser = (filePath, source) => reactDocs.parse(source, config.resolver, config.handlers(file));
+	const defaultParser = (filePath, source, resolver, handlers) => reactDocs.parse(source, resolver, handlers);
 	const propsParser = config.propsParser || defaultParser;
 
 	let props = {};
 	try {
-		props = propsParser(file, source);
+		props = propsParser(file, source, config.resolver, config.handlers(file));
 	}
 	/* istanbul ignore next */
 	catch (err) {


### PR DESCRIPTION
In examples i see that default propsParser is require('react-doc-gen').parse(content);
but here i see that you passed config.resolver, config.handlers(file) to docGen.
Now i need to call react-doc-gen in my custom propsParser, but i havent access to handlers and resolver.
