### PR TITLE
Makes getExampleFilename case insensitive

### DIFF
--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -16,6 +16,9 @@ const createDisplayNameHandler = require('react-docgen-displayname-handler')
 const findUserWebpackConfig = require('../utils/findUserWebpackConfig');
 const getUserPackageJson = require('../utils/getUserPackageJson');
 const consts = require('../consts');
+const memoize = require('lodash/memoize');
+
+const memoizedReaddirSync = memoize(fs.readdirSync);
 
 module.exports = {
 	assetsDir: {
@@ -62,7 +65,7 @@ module.exports = {
 	getExampleFilename: {
 		type: 'function',
 		default: componentPath => {
-			const files = fs.readdirSync(path.dirname(componentPath));
+			const files = memoizedReaddirSync(path.dirname(componentPath));
 
 			for (const file of files) {
 				const componentName = path.basename(componentPath).replace(path.extname(componentPath), '');

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -62,14 +62,15 @@ module.exports = {
 	getExampleFilename: {
 		type: 'function',
 		default: componentPath => {
-			const files = [
-				path.join(path.dirname(componentPath), 'Readme.md'),
-				componentPath.replace(path.extname(componentPath), '.md'),
-			];
+			const files = fs.readdirSync(path.dirname(componentPath));
 
 			for (const file of files) {
-				if (fs.existsSync(file)) {
-					return file;
+				const componentName = path.basename(componentPath).replace(path.extname(componentPath), '');
+
+				const isReadmeMd = file.toLowerCase() === 'readme.md';
+				const isComponentMd = file.toLowerCase() === componentName.toLowerCase() + '.md';
+				if (isReadmeMd || isComponentMd) {
+					return path.join(path.dirname(componentPath), file);
 				}
 			}
 


### PR DESCRIPTION
Current implementation of `getExampleFilename()` works in different way on Linux (case sensitive filesystem) and OS X (case insensitive filesystem). This pull request fixes this issue.