### PR TITLE
added share code feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ import {
 	processSections,
 	setSlugs,
 	slugger,
+	isPlayground,
+	getPlayground,
 } from './utils/utils';
 import StyleGuide from 'rsg-components/StyleGuide';
 
@@ -36,8 +38,13 @@ function renderStyleguide() {
 	let isolatedComponent = false;
 	let isolatedExample = false;
 
-	// Filter the requested component id required
-	if (targetComponentName) {
+	if (isPlayground()) {
+		sections = getPlayground(sections);
+		isolatedComponent = true;
+		styleguide.config = { ...styleguide.config, showCode: true };
+	}
+	else if (targetComponentName) {
+		// Filter the requested component id required
 		const filteredComponents = filterComponentsInSectionsByExactName(sections, targetComponentName);
 		sections = [{ components: filteredComponents }];
 		isolatedComponent = true;
@@ -48,7 +55,6 @@ function renderStyleguide() {
 			isolatedExample = true;
 		}
 	}
-
 	// Reset slugger for each render to be deterministic
 	slugger.reset();
 	sections = setSlugs(sections);

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -77,6 +77,11 @@ export default class Playground extends Component {
 		});
 	}
 
+	handleShareExampleClick() {
+		const code = encodeURI(this.state.code);
+		history.pushState({}, 'Playground', `#playground/code=${code}`);
+	}
+
 	render() {
 		const { code, showCode } = this.state;
 		const { evalInContext, index, name } = this.props;
@@ -91,6 +96,7 @@ export default class Playground extends Component {
 				evalInContext={evalInContext}
 				onChange={code => this.handleChange(code)}
 				onCodeToggle={() => this.handleCodeToggle()}
+				onShareExampleClick={() => this.handleShareExampleClick()}
 			/>
 		);
 	}

--- a/src/rsg-components/Playground/Playground.spec.js
+++ b/src/rsg-components/Playground/Playground.spec.js
@@ -124,6 +124,7 @@ it('renderer should render preview', () => {
 			name="name"
 			index={0}
 			onChange={() => {}}
+			onShareExampleClick={() => {}}
 			onCodeToggle={() => {}}
 		/>
 	);

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -15,6 +15,10 @@ const styles = ({ font, link, linkHover, border, baseBackground, codeBackground 
 			isolate: false,
 			opacity: 1,
 		},
+		'&:hover $shareExample': {
+			isolate: false,
+			opacity: 1,
+		},
 	},
 	preview: {
 		marginBottom: 3,
@@ -57,6 +61,16 @@ const styles = ({ font, link, linkHover, border, baseBackground, codeBackground 
 		opacity: 0,
 		transition: 'opacity ease-in-out .15s .2s',
 	},
+	shareExample: {
+		position: 'absolute',
+		top: 0,
+		right: 120,
+		padding: [[6, 8]],
+		fontFamily: font,
+		fontSize: 14,
+		opacity: 0,
+		transition: 'opacity ease-in-out .15s .2s',
+	},
 });
 
 export function PlaygroundRenderer({
@@ -69,10 +83,14 @@ export function PlaygroundRenderer({
 	evalInContext,
 	onChange,
 	onCodeToggle,
+	onShareExampleClick,
 }) {
 	return (
 		<div className={classes.root}>
 			<div className={classes.preview} data-preview={name ? name : ''}>
+				<div className={classes.shareExample}>
+					<Link onClick={onShareExampleClick}>Share example</Link>
+				</div>
 				<div className={classes.isolatedLink}>
 					{name && (
 						isolatedExample ? (
@@ -108,6 +126,7 @@ PlaygroundRenderer.propTypes = {
 	evalInContext: PropTypes.func.isRequired,
 	onChange: PropTypes.func.isRequired,
 	onCodeToggle: PropTypes.func.isRequired,
+	onShareExampleClick: PropTypes.func.isRequired,
 	name: PropTypes.string,
 	isolatedExample: PropTypes.bool,
 };

--- a/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
+++ b/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
@@ -7,6 +7,13 @@ exports[`renderer should render preview 1`] = `
   >
     <div>
       <_class
+        onClick={[Function]}
+      >
+        Share example
+      </_class>
+    </div>
+    <div>
+      <_class
         href="#!/name/0"
       >
         Open isolated ⇢
@@ -34,6 +41,7 @@ exports[`should render component renderer 1`] = `
   name="name"
   onChange={[Function]}
   onCodeToggle={[Function]}
+  onShareExampleClick={[Function]}
   showCode={false}
 />
 `;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -170,6 +170,19 @@ export function getComponentNameFromHash(hash = window.location.hash) {
 }
 
 /**
+ * Returns true if hash contains code of shared example
+ * from hash part or page URL:
+ * http://localhost:6060/#playground/code= → true
+ * http://localhost:6060/#!/Button/1 → false
+ *
+ * @param {string} [hash]
+ * @returns {boolean}
+ */
+export function isPlayground(hash = window.location.hash) {
+	return hash.indexOf('#playground/code=') !== -1;
+}
+
+/**
  * Return a shallow copy of the given component with the examples array filtered
  * to contain only the specified index:
  * filterComponentExamples({ examples: [1,2,3], ...other }, 2) → { examples: [3], ...other }
@@ -182,4 +195,30 @@ export function filterComponentExamples(component, index) {
 	const newComponent = Object.assign({}, component);
 	newComponent.props.examples = [component.props.examples[index]];
 	return newComponent;
+}
+/**
+ * Return playground
+ * It just create fake component with example from url
+ * @param {Array} sections
+ * @return {Array}
+ */
+export function getPlayground(sections) {
+	const evalInContext = sections[0].components[0].props.examples.filter(example =>
+	example.evalInContext)[0].evalInContext;
+	const code = decodeURI(location.hash.replace('#playground/code=', ''));
+	sections = [{
+		components: [{
+			name: 'PlayGround',
+			hasExamples: true,
+			props: {
+				examples: [{
+					content: code,
+					type: 'code',
+					evalInContext,
+				}],
+				methods: [],
+			},
+		}],
+	}];
+	return sections;
 }


### PR DESCRIPTION
Hello @sapegin!
Our team need in share code feature for sharing examples, bug stands for another developers.
I thing that this feature useful for all styleguidist users.
In playgroundRenderer component i added 
![image](https://cloud.githubusercontent.com/assets/2854910/25563669/7cf9665e-2da9-11e7-866e-eee5f97219b8.png) share example button which copy code to url (maybe clipboard in the future).
Then user can copy url and pass to another developer which will past it to browser and see playground with example.
Please, review PR, and maybe you have suggestions how to implement this functionality more simple 