### PR TITLE
Fix missing title in function descriptions

### DIFF
--- a/src/rsg-components/Text/Text.spec.js
+++ b/src/rsg-components/Text/Text.spec.js
@@ -16,3 +16,9 @@ it('should render underlined text', () => {
 
 	expect(actual).toMatchSnapshot();
 });
+
+it('should render text with a title', () => {
+	const actual = shallow(<TextRenderer {...props} title="Pasta">Pizza</TextRenderer>);
+
+	expect(actual).toMatchSnapshot();
+});

--- a/src/rsg-components/Text/TextRenderer.js
+++ b/src/rsg-components/Text/TextRenderer.js
@@ -14,11 +14,11 @@ export const styles = ({ fontFamily, fontSize, color }) => ({
 	},
 });
 
-export function TextRenderer({ classes, children, underlined }) {
+export function TextRenderer({ classes, children, underlined, ...other }) {
 	const classNames = cx(classes.text, {
 		[classes.isUnderlined]: underlined,
 	});
-	return <span className={classNames}>{children}</span>;
+	return <span className={classNames} {...other}>{children}</span>;
 }
 
 TextRenderer.propTypes = {

--- a/src/rsg-components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/rsg-components/Text/__snapshots__/Text.spec.js.snap
@@ -8,6 +8,15 @@ exports[`should render text 1`] = `
 </span>
 `;
 
+exports[`should render text with a title 1`] = `
+<span
+  className="text"
+  title="Pasta"
+>
+  Pizza
+</span>
+`;
+
 exports[`should render underlined text 1`] = `
 <span
   className="text isUnderlined"


### PR DESCRIPTION
This PR restores the popup which described function text for functions as default props.