### PR TITLE
Added support to enable HMR for component dependencies

### DIFF
--- a/loaders/__tests__/props-loader.spec.js
+++ b/loaders/__tests__/props-loader.spec.js
@@ -110,3 +110,24 @@ it('should warn if a file cannot be parsed', () => {
 	expect(() => new vm.Script(result)).not.toThrow();
 	expect(warn).toBeCalledWith(expect.stringMatching('Cannot parse'));
 });
+
+it('should add context dependencies to webpack from contextDependencies config option', () => {
+	const contextDependencies = ['foo', 'bar'];
+	const addContextDependency = jest.fn();
+	const file = './test/components/Button/Button.js';
+	const result = propsLoader.call(
+		{
+			request: file,
+			_styleguidist: Object.assign(_styleguidist, {
+				contextDependencies,
+			}),
+			addContextDependency,
+		},
+		readFileSync(file, 'utf8')
+	);
+
+	expect(() => new vm.Script(result)).not.toThrow();
+	expect(addContextDependency).toHaveBeenCalledTimes(2);
+	expect(addContextDependency).toBeCalledWith(contextDependencies[0]);
+	expect(addContextDependency).toBeCalledWith(contextDependencies[1]);
+});

--- a/loaders/props-loader.js
+++ b/loaders/props-loader.js
@@ -14,6 +14,11 @@ module.exports = function(source) {
 	const file = this.request.split('!').pop();
 	const config = this._styleguidist;
 
+	// Setup Webpack context dependencies to enable hot reload when adding new files or updating any of component dependencies
+	if (config.contextDependencies) {
+		config.contextDependencies.forEach(dir => this.addContextDependency(dir));
+	}
+
 	const defaultParser = (filePath, source, resolver, handlers) =>
 		reactDocs.parse(source, resolver, handlers);
 	const propsParser = config.propsParser || defaultParser;


### PR DESCRIPTION
Added support to re-compile component (invoking props-loader) when any of its dependencies gets changed. This will enable only when [`contextDependencies`](https://react-styleguidist.js.org/docs/configuration#contextdependencies) is configured.

Issued in favor of this [discussion](https://github.com/styleguidist/react-styleguidist/issues/551) 