### PR TITLE
Fixes a crash when using a defaultProp that is not listed in props

### DIFF
--- a/examples/basic/src/components/Button/Button.js
+++ b/examples/basic/src/components/Button/Button.js
@@ -33,7 +33,6 @@ Button.propTypes = {
 };
 Button.defaultProps = {
 	color: '#333',
-	crash: true,
 	size: 'normal',
 	/* eslint-disable no-console */
 	onClick: (event) => {

--- a/examples/basic/src/components/Button/Button.js
+++ b/examples/basic/src/components/Button/Button.js
@@ -33,6 +33,7 @@ Button.propTypes = {
 };
 Button.defaultProps = {
 	color: '#333',
+	crash: true,
 	size: 'normal',
 	/* eslint-disable no-console */
 	onClick: (event) => {

--- a/loaders/utils/__tests__/__snapshots__/getProps.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/getProps.spec.js.snap
@@ -24,6 +24,22 @@ Object {
 }
 `;
 
+exports[`should not crash when using doctrine to parse a default prop that isn't in the props list 1`] = `
+Object {
+  "description": "The only true button.
+",
+  "doclets": Object {},
+  "methods": Array [],
+  "props": Object {
+    "crash": Object {
+      "description": "",
+      "tags": Object {},
+    },
+  },
+  "tags": Object {},
+}
+`;
+
 exports[`should remove non-public methods 1`] = `
 Object {
   "doclets": Object {},

--- a/loaders/utils/__tests__/getProps.spec.js
+++ b/loaders/utils/__tests__/getProps.spec.js
@@ -107,3 +107,17 @@ alert('Hello world');
 
 	expect(result).toMatchSnapshot();
 });
+
+it('should not crash when using doctrine to parse a default prop that isn\'t in the props list', () => {
+	const result = getProps({
+		description: 'The only true button.',
+		methods: [],
+		props: {
+			crash: {
+				description: undefined,
+			},
+		},
+	});
+
+	expect(result).toMatchSnapshot();
+});

--- a/loaders/utils/getProps.js
+++ b/loaders/utils/getProps.js
@@ -68,7 +68,8 @@ module.exports = function getProps(doc) {
 		Object.keys(doc.props).forEach(propName => {
 			const prop = doc.props[propName];
 			const doclets = getDocletsObject(prop.description);
-			const documentation = doctrine.parse(prop.description);
+			// when a prop is listed in defaultProps but not in props the prop.description is undefined
+			const documentation = doctrine.parse(prop.description || '');
 
 			// documentation.description is the description without tags
 			doc.props[propName].description = documentation.description;


### PR DESCRIPTION
This pull request fixes a crash, that occurs when you use a defaultProp that is not listed in the props. The cause was my previous PR not checking whether the incoming description might be `undefined`.

The error is kind of nasty because the styleguidist wont compile. 

I added the fix and the test to replicate the error.