### PR TITLE
Render null and undefined defaultValues as code

### DIFF
--- a/src/rsg-components/Props/Props.spec.js
+++ b/src/rsg-components/Props/Props.spec.js
@@ -191,6 +191,18 @@ describe('props columns', () => {
 		expect(actual).toMatchSnapshot();
 	});
 
+	it('should render function defaultValue as code when undefined', () => {
+		const actual = render(['fn: PropTypes.func'], ['fn: undefined']);
+
+		expect(actual).toMatchSnapshot();
+	});
+
+	it('should render function defaultValue as code when null', () => {
+		const actual = render(['fn: PropTypes.func'], ['fn: null']);
+
+		expect(actual).toMatchSnapshot();
+	});
+
 	it('should render arguments from JsDoc tags', () => {
 		const props = {
 			size: {

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -82,6 +82,8 @@ function renderShape(props) {
 	return rows;
 }
 
+const defaultValueBlacklist = ['null', 'undefined'];
+
 function renderDefault(prop) {
 	if (prop.required) {
 		return <Text>Required</Text>;
@@ -89,7 +91,13 @@ function renderDefault(prop) {
 		if (prop.type) {
 			const propName = prop.type.name;
 
-			if (propName === 'func') {
+			if (defaultValueBlacklist.indexOf(prop.defaultValue.value) > -1) {
+				return (
+					<Code>
+						{showSpaces(unquote(prop.defaultValue.value))}
+					</Code>
+				);
+			} else if (propName === 'func') {
 				return (
 					<Text underlined title={showSpaces(unquote(prop.defaultValue.value))}>
 						Function

--- a/src/rsg-components/Props/__snapshots__/Props.spec.js.snap
+++ b/src/rsg-components/Props/__snapshots__/Props.spec.js.snap
@@ -677,6 +677,64 @@ exports[`props columns should render function body in tooltip 1`] = `
 </ul>
 `;
 
+exports[`props columns should render function defaultValue as code when null 1`] = `
+<ul>
+  <li>
+    <div>
+      <Styled(Name)
+        deprecated={false}
+      >
+        fn
+      </Styled(Name)>
+    </div>
+    <div>
+      <Styled(Type)>
+        func
+      </Styled(Type)>
+    </div>
+    <div>
+      <Styled(Code)>
+        null
+      </Styled(Code)>
+    </div>
+    <div>
+      <div>
+        <JsDoc />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`props columns should render function defaultValue as code when undefined 1`] = `
+<ul>
+  <li>
+    <div>
+      <Styled(Name)
+        deprecated={false}
+      >
+        fn
+      </Styled(Name)>
+    </div>
+    <div>
+      <Styled(Type)>
+        func
+      </Styled(Type)>
+    </div>
+    <div>
+      <Styled(Code)>
+        undefined
+      </Styled(Code)>
+    </div>
+    <div>
+      <div>
+        <JsDoc />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
 exports[`props columns should render name as deprecated when tag deprecated is present 1`] = `
 <ul>
   <li>


### PR DESCRIPTION
Hi,

I found another thing I found to be lacking with `defaultProps`. In the case where you specify a default value that is `null` or `undefined`, I would expect it to show that value. Instead, what you get is a title with that value, see below.

![2017-07-31-192516_swaygrab](https://user-images.githubusercontent.com/5845924/28789539-54156c56-7615-11e7-9def-a4a412ee9b2b.png)

Here's a PR that makes an exception  for `null` and `undefined` values, and renders them as code instead.