### PR TITLE
Add buble configuration option

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,11 +8,11 @@ Type: `String`, optional
 
 Your application static assets folder, will be accessible as `/` in the style guide dev server.
 
-#### `bubleConfig`
+#### `compilerConfig`
 
 Type: `Object`, optional, default: `{ objectAssign: 'Object.assign' }`
 
-Styleguidist uses [`bublé`](https://buble.surge.sh/guide/) to run ES6 code on the frontend. This config object will be added as the second argument for `buble.transform`
+Styleguidist currently uses [`bublé`](https://buble.surge.sh/guide/) to run ES6 code on the frontend. This config object will be added as the second argument for `buble.transform`
 
 #### `components`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,6 +8,12 @@ Type: `String`, optional
 
 Your application static assets folder, will be accessible as `/` in the style guide dev server.
 
+#### `bubleConfig`
+
+Type: `Object`, optional, default: `{ objectAssign: 'Object.assign' }`
+
+Styleguidist uses [`bublé`](https://buble.surge.sh/guide/) to run ES6 code on the frontend. This config object will be added as the second argument for `buble.transform`
+
 #### `components`
 
 Type: `String` or `Function`, default: `src/components/**/*.js`

--- a/loaders/styleguide-loader.js
+++ b/loaders/styleguide-loader.js
@@ -20,6 +20,7 @@ const CLIENT_CONFIG_OPTIONS = [
 	'previewDelay',
 	'theme',
 	'styles',
+	'bubleConfig',
 ];
 
 module.exports = function() {};

--- a/loaders/styleguide-loader.js
+++ b/loaders/styleguide-loader.js
@@ -20,7 +20,7 @@ const CLIENT_CONFIG_OPTIONS = [
 	'previewDelay',
 	'theme',
 	'styles',
-	'bubleConfig',
+	'compilerConfig',
 ];
 
 module.exports = function() {};

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -21,7 +21,7 @@ module.exports = {
 		type: 'existing directory path',
 		example: 'assets',
 	},
-	bubleConfig: {
+	compilerConfig: {
 		type: 'object',
 		default: {
 			objectAssign: 'Object.assign',

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -21,6 +21,12 @@ module.exports = {
 		type: 'existing directory path',
 		example: 'assets',
 	},
+	bubleConfig: {
+		type: 'object',
+		default: {
+			objectAssign: 'Object.assign',
+		},
+	},
 	// `components` is a shortcut for { sections: [{ components }] }, see `sections` below
 	components: {
 		type: ['string', 'function'],

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -7,14 +7,15 @@ import Wrapper from 'rsg-components/Wrapper';
 
 /* eslint-disable react/no-multi-comp */
 
-const compileCode = code => transform(code, {
-	objectAssign: 'Object.assign',
-}).code;
+const compileCode = (code, config) => transform(code, config).code;
 
 // Wrap everything in a React component to leverage the state management of this component
 class PreviewComponent extends Component {
 	static propTypes = {
 		component: PropTypes.func.isRequired,
+	};
+	static contextTypes = {
+		config: PropTypes.object.isRequired,
 	};
 
 	constructor() {
@@ -93,7 +94,7 @@ export default class Preview extends Component {
 
 	compileCode(code) {
 		try {
-			return compileCode(code);
+			return compileCode(code, this.context.config.bubleConfig);
 		}
 		catch (err) {
 			this.handleError(err);

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -14,9 +14,6 @@ class PreviewComponent extends Component {
 	static propTypes = {
 		component: PropTypes.func.isRequired,
 	};
-	static contextTypes = {
-		config: PropTypes.object.isRequired,
-	};
 
 	constructor() {
 		super();
@@ -42,6 +39,10 @@ export default class Preview extends Component {
 		code: PropTypes.string.isRequired,
 		evalInContext: PropTypes.func.isRequired,
 	};
+	static contextTypes = {
+		config: PropTypes.object.isRequired,
+	};
+
 	state = {
 		error: null,
 	};

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -95,7 +95,7 @@ export default class Preview extends Component {
 
 	compileCode(code) {
 		try {
-			return compileCode(code, this.context.config.bubleConfig);
+			return compileCode(code, this.context.config.compilerConfig);
 		}
 		catch (err) {
 			this.handleError(err);

--- a/src/rsg-components/Preview/Preview.spec.js
+++ b/src/rsg-components/Preview/Preview.spec.js
@@ -3,13 +3,21 @@ import noop from 'lodash/noop';
 import Preview from '../Preview';
 
 const code = '<button>OK</button>';
+const options = {
+	context: {
+		config: {
+			bubleConfig: {},
+		},
+	},
+};
 
 it('should render component renderer', () => {
 	const actual = shallow(
 		<Preview
 			code={code}
 			evalInContext={noop}
-		/>
+		/>,
+		options
 	);
 
 	expect(actual).toMatchSnapshot();

--- a/src/rsg-components/Preview/Preview.spec.js
+++ b/src/rsg-components/Preview/Preview.spec.js
@@ -6,7 +6,7 @@ const code = '<button>OK</button>';
 const options = {
 	context: {
 		config: {
-			bubleConfig: {},
+			compilerConfig: {},
 		},
 	},
 };


### PR DESCRIPTION
Allows for configuration of buble. Needed this for my use case so that my code examples could have tagged template literals. In buble the config is `transforms.dangerousTaggedTemplateString`