### PR TITLE
Fix: Enable webpack example run alone

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -18,6 +18,10 @@
   },
   "dependencies": {
     "babel-loader": "^6.4.0",
+    "babel-core": "^6.25.0",
+    "babel-preset-env": "^1.5.2",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "css-loader": "^0.26.2",
     "dog-names": "^1.0.2",
     "file-loader": "^0.10.1",

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -12,6 +12,14 @@ module.exports = {
 				test: /\.(js|jsx)$/,
 				include: path.resolve(__dirname, 'src'),
 				loader: 'babel-loader',
+				query: {
+					presets: [['env', {"targets": { "node": "current" }}], 'react'],
+					plugins: [
+						'transform-class-properties',
+						'transform-object-rest-spread'
+					],
+					babelrc: false
+				}
 			},
 			{
 				test: /\.css$/,


### PR DESCRIPTION
When trying to run this example I was getting an error because of `.babelrc` defined in the root folder of the project. 

Error before the change:
```bash
Hash: 433f7d975abbc65d5e0e
Version: webpack 2.6.1
Time: 503ms
    Asset     Size  Chunks             Chunk Names
bundle.js  4.38 kB       0  [emitted]  main
   [0] ./src/index.js 1.74 kB {0} [built] [failed] [1 error]

ERROR in ./src/index.js
Module build failed: ReferenceError: Unknown plugin "transform-class-properties" specified in "/Users/cristian.oliveira/other/react-styleguidist/.babelrc" at 0, attempted to resolve relative to "/Users/cristian.oliveira/other/react-styleguidist"
    at /Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
    at Array.map (native)
    at Function.normalisePlugins (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
    at OptionManager.mergeOptions (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
    at OptionManager.init (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-loader/lib/index.js:46:20)
    at Object.module.exports (/Users/cristian.oliveira/other/react-styleguidist/examples/webpack/node_modules/babel-loader/lib/index.js:163:20)
```

This simple modification enables run it independently. Also, it enables using this example as a boilerplate for new projects. :)
