### PR TITLE
Fix/exit isolated button fix

### DIFF
--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -33,8 +33,12 @@ export default class Playground extends Component {
 		});
 	}
 
-	shouldComponentUpdate(nextProps, nextState) {
-		return nextState.code !== this.state.code || nextState.showCode !== this.state.showCode;
+	shouldComponentUpdate(nextProps, nextState, context) {
+		return (
+			nextState.code !== this.state.code ||
+			nextState.showCode !== this.state.showCode ||
+			this.context.isolatedExample !== context.isolatedExample
+		);
 	}
 
 	componentWillUnmount() {

--- a/src/rsg-components/Playground/Playground.spec.js
+++ b/src/rsg-components/Playground/Playground.spec.js
@@ -11,6 +11,7 @@ const options = {
 			showCode: false,
 			highlightTheme: 'base16-light',
 		},
+		isolatedExample: false,
 	},
 };
 
@@ -83,6 +84,19 @@ it('should open a code editor', () => {
 	actual.find('button').simulate('click');
 
 	expect(actual.find('.ReactCodeMirror')).toHaveLength(1);
+});
+
+it('should updated isolate mode toggle button text', () => {
+	const actual = mount(
+		<Playground code={code} evalInContext={a => () => a} name="name" index={0} />,
+		options
+	);
+	expect(actual.find('a').prop('children')).toEqual('Open isolated ⇢');
+	actual.setContext({
+		config: options.context.config,
+		isolatedExample: true,
+	});
+	expect(actual.find('a').prop('children')).toEqual('⇽ Exit Isolation');
 });
 
 it('renderer should render preview', () => {

--- a/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
+++ b/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
@@ -31,6 +31,7 @@ exports[`should render component renderer 1`] = `
   code="<button>OK</button>"
   evalInContext={[Function]}
   index={0}
+  isolatedExample={false}
   name="name"
   onChange={[Function]}
   onCodeToggle={[Function]}

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -88,7 +88,7 @@ export function ReactComponentRenderer({
 				<div className={classes.pathLine}>{pathLine}</div>
 				<div className={classes.isolatedLink}>
 					{isolated
-						? <Link href="/">← Back</Link>
+						? <Link href="#">← Back</Link>
 						: <Link href={'#!/' + name}>Open isolated ⇢</Link>}
 				</div>
 			</header>

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -88,7 +88,7 @@ export function ReactComponentRenderer({
 				<div className={classes.pathLine}>{pathLine}</div>
 				<div className={classes.isolatedLink}>
 					{isolated
-						? <Link href="#">← Back</Link>
+						? <Link href="">← Back</Link>
 						: <Link href={'#!/' + name}>Open isolated ⇢</Link>}
 				</div>
 			</header>

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -159,7 +159,7 @@ exports[`should render component in isolation mode 1`] = `
     </div>
     <div>
       <_class
-        href="/"
+        href="#"
       >
         ← Back
       </_class>

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -159,7 +159,7 @@ exports[`should render component in isolation mode 1`] = `
     </div>
     <div>
       <_class
-        href="#"
+        href=""
       >
         ← Back
       </_class>

--- a/src/rsg-components/Section/SectionRenderer.js
+++ b/src/rsg-components/Section/SectionRenderer.js
@@ -47,7 +47,7 @@ export function SectionRenderer({
 				<div className={classes.isolatedLink}>
 					{name &&
 						(isolatedSection
-							? <Link href="#">⇽ Back</Link>
+							? <Link href="">⇽ Back</Link>
 							: <Link href={'#!/' + name}>Open isolated ⇢</Link>)}
 				</div>
 			</div>

--- a/src/rsg-components/Section/SectionRenderer.js
+++ b/src/rsg-components/Section/SectionRenderer.js
@@ -47,7 +47,7 @@ export function SectionRenderer({
 				<div className={classes.isolatedLink}>
 					{name &&
 						(isolatedSection
-							? <Link href="/">⇽ Back</Link>
+							? <Link href="#">⇽ Back</Link>
 							: <Link href={'#!/' + name}>Open isolated ⇢</Link>)}
 				</div>
 			</div>


### PR DESCRIPTION
What happens:
When going into the isolation example and trying to go back button have text 'Exit isolated'.

What should happen: Button should have text 'Open isolated'


To reproduce,

go to https://react-styleguidist.js.org/examples/basic/#button

Press "Open isolated" in Playground
In the newly opened page, press "Exit isolated"
Observe you are now on component page, but button in playground still have "Exit isolated text"

This fix update Playground on context change.
Added test