### PR TITLE
Roll forward to markdown-to-jsx 5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "listify": "^1.0.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.4",
-    "markdown-to-jsx": "5.2.0",
+    "markdown-to-jsx": "^5.3.0",
     "minimist": "^1.2.0",
     "pretty-format": "^19.0.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
The issue with markdown-to-jsx 5.3.0 appears to be fixed in 5.3.2 (https://github.com/probablyup/markdown-to-jsx/pull/105), so I'm reverting my previous change

Fixes #413 (again)