### PR TITLE
Remove border from TabButton

### DIFF
--- a/src/rsg-components/TabButton/TabButtonRenderer.js
+++ b/src/rsg-components/TabButton/TabButtonRenderer.js
@@ -12,6 +12,7 @@ export const styles = ({ space, color, fontFamily, fontSize }) => ({
 		background: 'transparent',
 		textTransform: 'uppercase',
 		transition: 'color 750ms ease-out',
+		border: 'none',
 		cursor: 'pointer',
 		'&:hover, &:focus': {
 			isolate: false,


### PR DESCRIPTION
This PR explicitly removes border from TabButton to make it look good on Windows.