### PR TITLE
Tweak Webpack 2 conditions

### DIFF
--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -12,7 +12,7 @@ const getWebpackVersion = require('./utils/getWebpackVersion');
 const mergeWebpackConfig = require('./utils/mergeWebpackConfig');
 const StyleguidistOptionsPlugin = require('./utils/StyleguidistOptionsPlugin');
 
-const isWebpack2 = getWebpackVersion() === 2;
+const isWebpackLessThan2 = getWebpackVersion() < 2;
 const sourceDir = path.resolve(__dirname, '../lib');
 const htmlLoader = require.resolve('html-webpack-plugin/lib/loader');
 
@@ -29,7 +29,7 @@ module.exports = function(config, env) {
 			chunkFilename: 'build/[name].js',
 		},
 		resolve: {
-			extensions: isWebpack2 ? ['.js', '.jsx', '.json'] : ['.js', '.jsx', '.json', ''],
+			extensions: isWebpackLessThan2 ? ['.js', '.jsx', '.json', ''] : ['.js', '.jsx', '.json'],
 			alias: {
 				'rsg-codemirror-theme.css': `codemirror/theme/${config.highlightTheme}.css`,
 			},
@@ -79,7 +79,7 @@ module.exports = function(config, env) {
 				}),
 			],
 		});
-		if (!isWebpack2) {
+		if (isWebpackLessThan2) {
 			webpackConfig.plugins.push(new webpack.optimize.DedupePlugin());
 		}
 	} else {
@@ -98,7 +98,7 @@ module.exports = function(config, env) {
 	}
 
 	// Add JSON loader if user config has no one (Webpack 2 includes it by default)
-	if (!isWebpack2 && !hasJsonLoader(webpackConfig)) {
+	if (isWebpackLessThan2 && !hasJsonLoader(webpackConfig)) {
 		webpackConfig = merge(webpackConfig, {
 			module: {
 				loaders: [


### PR DESCRIPTION
`react-styleguidist` seems to have an incompatibility with Webpack 3 ([released today](https://github.com/webpack/webpack/releases/tag/v3.0.0)). Specifically, the issue I experienced was that the Webpack config used with Webpack 3 had its `config.resolve.extensions` [set to](https://github.com/styleguidist/react-styleguidist/blob/master/scripts/make-webpack-config.js#L32) `['.js', '.jsx', '.json', '']` (which Webpack 3 complains about):
```
$ ./node_modules/.bin/styleguidist server --config ./node_modules/js-infra/config/styleguidist/index.js
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.resolve.extensions[3] should not be empty.
```
I've tried tweaking the Webpack 2 conditions in [scripts/make-webpack-config.js](https://github.com/styleguidist/react-styleguidist/blob/master/scripts/make-webpack-config.js) a little so as to make it compatible with Webpack 3. Let me know what you think!