### PR TITLE
Create a jss instance for react-styleguidist

### DIFF
--- a/src/styles/createStyleSheet.js
+++ b/src/styles/createStyleSheet.js
@@ -1,6 +1,6 @@
-import jss from 'jss';
 import merge from 'lodash/merge';
 import memoize from 'lodash/memoize';
+import jss from './setupjss';
 import * as theme from './theme';
 
 export default memoize((styles, config, componentName) => {

--- a/src/styles/setupjss.js
+++ b/src/styles/setupjss.js
@@ -1,4 +1,4 @@
-import jss from 'jss';
+import { create } from 'jss';
 import global from 'jss-global';
 import isolate from 'jss-isolate';
 import nested from 'jss-nested';
@@ -7,7 +7,7 @@ import defaultUnit from 'jss-default-unit';
 import compose from 'jss-compose';
 import nonInheritedProps from './nonInheritedProps';
 
-jss.setup({
+export default create({
 	plugins: [
 		global(),
 		isolate({

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1,4 +1,4 @@
-import jss from 'jss';
+import jss from './setupjss';
 
 const styles = {
 	// Global styles


### PR DESCRIPTION
This helps to ensure that config/class names don't collide if components being presented by react-styleguidist also use jss.