### PR TITLE
feat(*): allow to pass settings for markdown code viewer

### DIFF
--- a/examples/basic/src/components/Button/Readme.md
+++ b/examples/basic/src/components/Button/Readme.md
@@ -20,8 +20,14 @@ If you define a fenced code block with another language it will be rendered as a
 <h1>Hello world</h1>
 ```
 
-If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with passed 'static' modifier it will be rendered as a regular Markdown code snippet:
 
 ```jsx // static
 import React from 'react';
+```
+
+You can define a fenced code block with 'noEditor' modifier. It will be rendered without editor
+
+```jsx // noEditor
+<Button>Push Me</Button>
 ```

--- a/examples/basic/src/components/Button/Readme.md
+++ b/examples/basic/src/components/Button/Readme.md
@@ -22,12 +22,12 @@ If you define a fenced code block with another language it will be rendered as a
 
 If you define a fenced code block with passed 'static' modifier it will be rendered as a regular Markdown code snippet:
 
-```jsx // static
+```jsx static
 import React from 'react';
 ```
 
 You can define a fenced code block with 'noEditor' modifier. It will be rendered without editor
 
-```jsx // noEditor
+```jsx noEditor
 <Button>Push Me</Button>
 ```

--- a/examples/basic/src/components/Button/Readme.md
+++ b/examples/basic/src/components/Button/Readme.md
@@ -8,8 +8,14 @@ Big pink button:
 
 And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
 
-If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with js | jsx | javascript language it will be rendered as a regular Markdown code snippet:
 
-```javascript
+```jsx
+<Button>Push Me</Button>
+```
+
+If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
+
+```html
 import React from 'react';
 ```

--- a/examples/basic/src/components/Button/Readme.md
+++ b/examples/basic/src/components/Button/Readme.md
@@ -17,5 +17,11 @@ If you define a fenced code block with js | jsx | javascript language it will be
 If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
 
 ```html
+<h1>Hello world</h1>
+```
+
+If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+
+```jsx // static
 import React from 'react';
 ```

--- a/examples/cra/src/components/Button.md
+++ b/examples/cra/src/components/Button.md
@@ -22,6 +22,6 @@ If you define a fenced code block with another language it will be rendered as a
 
 If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
 
-```jsx // static
+```jsx static
 import React from 'react';
 ```

--- a/examples/cra/src/components/Button.md
+++ b/examples/cra/src/components/Button.md
@@ -8,8 +8,14 @@ Big pink button:
 
 And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
 
-If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with js | jsx | javascript language it will be rendered as a regular Markdown code snippet:
 
-```javascript
+```jsx
+<Button>Push Me</Button>
+```
+
+If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
+
+```html
 import React from 'react';
 ```

--- a/examples/cra/src/components/Button.md
+++ b/examples/cra/src/components/Button.md
@@ -17,5 +17,11 @@ If you define a fenced code block with js | jsx | javascript language it will be
 If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
 
 ```html
+<h1>Hello world</h1>
+```
+
+If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+
+```jsx // static
 import React from 'react';
 ```

--- a/examples/customised/src/components/Button/Readme.md
+++ b/examples/customised/src/components/Button/Readme.md
@@ -22,6 +22,6 @@ If you define a fenced code block with another language it will be rendered as a
 
 If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
 
-```jsx // static
+```jsx static
 import React from 'react';
 ```

--- a/examples/customised/src/components/Button/Readme.md
+++ b/examples/customised/src/components/Button/Readme.md
@@ -8,8 +8,20 @@ Big pink button:
 
 And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
 
-If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with js | jsx | javascript language it will be rendered as a regular Markdown code snippet:
 
-```javascript
+```jsx
+<Button>Push Me</Button>
+```
+
+If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
+
+```html
+<h1>Hello world</h1>
+```
+
+If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+
+```jsx // static
 import React from 'react';
 ```

--- a/examples/preact/src/components/Button/Readme.md
+++ b/examples/preact/src/components/Button/Readme.md
@@ -22,6 +22,6 @@ If you define a fenced code block with another language it will be rendered as a
 
 If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
 
-```jsx // static
+```jsx static
 import React from 'react';
 ```

--- a/examples/preact/src/components/Button/Readme.md
+++ b/examples/preact/src/components/Button/Readme.md
@@ -8,8 +8,14 @@ Big pink button:
 
 And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
 
-If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with js | jsx | javascript language it will be rendered as a regular Markdown code snippet:
 
-```javascript
+```jsx
+<Button>Push Me</Button>
+```
+
+If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
+
+```html
 import React from 'react';
 ```

--- a/examples/preact/src/components/Button/Readme.md
+++ b/examples/preact/src/components/Button/Readme.md
@@ -17,5 +17,11 @@ If you define a fenced code block with js | jsx | javascript language it will be
 If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
 
 ```html
+<h1>Hello world</h1>
+```
+
+If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+
+```jsx // static
 import React from 'react';
 ```

--- a/examples/sections/docs/One.md
+++ b/examples/sections/docs/One.md
@@ -53,7 +53,7 @@ A [link](http://example.com).
 
 ![React](http://morning.photos/photos/thumb/2014-09-27-3218-thumb.jpg)
 
-```js // static
+```js static
 function eatFood(food) {
     if (!food.length) {
         return ['No food'];

--- a/examples/sections/docs/One.md
+++ b/examples/sections/docs/One.md
@@ -53,7 +53,7 @@ A [link](http://example.com).
 
 ![React](http://morning.photos/photos/thumb/2014-09-27-3218-thumb.jpg)
 
-```js
+```js // static
 function eatFood(food) {
     if (!food.length) {
         return ['No food'];

--- a/examples/sections/src/components/Button/Readme.md
+++ b/examples/sections/src/components/Button/Readme.md
@@ -22,6 +22,6 @@ If you define a fenced code block with another language it will be rendered as a
 
 If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
 
-```jsx // static
+```jsx static
 import React from 'react';
 ```

--- a/examples/sections/src/components/Button/Readme.md
+++ b/examples/sections/src/components/Button/Readme.md
@@ -8,8 +8,20 @@ Big pink button:
 
 And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
 
-If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with js | jsx | javascript language it will be rendered as a regular Markdown code snippet:
 
-```javascript
+```jsx
+<Button>Push Me</Button>
+```
+
+If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
+
+```html
+<h1>Hello world</h1>
+```
+
+If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+
+```jsx // static
 import React from 'react';
 ```

--- a/examples/webpack/src/components/Button.md
+++ b/examples/webpack/src/components/Button.md
@@ -22,6 +22,6 @@ If you define a fenced code block with another language it will be rendered as a
 
 If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
 
-```jsx // static
+```jsx static
 import React from 'react';
 ```

--- a/examples/webpack/src/components/Button.md
+++ b/examples/webpack/src/components/Button.md
@@ -8,8 +8,14 @@ Big pink button:
 
 And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
 
-If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+If you define a fenced code block with js | jsx | javascript language it will be rendered as a regular Markdown code snippet:
 
-```javascript
+```jsx
+<Button>Push Me</Button>
+```
+
+If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
+
+```html
 import React from 'react';
 ```

--- a/examples/webpack/src/components/Button.md
+++ b/examples/webpack/src/components/Button.md
@@ -17,5 +17,11 @@ If you define a fenced code block with js | jsx | javascript language it will be
 If you define a fenced code block with another language it will be rendered as a regular Markdown code snippet:
 
 ```html
+<h1>Hello world</h1>
+```
+
+If you define a fenced code block with passed static modifier it will be rendered as a regular Markdown code snippet:
+
+```jsx // static
 import React from 'react';
 ```

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -16,7 +16,7 @@ Text with *some* **formatting** and a [link](/foo).
 
 Text with some \`code\`.
 
-\`\`\`
+\`\`\`jsx // { "static": false }
 <h2>Hello Markdown!</h2>
 \`\`\`
 
@@ -41,6 +41,7 @@ This should be highlighted:
 		{
 			type: 'code',
 			content: '<h1>Hello Markdown!</h1>',
+			settings: {},
 		},
 		{
 			type: 'markdown',
@@ -49,6 +50,9 @@ This should be highlighted:
 		{
 			type: 'code',
 			content: '<h2>Hello Markdown!</h2>',
+			settings: {
+				static: false,
+			},
 		},
 		{
 			type: 'markdown',
@@ -57,6 +61,7 @@ This should be highlighted:
 		{
 			type: 'code',
 			content: '<h3>Hello Markdown!</h3>',
+			settings: {},
 		},
 		{
 			type: 'markdown',
@@ -83,9 +88,61 @@ Foo:
 		{
 			type: 'code',
 			content: '<h1>Hello Markdown!</h1>',
+			settings: {},
 		},
 	];
 
+	const actual = chunkify(markdown);
+	expect(actual).toEqual(expected);
+});
+
+it('should parse examples settings correctly', () => {
+	const markdown = `
+Pass props to CodeRenderer
+
+\`\`\`js // { "showCode": true }
+<h1>Hello Markdown!</h1>
+\`\`\`
+	
+Pass props to PreviewRenderer
+
+\`\`\`jsx // { "noEditor": true }
+<h2>Hello Markdown!</h2>
+\`\`\`
+
+\`\`\`jsx // { "static": true }
+<h2>This is Highlighted!</h2>
+\`\`\`
+`;
+	const expected = [
+		{
+			type: 'markdown',
+			content: 'Pass props to CodeRenderer',
+		},
+		{
+			type: 'code',
+			content: '<h1>Hello Markdown!</h1>',
+			settings: {
+				showCode: true,
+			},
+		},
+		{
+			type: 'markdown',
+			content: 'Pass props to PreviewRenderer',
+		},
+		{
+			type: 'code',
+			content: '<h2>Hello Markdown!</h2>',
+			settings: {
+				noEditor: true,
+			},
+		},
+		{
+			type: 'markdown',
+			content:
+				'```jsx\n&lt;h2&gt;This is Highlighted!<span class="xml"><span class="hljs-tag">&lt;/<span class="hljs-name">h2</span>&gt;</span></span>\n```',
+		},
+	];
 	const actual = chunkify(markdown);
 	expect(actual).toEqual(expected);
 });

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -20,12 +20,6 @@ Text with some \`code\`.
 <h2>Hello Markdown!</h2>
 \`\`\`
 
-This is the same as above:
-
-\`\`\`example
-<h3>Hello Markdown!</h3>
-\`\`\`
-
 This should be highlighted:
 
 \`\`\`html
@@ -53,15 +47,6 @@ This should be highlighted:
 			settings: {
 				static: false,
 			},
-		},
-		{
-			type: 'markdown',
-			content: 'This is the same as above:',
-		},
-		{
-			type: 'code',
-			content: '<h3>Hello Markdown!</h3>',
-			settings: {},
 		},
 		{
 			type: 'markdown',
@@ -104,7 +89,7 @@ Pass props to CodeRenderer
 <h1>Hello Markdown!</h1>
 \`\`\`
 
-\`\`\`js // noEditor { "frame": {"width": "400px"} }
+\`\`\`js // { "frame": {"width": "400px"} }
 <h1>Example in frame and Without editor</h1>
 \`\`\`
 	
@@ -134,7 +119,6 @@ Pass props to PreviewRenderer
 			type: 'code',
 			content: '<h1>Example in frame and Without editor</h1>',
 			settings: {
-				noEditor: true,
 				frame: {
 					width: '400px',
 				},

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -16,7 +16,7 @@ Text with *some* **formatting** and a [link](/foo).
 
 Text with some \`code\`.
 
-\`\`\`jsx // { "static": false }
+\`\`\`jsx { "static": false }
 <h2>Hello Markdown!</h2>
 \`\`\`
 
@@ -85,21 +85,21 @@ it('should parse examples settings correctly', () => {
 	const markdown = `
 Pass props to CodeRenderer
 
-\`\`\`js // { "showCode": true }
+\`\`\`js { "showCode": true }
 <h1>Hello Markdown!</h1>
 \`\`\`
 
-\`\`\`js // { "frame": {"width": "400px"} }
+\`\`\`js { "frame": {"width": "400px"} }
 <h1>Example in frame and Without editor</h1>
 \`\`\`
 	
 Pass props to PreviewRenderer
 
-\`\`\`jsx // { "noEditor": true }
+\`\`\`jsx { "noEditor": true }
 <h2>Hello Markdown!</h2>
 \`\`\`
 
-\`\`\`jsx // static
+\`\`\`jsx static
 <h2>This is Highlighted!</h2>
 \`\`\`
 `;

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -103,6 +103,10 @@ Pass props to CodeRenderer
 \`\`\`js // { "showCode": true }
 <h1>Hello Markdown!</h1>
 \`\`\`
+
+\`\`\`js // noEditor { "frame": {"width": "400px"} }
+<h1>Example in frame and Without editor</h1>
+\`\`\`
 	
 Pass props to PreviewRenderer
 
@@ -110,7 +114,7 @@ Pass props to PreviewRenderer
 <h2>Hello Markdown!</h2>
 \`\`\`
 
-\`\`\`jsx // { "static": true }
+\`\`\`jsx // static
 <h2>This is Highlighted!</h2>
 \`\`\`
 `;
@@ -124,6 +128,16 @@ Pass props to PreviewRenderer
 			content: '<h1>Hello Markdown!</h1>',
 			settings: {
 				showCode: true,
+			},
+		},
+		{
+			type: 'code',
+			content: '<h1>Example in frame and Without editor</h1>',
+			settings: {
+				noEditor: true,
+				frame: {
+					width: '400px',
+				},
 			},
 		},
 		{

--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -15,7 +15,7 @@ const CODE_PLACEHOLDER = '<%{#code#}%>';
 module.exports = function chunkify(markdown) {
 	const codeChunks = [];
 	const codeLanguages = ['javascript', 'js', 'jsx'];
-
+	const settingsModifiers = ['static', 'noEditor'];
 	/*
 	 * - Highlight code in fenced code blocks with defined language (```html) if the language is not `example`.
 	 * - Extract indented and fenced code blocks with lang javascript | js | jsx or if language is `example`.
@@ -25,13 +25,20 @@ module.exports = function chunkify(markdown) {
 		return ast => {
 			visit(ast, 'code', node => {
 				let lang = node.lang || '';
-				let settings;
+				let settings = {};
 				try {
+					settingsModifiers.forEach(modifier => {
+						if (lang.indexOf(modifier) !== -1) {
+							settings[modifier] = true;
+						}
+					});
 					const settingsString = lang.slice(lang.indexOf('{'), lang.lastIndexOf('}') + 1) || '{}';
-					settings = JSON.parse(settingsString);
+					settings = { ...settings, ...JSON.parse(settingsString) };
 				} catch (exception) {
-					node.value = `Settings not parsed! Use JSON to pass settings!
-						\`\`\`jsx // { "static": false }
+					node.value = `Settings not parsed! Use single settings modifiers ${settingsModifiers.join(
+						','
+					)} or JSON to pass settings!
+						\`\`\`jsx // static noEditor
 							...
 						\`\`\`
 					`;

--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -25,9 +25,9 @@ module.exports = function chunkify(markdown) {
 			visit(ast, 'code', node => {
 				let lang = node.lang || '';
 				let settings = {};
-				const startSettingsString = lang.indexOf('//');
+				const startSettingsString = lang.indexOf(' ');
 				if (startSettingsString !== -1) {
-					const settingsString = lang.slice(startSettingsString + 2);
+					const settingsString = lang.slice(startSettingsString + 1);
 					try {
 						settings = JSON.parse(settingsString);
 					} catch (exception) {
@@ -38,11 +38,11 @@ module.exports = function chunkify(markdown) {
 							});
 						} else {
 							node.value = `Settings not parsed! Use single settings modifiers or JSON to pass settings!
-								\`\`\`jsx // static noEditor
+								\`\`\`jsx static noEditor
 									...
 								\`\`\`
 								or 
-								\`\`\`jsx // { "static": true }
+								\`\`\`jsx { "static": true }
 									...
 								\`\`\`
 							`;

--- a/src/rsg-components/Examples/Examples.js
+++ b/src/rsg-components/Examples/Examples.js
@@ -17,6 +17,7 @@ export default function Examples({ examples, name }, { codeRevision }) {
 								key={`${codeRevision}/${index}`}
 								name={name}
 								index={index}
+								settings={example.settings}
 							/>
 						);
 					case 'markdown':

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -20,12 +20,6 @@ export default class Playground extends Component {
 		isolatedExample: PropTypes.bool,
 	};
 
-	static childContextTypes = {
-		slots: PropTypes.object,
-		config: PropTypes.object.isRequired,
-		isolatedExample: PropTypes.bool,
-	};
-
 	constructor(props, context) {
 		super(props, context);
 		const { code } = props;
@@ -42,21 +36,6 @@ export default class Playground extends Component {
 			code,
 			activeTab: showCode ? EXAMPLE_TAB_CODE_EDITOR : undefined,
 		};
-	}
-
-	getChildContext() {
-		if (this.props.settings && this.props.settings.noEditor) {
-			const slots = this.context.slots || {};
-			return {
-				...this.context,
-				slots: {
-					...slots,
-					exampleTabButtons: (slots.exampleTabButtons || [])
-						.filter(slot => slot.id !== 'rsg-code-editor'),
-				},
-			};
-		}
-		return this.context;
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -91,6 +70,14 @@ export default class Playground extends Component {
 		const { code, activeTab } = this.state;
 		const { evalInContext, index, name } = this.props;
 		const { isolatedExample } = this.context;
+		if (this.props.settings && this.props.settings.noEditor) {
+			return (
+				<PlaygroundRenderer
+					name={name}
+					preview={<Preview code={code} evalInContext={evalInContext} />}
+				/>
+			);
+		}
 		return (
 			<PlaygroundRenderer
 				name={name}

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -12,8 +12,16 @@ export default class Playground extends Component {
 		evalInContext: PropTypes.func.isRequired,
 		index: PropTypes.number.isRequired,
 		name: PropTypes.string.isRequired,
+		settings: PropTypes.object,
 	};
+
 	static contextTypes = {
+		config: PropTypes.object.isRequired,
+		isolatedExample: PropTypes.bool,
+	};
+
+	static childContextTypes = {
+		slots: PropTypes.object,
 		config: PropTypes.object.isRequired,
 		isolatedExample: PropTypes.bool,
 	};
@@ -21,8 +29,11 @@ export default class Playground extends Component {
 	constructor(props, context) {
 		super(props, context);
 		const { code } = props;
-		const { previewDelay, showCode } = context.config;
-
+		const { previewDelay } = context.config;
+		let { showCode } = this.context;
+		if (props.settings && typeof props.settings.showCode === 'boolean') {
+			showCode = props.settings.showCode;
+		}
 		this.handleChange = this.handleChange.bind(this);
 		this.handleTabChange = this.handleTabChange.bind(this);
 		this.handleChange = debounce(this.handleChange, previewDelay);
@@ -31,6 +42,21 @@ export default class Playground extends Component {
 			code,
 			activeTab: showCode ? EXAMPLE_TAB_CODE_EDITOR : undefined,
 		};
+	}
+
+	getChildContext() {
+		if (this.props.settings && this.props.settings.noEditor) {
+			const slots = this.context.slots || {};
+			return {
+				...this.context,
+				slots: {
+					...slots,
+					exampleTabButtons: (slots.exampleTabButtons || [])
+						.filter(slot => slot.id !== 'rsg-code-editor'),
+				},
+			};
+		}
+		return this.context;
 	}
 
 	componentWillReceiveProps(nextProps) {

--- a/src/rsg-components/Playground/Playground.spec.js
+++ b/src/rsg-components/Playground/Playground.spec.js
@@ -79,6 +79,56 @@ it('should open a code editor', () => {
 	expect(actual.find('.ReactCodeMirror')).toHaveLength(1);
 });
 
+it('should not render a code editor if noEditor option passed in example settings', () => {
+	const actual = mount(
+		<Playground
+			code={code}
+			evalInContext={a => () => a}
+			name="name"
+			index={0}
+			settings={{ noEditor: true }}
+		/>,
+		options
+	);
+	expect(actual.find(`button[name="${EXAMPLE_TAB_CODE_EDITOR}"]`)).toHaveLength(0);
+});
+
+it('should render a code editor opened by default if showCode:true option passed in example settings', () => {
+	const actual = mount(
+		<Playground
+			code={code}
+			evalInContext={a => () => a}
+			name="name"
+			index={0}
+			settings={{ showCode: true }}
+		/>,
+		options
+	);
+	expect(actual.find('.ReactCodeMirror')).toHaveLength(1);
+});
+
+it('should render a code editor closed by default if showCode:false option passed in example settings', () => {
+	const actual = mount(
+		<Playground
+			code={code}
+			evalInContext={a => () => a}
+			name="name"
+			index={0}
+			settings={{ showCode: false }}
+		/>,
+		{
+			context: {
+				...options.context,
+				config: {
+					...options.context.config,
+					showCode: true,
+				},
+			},
+		}
+	);
+	expect(actual.find('.ReactCodeMirror')).toHaveLength(0);
+});
+
 it('renderer should render preview', () => {
 	const actual = shallow(
 		<PlaygroundRenderer

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -24,11 +24,13 @@ export function PlaygroundRenderer({ classes, name, preview, tabButtons, tabBody
 	return (
 		<div className={classes.root}>
 			<div className={classes.preview} data-preview={name}>{preview}</div>
-			<div className={classes.controls}>
-				<div className={classes.tabs}>{tabButtons}</div>
-				<div className={classes.toolbar}>{toolbar}</div>
-			</div>
-			<div className={classes.tab}>{tabBody}</div>
+			{tabButtons &&
+				toolbar &&
+				<div className={classes.controls}>
+					{tabButtons && <div className={classes.tabs}>{tabButtons}</div>}
+					{toolbar && <div className={classes.toolbar}>{toolbar}</div>}
+				</div>}
+			{tabBody && <div className={classes.tab}>{tabBody}</div>}
 		</div>
 	);
 }
@@ -37,9 +39,9 @@ PlaygroundRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
 	name: PropTypes.string.isRequired,
 	preview: PropTypes.node.isRequired,
-	tabButtons: PropTypes.node.isRequired,
-	tabBody: PropTypes.node.isRequired,
-	toolbar: PropTypes.node.isRequired,
+	tabButtons: PropTypes.node,
+	tabBody: PropTypes.node,
+	toolbar: PropTypes.node,
 };
 
 export default Styled(styles)(PlaygroundRenderer);


### PR DESCRIPTION
https://github.com/styleguidist/react-styleguidist/issues/257
1) render preview for jsx, js, javascript by default
2) allow to pass settings for code viewer
```
    ```jsx // { "static": true, "wrapInIframe": true }
    <span></span>
    ```
```