### PR TITLE
Feat: Improve shape defaultProp rendering (#524)

### DIFF
--- a/examples/sections/styleguide.config.js
+++ b/examples/sections/styleguide.config.js
@@ -31,8 +31,8 @@ module.exports = {
 			env === 'development'
 				? false
 				: {
-						maxAssetSize: 670000, // bytes
-						maxEntrypointSize: 670000, // bytes
+						maxAssetSize: 680000, // bytes
+						maxEntrypointSize: 680000, // bytes
 						hints: 'error',
 					},
 	}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,9 +249,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
       "dev": true
     },
     "ansi-html": {
@@ -418,9 +418,9 @@
       "dev": true
     },
     "asap": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.3",
@@ -485,7 +485,7 @@
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000697",
+        "caniuse-db": "1.0.30000701",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.17",
@@ -1327,7 +1327,7 @@
           "integrity": "sha1-6IJVDfPRzW1IHBo+ADjyuvE6RxE=",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000697",
+            "caniuse-lite": "1.0.30000701",
             "electron-to-chromium": "1.3.15"
           }
         }
@@ -1695,10 +1695,15 @@
         "to-fast-properties": "1.0.3"
       }
     },
+    "babylon": {
+      "version": "7.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.8.tgz",
+      "integrity": "sha1-K9xa42YEFELCfgaMzm8NfAbqmUk="
+    },
     "bail": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.1.tgz",
-      "integrity": "sha1-kSV53os5Gq3zxf30zSoPwiXfO8I="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1836,7 +1841,7 @@
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.0",
         "inherits": "2.0.3"
@@ -1859,7 +1864,7 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "des.js": "1.0.0",
         "inherits": "2.0.3"
       }
@@ -1903,7 +1908,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "requires": {
-        "caniuse-db": "1.0.30000697",
+        "caniuse-db": "1.0.30000701",
         "electron-to-chromium": "1.3.15"
       }
     },
@@ -1960,9 +1965,9 @@
       "dev": true
     },
     "bytes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
-      "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
+      "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -1989,9 +1994,9 @@
       }
     },
     "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
       "dev": true
     },
     "camelcase-keys": {
@@ -2002,6 +2007,14 @@
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
       }
     },
     "caniuse-api": {
@@ -2010,20 +2023,20 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000697",
+        "caniuse-db": "1.0.30000701",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000697",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000697.tgz",
-      "integrity": "sha1-IM5qnO7vTvShXcjoDy6PuQSejXc="
+      "version": "1.0.30000701",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000701.tgz",
+      "integrity": "sha1-LjKwaZO/Pb2QtD2T8E4m0Rr93Lo="
     },
     "caniuse-lite": {
-      "version": "1.0.30000697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000697.tgz",
-      "integrity": "sha1-El+wBgS2P7sYjblqZnziki3NbN0=",
+      "version": "1.0.30000701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000701.tgz",
+      "integrity": "sha1-nWc89rdNyz1cIdITF2sBGsakW6o=",
       "dev": true
     },
     "caseless": {
@@ -2033,9 +2046,9 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.1.tgz",
-      "integrity": "sha1-ZlaHlFFowhjsd/9hpBVa4AInqWw="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
     },
     "center-align": {
       "version": "0.1.3",
@@ -2060,24 +2073,24 @@
       }
     },
     "character-entities": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.0.tgz",
-      "integrity": "sha1-poPiz3Xb6LFxljUxNk5Y4YobFV8="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
     },
     "character-entities-html4": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.0.tgz",
-      "integrity": "sha1-GrCFUdPOH6HfCNAPucod77FHoGw="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA="
     },
     "character-entities-legacy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.0.tgz",
-      "integrity": "sha1-sYqtmPa3vMZGweTIH58ZVjdqVho="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
     },
     "character-reference-invalid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.0.tgz",
-      "integrity": "sha1-3smtHfufjQa0/NqircPE/ZevHmg="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
     },
     "cheerio": {
       "version": "0.22.0",
@@ -2193,12 +2206,13 @@
       "dev": true
     },
     "cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
@@ -2221,9 +2235,9 @@
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
     },
     "clean-css": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.5.tgz",
-      "integrity": "sha1-0JqHoCpTdRF1iXlq52oGPKzbVBo=",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.7.tgz",
+      "integrity": "sha1-ua6k+FZ5iJzz6ui0A0nsTr390DI=",
       "requires": {
         "source-map": "0.5.6"
       }
@@ -2237,12 +2251,12 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -2273,22 +2287,14 @@
       "integrity": "sha1-9qPeZaiiUvqZP8sqTgz+OqS4dp4="
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -2303,9 +2309,9 @@
       "dev": true
     },
     "coa": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
-      "integrity": "sha1-G1Sl4dz3fJkEVdTe6pjFZEFtyJM=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
         "q": "1.5.0"
       }
@@ -2424,31 +2430,17 @@
       }
     },
     "compression": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
-      "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
+      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
       "requires": {
         "accepts": "1.3.3",
-        "bytes": "2.3.0",
+        "bytes": "2.5.0",
         "compressible": "2.0.10",
-        "debug": "2.2.0",
+        "debug": "2.6.8",
         "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
         "vary": "1.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-        }
       }
     },
     "concat-map": {
@@ -2632,40 +2624,36 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-webpack-plugin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
       "integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
       "requires": {
-        "bluebird": "2.11.0",
-        "fs-extra": "0.26.7",
-        "glob": "6.0.4",
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
         "is-glob": "3.1.0",
-        "loader-utils": "0.2.17",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "node-dir": "0.1.17"
       },
       "dependencies": {
         "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "fs-extra": {
-          "version": "0.26.7",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
+            "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
             "path-is-absolute": "1.0.1",
             "rimraf": "2.5.4"
           }
         },
         "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
             "inflight": "1.0.6",
@@ -2676,8 +2664,7 @@
           }
         },
         "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "requires": {
             "big.js": "3.1.3",
@@ -2730,7 +2717,7 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "sha.js": "2.4.8"
@@ -2742,7 +2729,7 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
@@ -2781,9 +2768,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
-      "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -2959,24 +2946,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
           "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
           "dev": true
-        },
-        "github": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
-          "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "0.0.7",
-            "https-proxy-agent": "1.0.0",
-            "mime": "1.3.4",
-            "netrc": "0.1.4"
-          }
-        },
-        "lodash.keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-          "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
-          "dev": true
         }
       }
     },
@@ -3123,7 +3092,7 @@
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "asap": "2.0.5",
+        "asap": "2.0.6",
         "wrappy": "1.0.2"
       }
     },
@@ -3230,7 +3199,7 @@
       "optional": true,
       "requires": {
         "fs-promise": "2.0.3",
-        "parsimmon": "1.6.1",
+        "parsimmon": "1.6.2",
         "strip-json-comments": "2.0.1",
         "tsutils": "1.9.1"
       }
@@ -3345,6 +3314,18 @@
         "iconv-lite": "0.4.18"
       }
     },
+    "enhanced-resolve": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+      "integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.6"
+      }
+    },
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
@@ -3357,7 +3338,7 @@
       "dev": true,
       "requires": {
         "cheerio": "0.22.0",
-        "function.prototype.name": "1.0.0",
+        "function.prototype.name": "1.0.1",
         "is-subset": "0.1.1",
         "lodash": "4.17.4",
         "object-is": "1.0.1",
@@ -3475,11 +3456,12 @@
       }
     },
     "eslint": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.1.1.tgz",
-      "integrity": "sha1-+svfz+Pg+s06i4DcmMTmwTrlgt8=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.2.0.tgz",
+      "integrity": "sha1-orMYQRGxmOAunH88ymJaXgHFaz0=",
       "dev": true,
       "requires": {
+        "ajv": "5.2.2",
         "babel-code-frame": "6.22.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
@@ -3495,10 +3477,9 @@
         "globals": "9.18.0",
         "ignore": "3.3.3",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.1.1",
-        "is-my-json-valid": "2.16.0",
+        "inquirer": "3.2.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
+        "js-yaml": "3.9.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -3515,31 +3496,22 @@
         "text-table": "0.2.0"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+        "ajv": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         },
         "estraverse": {
@@ -3548,138 +3520,14 @@
           "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
           "dev": true
         },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5"
-          }
-        },
-        "inquirer": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.1.1.tgz",
-          "integrity": "sha512-H50sHQwgvvaTBd3HpKMVtL/u6LoHDvYym51gd7bGQe/+9HkCE+J0/3N5FJLfd6O6oz44hHewC2Pc2LodzWVafQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "2.0.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.1.0",
-            "external-editor": "2.0.4",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.0",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "js-yaml": {
-          "version": "3.8.4",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-          "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+          "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
-            "esprima": "3.1.3"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "pluralize": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-          "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
-          "dev": true
-        },
-        "progress": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "dev": true,
-          "requires": {
-            "is-promise": "2.1.0"
-          }
-        },
-        "rx-lite": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "table": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-          "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.4",
-            "slice-ansi": "0.0.4",
-            "string-width": "2.1.0"
+            "esprima": "4.0.0"
           }
         }
       }
@@ -3728,7 +3576,7 @@
           "integrity": "sha1-zFJq9KExK30uBWU+VtDIq3DA4FM=",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000697",
+            "caniuse-lite": "1.0.30000701",
             "electron-to-chromium": "1.3.15"
           }
         },
@@ -3747,9 +3595,9 @@
       "dev": true
     },
     "eslint-plugin-import": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.6.1.tgz",
-      "integrity": "sha512-aAMb32eHCQaQmgdb1MOG1hfu/rPiNgGur2IF71VJeDfTXdLpPiKALKWlzxMdcxQOZZ2CmYVKabAxCvjACxH1uQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
@@ -3869,14 +3717,14 @@
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.0",
+        "acorn": "5.1.1",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.0.tgz",
-          "integrity": "sha512-WXZ0VTJT8EE25BmZjc+wr0qIwG7QaEna9csPKHS6WQp8gDo4V376wUWi222LXRiuAF6CAS4Ejv736DdRwuPK9g==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
           "dev": true
         }
       }
@@ -4113,6 +3961,12 @@
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true
     },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
     "fast-diff": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.1.tgz",
@@ -4161,13 +4015,12 @@
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -5444,9 +5297,9 @@
       "integrity": "sha1-00m7TiSjJPCBIEVe54oEFCsSV7s="
     },
     "function.prototype.name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz",
-      "integrity": "sha1-X1I8pk5JGl+Vq6gMweORCAoUSC4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.1.tgz",
+      "integrity": "sha512-yPTD33NazY14aRlTORxhFf8gTrNmnxmAGaw2Ge36m4ThRN7HauJU8hESMQQXixdJbnaO43c3MgMoZXP/QqGnTw==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -5575,9 +5428,9 @@
       }
     },
     "github": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
-      "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY=",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
+      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=",
       "dev": true,
       "requires": {
         "follow-redirects": "0.0.7",
@@ -5743,6 +5596,18 @@
           "dev": true,
           "optional": true
         },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
+        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -5772,6 +5637,20 @@
               "optional": true
             }
           }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
         },
         "yargs": {
           "version": "3.10.0",
@@ -5936,13 +5815,13 @@
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.5",
+        "clean-css": "4.1.7",
         "commander": "2.9.0",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.0.23"
+        "uglify-js": "3.0.24"
       },
       "dependencies": {
         "commander": {
@@ -6114,7 +5993,7 @@
           "requires": {
             "ansi-styles": "3.1.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "has-flag": {
@@ -6129,13 +6008,13 @@
           "requires": {
             "chalk": "2.0.1",
             "source-map": "0.5.6",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "supports-color": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
-          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -6164,9 +6043,9 @@
       "dev": true
     },
     "immutability-helper": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.2.3.tgz",
-      "integrity": "sha1-aBoOyboqJDuYmFZOOWI8g9nOGYU=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.3.0.tgz",
+      "integrity": "sha1-6Jd0HB2ilUGoYeoWvb+QkmXi61U=",
       "dev": true,
       "requires": {
         "invariant": "2.2.2"
@@ -6223,6 +6102,96 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
+    },
+    "inquirer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.0.tgz",
+      "integrity": "sha512-4CyUYMP7lOBkiUU1rR24WGrfRX6SucwbY2Mqb1PdApU24wnTIk4TsnkQwV72dDdIKZ2ycLP+fWCV+tA7wwgoew==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.0.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.1.0",
+        "external-editor": "2.0.4",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.0",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
+          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.1.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "interpret": {
       "version": "1.0.3",
@@ -6389,9 +6358,9 @@
       "integrity": "sha1-XEWXcdKvmi45Ungf1U/LG8/kETw="
     },
     "is-in-browser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.0.2.tgz",
-      "integrity": "sha1-9oi+qPHlqtwyROvIcNGIz7m2E88="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-my-json-valid": {
       "version": "2.16.0",
@@ -6685,6 +6654,11 @@
         "handlebars": "4.0.10"
       }
     },
+    "javascript-stringify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-1.6.0.tgz",
+      "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM="
+    },
     "jest": {
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
@@ -6694,6 +6668,12 @@
         "jest-cli": "20.0.4"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -7054,29 +7034,6 @@
         "yargs": "4.8.1"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-          "dev": true
-        },
         "yargs": {
           "version": "4.8.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
@@ -7120,6 +7077,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
@@ -7204,11 +7167,11 @@
       }
     },
     "jss": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-8.0.0.tgz",
-      "integrity": "sha512-LjwI11N7AgNNKBcAgrVeiG0rNx5gZmmx+N7uXGbgybumd4FiHHs8E0lvfAHq0JhVjcpdmNMeAHVNDdGOsXG8hg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-8.1.0.tgz",
+      "integrity": "sha512-NZ4CNAoPaPlM2rqHxPG5uGQbQEFZ9n1PITn0+wGIdAk2ZtA/F6el0SphLHf8So1Sx6N34hnVFFIuc32/hdsEzw==",
       "requires": {
-        "is-in-browser": "1.0.2",
+        "is-in-browser": "1.1.3",
         "warning": "3.0.0"
       }
     },
@@ -7269,8 +7232,7 @@
       }
     },
     "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
         "graceful-fs": "4.1.11"
@@ -7349,6 +7311,18 @@
         "rxjs": "5.4.2",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "listr-silent-renderer": {
@@ -7373,6 +7347,16 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
         "indent-string": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.1.0.tgz",
@@ -7391,6 +7375,43 @@
         "cli-cursor": "1.0.2",
         "date-fns": "1.28.5",
         "figures": "1.7.0"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -7558,6 +7579,19 @@
       "requires": {
         "lodash._basecopy": "3.0.1",
         "lodash.keys": "3.1.2"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        }
       }
     },
     "lodash._basecopy": {
@@ -7746,15 +7780,10 @@
       "dev": true
     },
     "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+      "dev": true
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -7864,6 +7893,39 @@
       "requires": {
         "ansi-escapes": "1.4.0",
         "cli-cursor": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
       }
     },
     "longest": {
@@ -7908,14 +7970,6 @@
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        }
       }
     },
     "macaddress": {
@@ -7953,9 +8007,9 @@
       "dev": true
     },
     "markdown-escapes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.0.tgz",
-      "integrity": "sha1-yMoZ8dlNaCRZ4Kk8htsnp+9xayM="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
+      "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
     },
     "markdown-table": {
       "version": "1.1.0",
@@ -8173,6 +8227,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "mz": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
@@ -8253,6 +8313,65 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node-libs-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
+          }
+        }
+      }
     },
     "node-notifier": {
       "version": "5.1.2",
@@ -8558,10 +8677,13 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "open": {
       "version": "0.0.5",
@@ -8621,6 +8743,33 @@
         "cli-cursor": "1.0.2",
         "cli-spinners": "0.1.2",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
       }
     },
     "original": {
@@ -8754,9 +8903,9 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
       "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
       "requires": {
-        "character-entities": "1.2.0",
-        "character-entities-legacy": "1.1.0",
-        "character-reference-invalid": "1.1.0",
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
         "is-alphanumerical": "1.0.0",
         "is-decimal": "1.0.0",
         "is-hexadecimal": "1.0.0"
@@ -8815,9 +8964,9 @@
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
     },
     "parsimmon": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.6.1.tgz",
-      "integrity": "sha512-kgpKs+wVqMVJSrvSbKqHW2hS9RCxiG3uo4Ntkl80fWUa2iQR6VnGHd9xbj14hbvCrtbjf+Yjkx9UAogW3+7uEA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.6.2.tgz",
+      "integrity": "sha512-bJNB0ZQhHyM5KqO2Z5ttQAVn/PZ2pccxaOnMcZ0Su7HA1Iv4GQTfUmzSZ6N3jcsCn9F68PZcypAvF3nDRRL+3g==",
       "dev": true,
       "optional": true
     },
@@ -8869,6 +9018,17 @@
             "lodash._baseassign": "3.2.0",
             "lodash._createassigner": "3.1.1",
             "lodash.keys": "3.1.2"
+          }
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
           }
         }
       }
@@ -8971,6 +9131,12 @@
           }
         }
       }
+    },
+    "pluralize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "dev": true
     },
     "pop-iterate": {
       "version": "1.0.1",
@@ -9286,7 +9452,7 @@
           "requires": {
             "ansi-styles": "3.1.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "has-flag": {
@@ -9301,13 +9467,13 @@
           "requires": {
             "chalk": "2.0.1",
             "source-map": "0.5.6",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "supports-color": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
-          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -9338,7 +9504,7 @@
           "requires": {
             "ansi-styles": "3.1.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "has-flag": {
@@ -9353,13 +9519,13 @@
           "requires": {
             "chalk": "2.0.1",
             "source-map": "0.5.6",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "supports-color": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
-          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -9390,7 +9556,7 @@
           "requires": {
             "ansi-styles": "3.1.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "has-flag": {
@@ -9405,13 +9571,13 @@
           "requires": {
             "chalk": "2.0.1",
             "source-map": "0.5.6",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "supports-color": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
-          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -9442,7 +9608,7 @@
           "requires": {
             "ansi-styles": "3.1.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "has-flag": {
@@ -9457,13 +9623,13 @@
           "requires": {
             "chalk": "2.0.1",
             "source-map": "0.5.6",
-            "supports-color": "4.1.0"
+            "supports-color": "4.2.0"
           }
         },
         "supports-color": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
-          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -9572,9 +9738,9 @@
       }
     },
     "preact": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.1.0.tgz",
-      "integrity": "sha1-8DW4CO67dORtViRrAsoPGQttZXQ=",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.1.tgz",
+      "integrity": "sha1-Z0JD3wyEeITQGYNARKovzTEecu0=",
       "dev": true
     },
     "preact-compat": {
@@ -9583,7 +9749,7 @@
       "integrity": "sha1-zyvBsvj8oUkA1oCU+eELizKcxB4=",
       "dev": true,
       "requires": {
-        "immutability-helper": "2.2.3",
+        "immutability-helper": "2.3.0",
         "preact-render-to-string": "3.6.3",
         "preact-transition-group": "1.1.1",
         "prop-types": "15.5.10",
@@ -9678,12 +9844,18 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.5"
+        "asap": "2.0.6"
       }
     },
     "prop-types": {
@@ -9890,11 +10062,6 @@
         "recast": "0.11.23"
       },
       "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.8",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.8.tgz",
-          "integrity": "sha1-K9xa42YEFELCfgaMzm8NfAbqmUk="
-        },
         "commander": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
@@ -10264,7 +10431,7 @@
         "is-decimal": "1.0.0",
         "is-whitespace-character": "1.0.0",
         "is-word-character": "1.0.0",
-        "markdown-escapes": "1.0.0",
+        "markdown-escapes": "1.0.1",
         "parse-entities": "1.1.1",
         "repeat-string": "1.6.1",
         "state-toggle": "1.0.0",
@@ -10281,12 +10448,12 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-3.0.1.tgz",
       "integrity": "sha1-eSQr6+CnUggbWAlRb6DAbt7Aac8=",
       "requires": {
-        "ccount": "1.0.1",
+        "ccount": "1.0.2",
         "is-alphanumeric": "1.0.0",
         "is-decimal": "1.0.0",
         "is-whitespace-character": "1.0.0",
         "longest-streak": "2.0.1",
-        "markdown-escapes": "1.0.0",
+        "markdown-escapes": "1.0.1",
         "markdown-table": "1.1.0",
         "mdast-util-compact": "1.0.1",
         "parse-entities": "1.1.1",
@@ -10465,13 +10632,13 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "retry": {
@@ -10513,6 +10680,15 @@
         "inherits": "2.0.3"
       }
     },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
     "run-auto": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/run-auto/-/run-auto-2.0.0.tgz",
@@ -10529,9 +10705,9 @@
       "dev": true
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
     "rx-lite-aggregates": {
@@ -10540,7 +10716,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "3.1.2"
+        "rx-lite": "4.0.8"
       }
     },
     "rxjs": {
@@ -10621,6 +10797,20 @@
         "run-auto": "2.0.0",
         "run-series": "1.1.4",
         "semver": "5.3.0"
+      },
+      "dependencies": {
+        "github": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
+          "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "0.0.7",
+            "https-proxy-agent": "1.0.0",
+            "mime": "1.3.4",
+            "netrc": "0.1.4"
+          }
+        }
       }
     },
     "semantic-release-tamia": {
@@ -11142,8 +11332,8 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
       "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
       "requires": {
-        "character-entities-html4": "1.1.0",
-        "character-entities-legacy": "1.1.0",
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
         "is-alphanumerical": "1.0.0",
         "is-hexadecimal": "1.0.0"
       }
@@ -11227,7 +11417,7 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
-        "coa": "1.0.3",
+        "coa": "1.0.4",
         "colors": "1.1.2",
         "csso": "2.3.2",
         "js-yaml": "3.7.0",
@@ -11263,12 +11453,65 @@
           "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
           "dev": true,
           "requires": {
-            "asap": "2.0.5",
+            "asap": "2.0.6",
             "pop-iterate": "1.0.1",
             "weak-map": "1.0.5"
           }
         }
       }
+    },
+    "table": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
+      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "tapable": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
+      "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0=",
+      "dev": true
     },
     "test-exclude": {
       "version": "4.1.1",
@@ -11361,6 +11604,15 @@
         }
       }
     },
+    "timers-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+      "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
+    },
     "tmp": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
@@ -11439,7 +11691,7 @@
         "github": "0.1.16",
         "lodash": "1.3.1",
         "request": "2.74.0",
-        "underscore.string": "2.2.1"
+        "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
       },
       "dependencies": {
         "caseless": {
@@ -11574,9 +11826,9 @@
       "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
     },
     "trough": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.0.tgz",
-      "integrity": "sha1-a97f5/KqSabzxDIldodVWVfzQv0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
+      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y="
     },
     "tryit": {
       "version": "1.0.3",
@@ -11647,9 +11899,9 @@
       "integrity": "sha1-zZ3S+GSTs/RNvu7zeA/adMXuFL4="
     },
     "uglify-js": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.23.tgz",
-      "integrity": "sha512-miLHbO2QcdQGxL/q1wLcUr6TGIRHhMnpKyywUbAdZRkJMqCeZCDmBsgYu1Wlj26xHBXN+sU5tHaWh38QsN208g==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.24.tgz",
+      "integrity": "sha512-IZ7l7MU2j7LIuz6IAFWBOk1dbuQ0QVQsKLffpNPKXuL8NYcFBBQ5QkvMAtfL1+oaBW16344DY4sA26GI9cXzlA==",
       "requires": {
         "commander": "2.9.0",
         "source-map": "0.5.6"
@@ -11679,8 +11931,7 @@
       "dev": true
     },
     "underscore.string": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
@@ -11698,10 +11949,10 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.5.tgz",
       "integrity": "sha1-cWk3hyYhpjE15iztLzrGoGPG+4c=",
       "requires": {
-        "bail": "1.0.1",
+        "bail": "1.0.2",
         "extend": "3.0.1",
         "is-plain-obj": "1.1.0",
-        "trough": "1.0.0",
+        "trough": "1.0.1",
         "vfile": "2.1.0",
         "x-is-function": "1.0.4",
         "x-is-string": "0.1.0"
@@ -11992,12 +12243,12 @@
       "dev": true
     },
     "webpack": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
-      "integrity": "sha1-LgRX8KuxrF3zqxBsacZy8jZ4Xwc=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+      "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.0",
+        "acorn": "5.1.1",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
@@ -12016,14 +12267,14 @@
         "tapable": "0.2.6",
         "uglify-js": "2.8.29",
         "watchpack": "1.3.1",
-        "webpack-sources": "0.2.3",
+        "webpack-sources": "1.0.1",
         "yargs": "6.6.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.0.tgz",
-          "integrity": "sha512-WXZ0VTJT8EE25BmZjc+wr0qIwG7QaEna9csPKHS6WQp8gDo4V376wUWi222LXRiuAF6CAS4Ejv736DdRwuPK9g==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
           "dev": true
         },
         "camelcase": {
@@ -12032,16 +12283,15 @@
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true
         },
-        "enhanced-resolve": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
-          "integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "memory-fs": "0.4.1",
-            "object-assign": "4.1.1",
-            "tapable": "0.2.6"
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
           }
         },
         "loader-utils": {
@@ -12056,63 +12306,6 @@
             "object-assign": "4.1.1"
           }
         },
-        "node-libs-browser": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-          "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
-          "dev": true,
-          "requires": {
-            "assert": "1.4.1",
-            "browserify-zlib": "0.1.4",
-            "buffer": "4.9.1",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.11.0",
-            "domain-browser": "1.1.7",
-            "events": "1.1.1",
-            "https-browserify": "0.0.1",
-            "os-browserify": "0.2.1",
-            "path-browserify": "0.0.0",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "readable-stream": "2.3.3",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.7.2",
-            "string_decoder": "0.10.31",
-            "timers-browserify": "2.0.2",
-            "tty-browserify": "0.0.0",
-            "url": "0.11.0",
-            "util": "0.10.3",
-            "vm-browserify": "0.0.4"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
-          "dependencies": {
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -12120,21 +12313,6 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
-          }
-        },
-        "tapable": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
-          "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0=",
-          "dev": true
-        },
-        "timers-browserify": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
-          "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
-          "dev": true,
-          "requires": {
-            "setimmediate": "1.0.5"
           }
         },
         "uglify-js": {
@@ -12161,6 +12339,18 @@
               }
             }
           }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
         },
         "yargs": {
           "version": "6.6.0",
@@ -12237,7 +12427,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
       "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
       "requires": {
-        "compression": "1.6.2",
+        "compression": "1.7.0",
         "connect-history-api-fallback": "1.3.0",
         "express": "4.15.3",
         "http-proxy-middleware": "0.17.4",
@@ -12292,19 +12482,19 @@
       }
     },
     "webpack-sources": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
-      "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "dev": true,
       "requires": {
-        "source-list-map": "1.1.2",
+        "source-list-map": "2.0.0",
         "source-map": "0.5.6"
       },
       "dependencies": {
         "source-list-map": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
-          "integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
           "dev": true
         }
       }
@@ -12397,9 +12587,9 @@
       }
     },
     "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
     "wordwrap": {
@@ -12473,6 +12663,12 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
     "yargs": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
@@ -12492,25 +12688,6 @@
         "which-module": "1.0.0",
         "y18n": "3.2.1",
         "yargs-parser": "5.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        }
       }
     },
     "yargs-parser": {
@@ -12520,14 +12697,6 @@
       "dev": true,
       "requires": {
         "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "highlight.js": "^9.11.0",
     "html-webpack-plugin": "^2.28.0",
     "is-directory": "^0.3.1",
+    "javascript-stringify": "^1.6.0",
     "json-loader": "^0.5.4",
     "jss": "^8.0.0",
     "jss-camel-case": "^5.0.0",

--- a/src/rsg-components/Props/Props.spec.js
+++ b/src/rsg-components/Props/Props.spec.js
@@ -98,6 +98,35 @@ describe('props columns', () => {
 		expect(actual).toMatchSnapshot();
 	});
 
+	it('should render PropTypes.shape with formatted defaultProps', () => {
+		const actual = render(
+			[
+				`
+				foo: PropTypes.shape({
+					bar: PropTypes.number.isRequired,
+					baz: PropTypes.any,
+				})
+			`,
+			],
+			[
+				`
+				foo: {
+					bar: 123, baz() {
+						return 'foo';
+					},
+					bing() {
+						return 'badaboom';
+					},
+					trotskij: () => 1935,
+					qwarc: { si: 'señor', },
+				}
+			`,
+			]
+		);
+
+		expect(actual).toMatchSnapshot();
+	});
+
 	it('should render PropTypes.shape with description', () => {
 		const actual = render([
 			`foo: PropTypes.shape({

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Group from 'react-group';
+import objectToString from 'javascript-stringify';
 import Arguments from 'rsg-components/Arguments';
 import Code from 'rsg-components/Code';
 import JsDoc from 'rsg-components/JsDoc';
@@ -85,12 +86,27 @@ function renderDefault(prop) {
 	if (prop.required) {
 		return <Text>Required</Text>;
 	} else if (prop.defaultValue) {
-		if (prop.type && prop.type.name === 'func') {
-			return (
-				<Text underlined title={showSpaces(unquote(prop.defaultValue.value))}>
-					Function
-				</Text>
-			);
+		if (prop.type) {
+			const propName = prop.type.name;
+
+			if (propName === 'func') {
+				return (
+					<Text underlined title={showSpaces(unquote(prop.defaultValue.value))}>
+						Function
+					</Text>
+				);
+			} else if (propName === 'shape' || propName === 'object') {
+				// We eval source code to be able to format the defaultProp here. This
+				// can be considered safe, as it is the source code that is evaled,
+				// which is from a known source and safe by default
+				// eslint-disable-next-line no-eval
+				const object = eval(`(${prop.defaultValue.value})`);
+				return (
+					<Text underlined title={objectToString(object, null, 2)}>
+						Shape
+					</Text>
+				);
+			}
 		}
 
 		return (

--- a/src/rsg-components/Props/__snapshots__/Props.spec.js.snap
+++ b/src/rsg-components/Props/__snapshots__/Props.spec.js.snap
@@ -402,6 +402,74 @@ exports[`props columns should render PropTypes.shape with description 1`] = `
 </ul>
 `;
 
+exports[`props columns should render PropTypes.shape with formatted defaultProps 1`] = `
+<ul>
+  <li>
+    <div>
+      <Styled(Name)
+        deprecated={false}
+      >
+        foo
+      </Styled(Name)>
+    </div>
+    <div>
+      <Styled(Type)>
+        shape
+      </Styled(Type)>
+    </div>
+    <div>
+      <Styled(Text)
+        title="{
+        bar: 123,
+        baz: baz() {
+                return 'foo';
+            },
+        bing: bing() {
+                return 'badaboom';
+            },
+        trotskij: () => 1935,
+        qwarc: {
+          si: 'señor'
+        }
+      }"
+        underlined={true}
+      >
+        Shape
+      </Styled(Text)>
+    </div>
+    <div>
+      <div>
+        <Styled(Para)>
+          <div>
+            <Styled(Name)>
+              bar
+            </Styled(Name)>
+            : 
+            <Styled(Type)>
+              number
+            </Styled(Type)>
+             — 
+            <Styled(Text)>
+              Required
+            </Styled(Text)>
+          </div>
+          <div>
+            <Styled(Name)>
+              baz
+            </Styled(Name)>
+            : 
+            <Styled(Type)>
+              any
+            </Styled(Type)>
+          </div>
+        </Styled(Para)>
+        <JsDoc />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
 exports[`props columns should render PropTypes.string 1`] = `
 <ul>
   <li>


### PR DESCRIPTION
# What

This PR improves the printing of objects in `defaultProps`, which had some issues in the existing version. See #524 for further details.

# How

This PR removes the fallback of printing objects as strings. Instead, objects will be parsed, beautified, then finally displayed in a title. This mirrors the existing method used by `function` props.

![The improved preview](https://user-images.githubusercontent.com/5845924/27973860-d4aeec24-635b-11e7-81f0-53208d501dcf.png)

Parsing is done with the [safe-eval](https://github.com/hacksparrow/safe-eval) library. Not sure if we actually need this library, though, as we are not in a node.js context here. Wanted to get some feedback first. We could use `eval` directly, or just render the unprettified source code representation in the title. Thoughts?

Fixes #524 