### PR TITLE
Change require to show absolute path

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -239,7 +239,7 @@ Modules that are required for your style guide. Useful for third-party styles or
 module.exports = {
   require: [
     'babel-polyfill',
-    '/absolute/path/to/styles.css',
+    path.join(__dirname, 'styleguide/styles.css'),
   ]
 };
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -239,7 +239,7 @@ Modules that are required for your style guide. Useful for third-party styles or
 module.exports = {
   require: [
     'babel-polyfill',
-    'path/to/styles.css',
+    '/absolute/path/to/styles.css',
   ]
 };
 ```


### PR DESCRIPTION
As a best practice one should use absolute paths for Webpack stuff