### PR TITLE
Roll back to markdown-to-jsx 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "listify": "^1.0.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.4",
-    "markdown-to-jsx": "^5.2.0",
+    "markdown-to-jsx": "5.2.0",
     "minimist": "^1.2.0",
     "pretty-format": "^19.0.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
This PR rolls markdown-to-jsx back to 5.2.0 to fix #413 