### PR TITLE
Fix: CSS EM unit is not isolate (#584)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "react-styleguidist",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@semantic-release/commit-analyzer": {
       "version": "2.0.0",

--- a/src/styles/setupjss.js
+++ b/src/styles/setupjss.js
@@ -21,6 +21,7 @@ jss.setup({
 				// Allow inheritance because it may be set on body and should be available for user components
 				fontFamily: 'inherit',
 				lineHeight: 'inherit',
+				fontSize: 'inherit',
 			},
 		}),
 		nested(),


### PR DESCRIPTION
I added font-size to jss configuration, I couldn't find any tests for jss conf.

I test the Fix with my react components library and it works fine.