### PR TITLE
Omit component if propsParser returns an empty array

### DIFF
--- a/loaders/props-loader.js
+++ b/loaders/props-loader.js
@@ -10,6 +10,8 @@ const getExamples = require('./utils/getExamples');
 const getProps = require('./utils/getProps');
 const consts = require('../scripts/consts');
 
+const ERROR_MISSING_DEFINITION = 'No suitable component definition found.';
+
 module.exports = function(source) {
 	const file = this.request.split('!').pop();
 	const config = this._styleguidist;
@@ -26,11 +28,19 @@ module.exports = function(source) {
 	let props = {};
 	try {
 		props = propsParser(file, source, config.resolver, config.handlers(file));
+
+		// Support only one component
+		if (isArray(props)) {
+			if (props.length === 0) {
+				throw new Error(ERROR_MISSING_DEFINITION);
+			}
+			props = props[0];
+		}
 	} catch (err) {
 		const errorMessage = err.toString();
 		const componentPath = path.relative(process.cwd(), file);
 		const message =
-			errorMessage === 'Error: No suitable component definition found.'
+			errorMessage === `Error: ${ERROR_MISSING_DEFINITION}`
 				? `${componentPath} matches a pattern defined in “components” or “sections” options in your ` +
 					'style guide config but doesn’t export a component.\n\n' +
 					'It usually happens when using third-party libraries, see possible solutions here:\n' +
@@ -39,11 +49,6 @@ module.exports = function(source) {
 					'It usually means that react-docgen don’t understand your source code, try to file an issue here:\n' +
 					'https://github.com/reactjs/react-docgen/issues';
 		logger.warn(message);
-	}
-
-	// Support only one component
-	if (isArray(props) && props.length > 0) {
-		props = props[0];
 	}
 
 	props = getProps(props, file);

--- a/loaders/props-loader.js
+++ b/loaders/props-loader.js
@@ -42,7 +42,7 @@ module.exports = function(source) {
 	}
 
 	// Support only one component
-	if (isArray(props)) {
+	if (isArray(props) && props.length > 0) {
 		props = props[0];
 	}
 


### PR DESCRIPTION
First of all, thanks for great project!

I started using `react-styleguidist` with Typescript and `react-typescript-docgen` and have found one really annoying bug. 

If there is no exported component in `.ts` file, `parse` from `react-typescript-docgen` return an empty array.

```ts
import * as React from 'react';

export interface MyComponentProps {
	foo: string;
	className?: string;
}

const MyComponent: React.SFC<MyComponentProps> = () => (...);

export default MyComponent;
```

It has to be ```export const MyComponent```, but during development you can forgot about this.

`props-loader.js` reaches line 45 and assumes that array is not empty. Then props[0], which is `undefined`, is passed to `getProps` function and `react-styleguidist` stops working. So, you have to add export to the component and start it again.

