### PR TITLE
Make rsg components overridable using dangerouslyUpdateWebpackConfig

### DIFF
--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -111,13 +111,13 @@ module.exports = function(config, env) {
 		});
 	}
 
-	// Add components folder alias at the end so users can override our components to customize the style guide
-	// (their aliases should be before this one)
-	webpackConfig.resolve.alias['rsg-components'] = path.resolve(sourceDir, 'rsg-components');
-
 	if (config.dangerouslyUpdateWebpackConfig) {
 		webpackConfig = config.dangerouslyUpdateWebpackConfig(webpackConfig, env);
 	}
+	
+	// Add components folder alias at the end so users can override our components to customize the style guide
+	// (their aliases should be before this one)
+	webpackConfig.resolve.alias['rsg-components'] = path.resolve(sourceDir, 'rsg-components');
 
 	return webpackConfig;
 };


### PR DESCRIPTION
I know that the usage of `dangerouslyUpdateWebpackConfig` is discouraged, but I was playing around with it ([I like to live dangerously](https://www.youtube.com/watch?v=dVSjCvGFMnM) :)) and I found out that I couldn't override the rsg components.