### PR TITLE
Hide empty path line

### DIFF
--- a/src/rsg-components/ReactComponent/ReactComponent.spec.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.spec.js
@@ -173,6 +173,12 @@ describe('ReactComponentRenderer', () => {
 		expect(actual).toMatchSnapshot();
 	});
 
+	test('should render component without a pathline', () => {
+		const actual = shallow(<ReactComponentRenderer {...props} pathLine='' />);
+
+		expect(actual).toMatchSnapshot();
+	});
+
 	test('should render usage section', () => {
 		const actual = shallow(
 			<ReactComponentRenderer

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -37,9 +37,10 @@ export function ReactComponentRenderer({
 		<div className={classes.root} id={name + '-container'}>
 			<header className={classes.header}>
 				{heading}
-				<Pathline>
-					{pathLine}
-				</Pathline>
+				{(pathLine || null) &&
+					<Pathline>
+						{pathLine}
+					</Pathline>}
 			</header>
 			{(description || docs) &&
 				<div className={classes.docs}>

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -63,7 +63,7 @@ ReactComponentRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
 	name: PropTypes.string.isRequired,
 	heading: PropTypes.node.isRequired,
-	pathLine: PropTypes.string.isRequired,
+	pathLine: PropTypes.string,
 	tabButtons: PropTypes.node,
 	tabBody: PropTypes.node,
 	description: PropTypes.node,

--- a/src/rsg-components/ReactComponent/ReactComponentRenderer.js
+++ b/src/rsg-components/ReactComponent/ReactComponentRenderer.js
@@ -37,7 +37,7 @@ export function ReactComponentRenderer({
 		<div className={classes.root} id={name + '-container'}>
 			<header className={classes.header}>
 				{heading}
-				{(pathLine || null) &&
+				{pathLine &&
 					<Pathline>
 						{pathLine}
 					</Pathline>}

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -198,6 +198,18 @@ exports[`ReactComponentRenderer should render component 1`] = `
 </div>
 `;
 
+exports[`ReactComponentRenderer should render component without a pathline component 1`] = `
+<div
+  id="Test-container"
+>
+  <header>
+    <div>
+      heading
+    </div>
+  </header>
+</div>
+`;
+
 exports[`ReactComponentRenderer should render description 1`] = `
 <div
   id="Test-container"

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -198,7 +198,7 @@ exports[`ReactComponentRenderer should render component 1`] = `
 </div>
 `;
 
-exports[`ReactComponentRenderer should render component without a pathline component 1`] = `
+exports[`ReactComponentRenderer should render component without a pathline 1`] = `
 <div
   id="Test-container"
 >


### PR DESCRIPTION
This is an implementation of one of the features from #195.

The Pathline component will not render if the path line is empty. I'm not sure if this requires an update to the docs.

Please let me know if anything needs changing.