### PR TITLE
Docs: Fix question order in Cookbook

### DIFF
--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -164,6 +164,27 @@ module.exports = {
 <MyComponent object={sample.object} />
 ```
 
+## How to use React Styleguidist with Preact?
+
+You need to alias `react` and `react-dom` to `preact-compat`:
+
+```javascript
+module.exports = {
+  webpackConfig: {
+    resolve: {
+      alias: {
+        react: 'preact-compat',
+        'react-dom': 'preact-compat',
+      }
+    }
+  }
+};
+```
+
+See the [Preact example style guide](https://github.com/styleguidist/react-styleguidist/tree/master/examples/preact).
+
+**Warning:** Preact support is experimental and far from perfect. Feel free to send a pull request to imporove it.
+
 ## How to use React Styleguidist with styled-components?
 
 The [recommended way](https://github.com/styleguidist/react-styleguidist/issues/37#issuecomment-263502454) of using [styled-components](https://styled-components.com/) is like this:
@@ -190,27 +211,6 @@ export default Button;
 You may need an appropriate webpack loader to handle these files.
 
 > **Note:** to change style guide styles use `theme` and `styles` options (see the next question).
-
-## How to use React Styleguidist with Preact?
-
-You need to alias `react` and `react-dom` to `preact-compat`:
-
-```javascript
-module.exports = {
-  webpackConfig: {
-    resolve: {
-      alias: {
-        react: 'preact-compat',
-        'react-dom': 'preact-compat',
-      }
-    }
-  }
-};
-```
-
-See the [Preact example style guide](https://github.com/styleguidist/react-styleguidist/tree/master/examples/preact).
-
-**Warning:** Preact support is experimental and far from perfect. Feel free to send a pull request to imporove it.
 
 ## How to change styles of a style guide?
 


### PR DESCRIPTION
Hello!

I found a little mistake IMO. The note after `styled-components` question said:

> **Note:** to change style guide styles use `theme` and `styles` options (see the next question).

But the next question is about `Preact` and the question right after is exactly about `theme` and `styles`. So I changed the order to match "note" in `styled-components` question.

Thank you for the project!

Best,
Nikolay.