### PR TITLE
Clear console on hot reload

### DIFF
--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -49,6 +49,7 @@ export default class Preview extends Component {
 	};
 
 	componentDidMount() {
+		console.clear(); // eslint-disable-line no-console
 		this.executeCode();
 	}
 

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -49,7 +49,9 @@ export default class Preview extends Component {
 	};
 
 	componentDidMount() {
-		console.clear(); // eslint-disable-line no-console
+		if (console) {
+			console.clear(); // eslint-disable-line no-console
+		}
 		this.executeCode();
 	}
 

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -49,7 +49,7 @@ export default class Preview extends Component {
 	};
 
 	componentDidMount() {
-		if (console) {
+		if (console.clear) { // eslint-disable-line no-console
 			console.clear(); // eslint-disable-line no-console
 		}
 		this.executeCode();


### PR DESCRIPTION
Adds #519

Clearing console in `ComponentDidMount` of Preview makes a lot more sense than Playground -- now understand how the two are related :)

Didn't think a doc update was necessary here.