### PR TITLE
fix(*): fix back button path for support pathname-relative paths

### DIFF
--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -88,7 +88,7 @@ export function ReactComponentRenderer({
 				<div className={classes.pathLine}>{pathLine}</div>
 				<div className={classes.isolatedLink}>
 					{isolated
-						? <Link href="/">← Back</Link>
+						? <Link href="#">← Back</Link>
 						: <Link href={'#!/' + name}>Open isolated ⇢</Link>}
 				</div>
 			</header>

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -88,7 +88,7 @@ export function ReactComponentRenderer({
 				<div className={classes.pathLine}>{pathLine}</div>
 				<div className={classes.isolatedLink}>
 					{isolated
-						? <Link href="#">← Back</Link>
+						? <Link href="">← Back</Link>
 						: <Link href={'#!/' + name}>Open isolated ⇢</Link>}
 				</div>
 			</header>

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -159,7 +159,7 @@ exports[`should render component in isolation mode 1`] = `
     </div>
     <div>
       <_class
-        href="/"
+        href="#"
       >
         ← Back
       </_class>

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -159,7 +159,7 @@ exports[`should render component in isolation mode 1`] = `
     </div>
     <div>
       <_class
-        href="#"
+        href=""
       >
         ← Back
       </_class>

--- a/src/rsg-components/Section/SectionRenderer.js
+++ b/src/rsg-components/Section/SectionRenderer.js
@@ -47,7 +47,7 @@ export function SectionRenderer({
 				<div className={classes.isolatedLink}>
 					{name &&
 						(isolatedSection
-							? <Link href="#">⇽ Back</Link>
+							? <Link href="">⇽ Back</Link>
 							: <Link href={'#!/' + name}>Open isolated ⇢</Link>)}
 				</div>
 			</div>

--- a/src/rsg-components/Section/SectionRenderer.js
+++ b/src/rsg-components/Section/SectionRenderer.js
@@ -47,7 +47,7 @@ export function SectionRenderer({
 				<div className={classes.isolatedLink}>
 					{name &&
 						(isolatedSection
-							? <Link href="/">⇽ Back</Link>
+							? <Link href="#">⇽ Back</Link>
 							: <Link href={'#!/' + name}>Open isolated ⇢</Link>)}
 				</div>
 			</div>


### PR DESCRIPTION
Hello @sapegin.
Minor fix for situation when you docs published not in root of domain.
for example when your docs build at https://alfa-laboratory.github.io/arui-feather/arui-demo/styleguide url for isolated component is https://alfa-laboratory.github.io/arui-feather/arui-demo/styleguide/#!/Amount
"Back" button navigates to https://alfa-laboratory.github.io/