### PR TITLE
Output correct protocol when starting RSG server

### DIFF
--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -106,7 +106,7 @@ function commandServer() {
 		if (err) {
 			console.error(err);
 		} else {
-			const isHttps = config.webpackConfig && config.webpackConfig.devServer && config.webpackConfig.devServer.https;
+			const isHttps = compiler.options.devServer && compiler.options.devServer.https;
 			logger.info(
 				'Style guide server started at:\n' + (isHttps ? 'https' : 'http') + '://' + config.serverHost + ':' + config.serverPort
 			);

--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -106,8 +106,9 @@ function commandServer() {
 		if (err) {
 			console.error(err);
 		} else {
+			const isHttps = config.webpackConfig && config.webpackConfig.devServer && config.webpackConfig.devServer.https;
 			logger.info(
-				'Style guide server started at:\nhttp://' + config.serverHost + ':' + config.serverPort
+				'Style guide server started at:\n' + (isHttps ? 'https' : 'http') + '://' + config.serverHost + ':' + config.serverPort
 			);
 		}
 	});


### PR DESCRIPTION
This PR changes "Style guide server started at:" notification to correctly state https protocol when starting RSG server with `{ devServer: { https: true } }`. 