### PR TITLE
add max-scale for mobile safari support

### DIFF
--- a/scripts/templates/index.html
+++ b/scripts/templates/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title><%=htmlWebpackPlugin.options.title%></title>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 	</head>
 	<body>
 		<div id="app"></div>


### PR DESCRIPTION
> Not all mobile browsers handle orientation changes in the same way. For example, Mobile Safari often just zooms the page when changing from portrait to landscape, instead of laying out the page as it would if originally loaded in landscape. If web developers want their scale settings to remain consistent when switching orientations on the iPhone, they must add a maximum-scale value to prevent this zooming, which has the sometimes-unwanted side effect of preventing users from zooming in

https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag