### PR TITLE
Fix duplicating of keys for 'arrayOf' prop type in the unions rendering

### DIFF
--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -156,8 +156,8 @@ function renderUnion(prop) {
 		);
 	}
 
-	const values = getType(prop).value.map(value =>
-		<Type key={value.name}>
+	const values = getType(prop).value.map((value, index) =>
+		<Type key={`${value.name}-${index}`}>
 			{renderType(value)}
 		</Type>
 	);


### PR DESCRIPTION
We get an error if we have in the component propTypes something like this: 
```
items: PropTypes.oneOfType([
  PropTypes.arrayOf(PropTypes.object),
  PropTypes.arrayOf(PropTypes.array),
]).isRequired,
```
 ![image](https://user-images.githubusercontent.com/614697/28111960-f3b408f0-66ff-11e7-9446-bbba8a0514ed.png)
It happens because at the moment styleguidist use just type of prop (`arrayOf`), and when we have two or more same types in the `oneOfType`- type can't be used as key.
So this PR just adds an index as a suffix to key.