### PR TITLE
Add logging for handled errors in Preview

### DIFF
--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -129,6 +129,8 @@ export default class Preview extends Component {
 		this.setState({
 			error: err.toString(),
 		});
+
+		console.error(err); // eslint-disable-line no-console
 	}
 
 	render() {


### PR DESCRIPTION
This change makes easier debugging.
Before this change you can't understand why and how did you get an error
![2017-05-06_14-58-48](https://cloud.githubusercontent.com/assets/3505878/25772143/b699c530-326c-11e7-9e94-82307d773607.png)
After merge, developer would be able to discover errors in console:
![2017-05-06_15-00-51](https://cloud.githubusercontent.com/assets/3505878/25772144/d3d439fa-326c-11e7-9f7b-532d8327ce0d.png)