### PR TITLE
Use `[name]` in output filename

### DIFF
--- a/scripts/__tests__/create-server.spec.js
+++ b/scripts/__tests__/create-server.spec.js
@@ -30,6 +30,6 @@ test('createServer should return an object containing a development Webpack comp
 	const result = createServer(config, 'development');
 	expect(result).toBeTruthy();
 	expect(result.compiler).toBeTruthy();
-	expect(result.compiler.options.output.filename).toBe('build/bundle.js');
+	expect(result.compiler.options.output.filename).toBe('build/[name].bundle.js');
 	expect(result.compiler.options.output.chunkFilename).toBe('build/[name].js');
 });

--- a/scripts/__tests__/index.spec.js
+++ b/scripts/__tests__/index.spec.js
@@ -25,7 +25,7 @@ describe('makeWebpackConfig', () => {
 		const api = styleguidist();
 		const result = api.makeWebpackConfig('development');
 		expect(result).toBeTruthy();
-		expect(result.output.filename).toBe('build/bundle.js');
+		expect(result.output.filename).toBe('build/[name].bundle.js');
 		expect(result.output.chunkFilename).toBe('build/[name].js');
 	});
 

--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -27,7 +27,7 @@ module.exports = function(config, env) {
 		]),
 		output: {
 			path: config.styleguideDir,
-			filename: 'build/bundle.js',
+			filename: 'build/[name].bundle.js',
 			chunkFilename: 'build/[name].js',
 		},
 		resolve: {


### PR DESCRIPTION
If you try to build a project with multiple entries without this, you get an error about multiple entries being written to `build/bundle.js`.

While there may be something to be said about not having multiple entrypoints in a dev build, this should have zero impact on any project without multiple entries. And since `output` can't be changed with the config's `webpackConfig` option, the only other way is to use `dangerouslyUpdateWebpackConfig`, which I'd rather avoid.