### PR TITLE
Fix: Preview should unmount the Wrapper component when it unmounts

### DIFF
--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -62,6 +62,13 @@ export default class Preview extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		if (!this.mountNode) {
+			return;
+		}
+		ReactDOM.unmountComponentAtNode(this.mountNode);
+	}
+
 	executeCode() {
 		this.setState({
 			error: null,

--- a/src/rsg-components/Preview/Preview.spec.js
+++ b/src/rsg-components/Preview/Preview.spec.js
@@ -11,6 +11,17 @@ const options = {
 	},
 };
 
+it('should unmount Wrapper when Preview unmounts', () => {
+	const actual = mount(<Preview code={code} evalInContext={() => noop} />, options);
+	const ReactDOM = require('react-dom');
+	const unmountComponentAtNodeMock = jest.fn();
+	ReactDOM.unmountComponentAtNode = unmountComponentAtNodeMock;
+
+	actual.unmount();
+
+	expect(unmountComponentAtNodeMock).toBeCalled();
+});
+
 it('should render component renderer', () => {
 	const actual = shallow(<Preview code={code} evalInContext={noop} />, options);
 

--- a/src/rsg-components/Preview/Preview.spec.js
+++ b/src/rsg-components/Preview/Preview.spec.js
@@ -11,8 +11,9 @@ const options = {
 	},
 };
 
-it('should unmount Wrapper when Preview unmounts', () => {
+it('should unmount Wrapper when Preview unmounts and mountNodeMock is not null', () => {
 	const actual = mount(<Preview code={code} evalInContext={() => noop} />, options);
+	actual.instance().mountNode = { hi: 1 };
 	const ReactDOM = require('react-dom');
 	const unmountComponentAtNodeMock = jest.fn();
 	ReactDOM.unmountComponentAtNode = unmountComponentAtNodeMock;
@@ -20,6 +21,18 @@ it('should unmount Wrapper when Preview unmounts', () => {
 	actual.unmount();
 
 	expect(unmountComponentAtNodeMock).toBeCalled();
+});
+
+it('should not unmount Wrapper when Preview unmounts and mountNodeMock is null', () => {
+	const actual = mount(<Preview code={code} evalInContext={() => noop} />, options);
+	actual.instance().mountNode = null;
+	const ReactDOM = require('react-dom');
+	const unmountComponentAtNodeMock = jest.fn();
+	ReactDOM.unmountComponentAtNode = unmountComponentAtNodeMock;
+
+	actual.unmount();
+
+	expect(unmountComponentAtNodeMock).not.toBeCalled();
 });
 
 it('should render component renderer', () => {


### PR DESCRIPTION
`Preview` doesn't unmount `Wrapper` it mounts when `Preview` is unmounted. As a result, clicking `IsolateButton`, all `Wrapper`s remain on the DOM including those irrelevant.

In this PR `Preview` is changed to clean up after itself.