### PR TITLE
Feat: Allow devServer.watchConfig to be configured

### DIFF
--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -390,6 +390,20 @@ initialState = {
 </div>
 ```
 
+## How to use Vagrant with Styleguidist?
+
+First of all, make sure you read [this guide](https://webpack.js.org/guides/development-vagrant/) from the webpack documentation.
+
+Then enable polling in your webpack config:
+
+```js
+devServer: {
+  watchOptions: {
+    poll: true,
+  },
+},
+```
+
 ## Are there any other projects like this?
 
 * [Atellier](https://github.com/scup/atellier), a React components emulator.

--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -2,11 +2,12 @@
 
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
+const merge = require('webpack-merge');
 const makeWebpackConfig = require('./make-webpack-config');
 
 module.exports = function createServer(config, env) {
 	const webpackConfig = makeWebpackConfig(config, env);
-	const webpackDevServerConfig = Object.assign({}, webpackConfig.devServer, {
+	const webpackDevServerConfig = merge(webpackConfig.devServer, {
 		noInfo: true,
 		compress: true,
 		clientLogLevel: 'none',


### PR DESCRIPTION
## Why

Currently, Vagrant with the VirtualBox provider does not work with styleguidist, as there are issues with webpack's default behavior. The way around this is to make webpack use a polling scheme for checking for changed files. This is currently not configurable in styleguidist.

## How

This PR makes the `devServer.watchConfig` configurable so that it is possible to use styleguidist with Vagrant

Fixes #515 