### PR TITLE
Fix: Add depth to sections so heading levels are correct (#600)

### DIFF
--- a/examples/sections/styleguide.config.js
+++ b/examples/sections/styleguide.config.js
@@ -4,19 +4,39 @@ module.exports = {
 	title: 'React Style Guide Example',
 	sections: [
 		{
-			name: 'Components',
-			components: './src/components/**/[A-Z]*.js',
-		},
-		{
 			name: 'Documentation',
 			sections: [
 				{
-					name: 'First File',
-					content: 'docs/One.md',
+					name: 'Files',
+					sections: [
+						{
+							name: 'First File',
+							content: 'docs/One.md',
+						},
+						{
+							name: 'Second File',
+							content: 'docs/Two.md',
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'Components',
+			sections: [
+				{
+					name: 'Buttons',
+					components: () => [
+						'./src/components/Button/Button.js',
+						'./src/components/RandomButton/RandomButton.js',
+					],
 				},
 				{
-					name: 'Second File',
-					content: 'docs/Two.md',
+					name: 'Fields',
+					components: () => [
+						'./src/components/Label/Label.js',
+						'./src/components/Placeholder/Placeholder.js',
+					],
 				},
 			],
 		},

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import ReactComponent from 'rsg-components/ReactComponent';
 import ComponentsRenderer from 'rsg-components/Components/ComponentsRenderer';
 
-export default function Components({ components }) {
+export default function Components({ components, depth }) {
 	return (
 		<ComponentsRenderer>
 			{components.map(component => (
-				<ReactComponent key={component.filepath} component={component} />
+				<ReactComponent key={component.filepath} component={component} depth={depth} />
 			))}
 		</ComponentsRenderer>
 	);
@@ -15,4 +15,5 @@ export default function Components({ components }) {
 
 Components.propTypes = {
 	components: PropTypes.array.isRequired,
+	depth: PropTypes.number.isRequired,
 };

--- a/src/rsg-components/Components/Components.spec.js
+++ b/src/rsg-components/Components/Components.spec.js
@@ -23,7 +23,7 @@ const components = [
 ];
 
 it('should render components list', () => {
-	const actual = shallow(<Components components={components} />);
+	const actual = shallow(<Components components={components} depth={3} />);
 
 	expect(actual).toMatchSnapshot();
 });
@@ -31,8 +31,8 @@ it('should render components list', () => {
 it('renderer should render components list layout', () => {
 	const actual = shallow(
 		<ComponentsRenderer>
-			<ReactComponent key={0} component={components[0]} />
-			<ReactComponent key={1} component={components[1]} />
+			<ReactComponent key={0} component={components[0]} depth={3} />
+			<ReactComponent key={1} component={components[1]} depth={3} />
 		</ComponentsRenderer>
 	);
 

--- a/src/rsg-components/Components/__snapshots__/Components.spec.js.snap
+++ b/src/rsg-components/Components/__snapshots__/Components.spec.js.snap
@@ -13,6 +13,7 @@ exports[`renderer should render components list layout 1`] = `
         },
       }
     }
+    depth={3}
   />
   <ReactComponent
     component={
@@ -25,6 +26,7 @@ exports[`renderer should render components list layout 1`] = `
         },
       }
     }
+    depth={3}
   />
 </div>
 `;
@@ -42,6 +44,7 @@ exports[`should render components list 1`] = `
         },
       }
     }
+    depth={3}
   />
   <ReactComponent
     component={
@@ -54,6 +57,7 @@ exports[`should render components list 1`] = `
         },
       }
     }
+    depth={3}
   />
 </ComponentsRenderer>
 `;

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -16,6 +16,7 @@ const ExamplePlaceholder =
 export default class ReactComponent extends Component {
 	static propTypes = {
 		component: PropTypes.object.isRequired,
+		depth: PropTypes.number.isRequired,
 	};
 	static contextTypes = {
 		config: PropTypes.object.isRequired,
@@ -42,7 +43,7 @@ export default class ReactComponent extends Component {
 	render() {
 		const { activeTab } = this.state;
 		const { isolatedComponent } = this.context;
-		const { component } = this.props;
+		const { component, depth } = this.props;
 		const { name, slug, pathLine } = component;
 		const { description, examples = [], tags = {} } = component.props;
 		if (!name) {
@@ -65,6 +66,7 @@ export default class ReactComponent extends Component {
 							...component,
 							isolated: isolatedComponent,
 						}}
+						depth={depth}
 					>
 						{name}
 					</SectionHeading>

--- a/src/rsg-components/ReactComponent/ReactComponent.spec.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.spec.js
@@ -63,7 +63,7 @@ const componentWithEverything = {
 
 describe('ReactComponent', () => {
 	it('should render an example placeholder', () => {
-		const actual = shallow(<ReactComponent component={component} />, options);
+		const actual = shallow(<ReactComponent component={component} depth={3} />, options);
 
 		const props = actual.prop('examples').props;
 		expect(props.name).toBeTruthy();
@@ -71,7 +71,10 @@ describe('ReactComponent', () => {
 	});
 
 	it('should render examples', () => {
-		const actual = shallow(<ReactComponent component={componentWithEverything} />, options);
+		const actual = shallow(
+			<ReactComponent component={componentWithEverything} depth={3} />,
+			options
+		);
 
 		const props = actual.prop('examples').props;
 		expect(props.name).toBeTruthy();
@@ -79,20 +82,26 @@ describe('ReactComponent', () => {
 	});
 
 	it('should pass rendered description, usage, examples, etc. to the renderer', () => {
-		const actual = shallow(<ReactComponent component={componentWithEverything} />, options);
+		const actual = shallow(
+			<ReactComponent component={componentWithEverything} depth={3} />,
+			options
+		);
 
 		expect(actual).toMatchSnapshot();
 	});
 
 	it('should render usage closed by default when showUsage config options is false', () => {
-		const actual = shallow(<ReactComponent component={componentWithEverything} />, options);
+		const actual = shallow(
+			<ReactComponent component={componentWithEverything} depth={3} />,
+			options
+		);
 
 		expect(actual.prop('tabButtons').props.active).toBeFalsy();
 		expect(actual.prop('tabBody').props.active).toBeFalsy();
 	});
 
 	it('should render usage opened by default when showUsage config options is true', () => {
-		const actual = shallow(<ReactComponent component={componentWithEverything} />, {
+		const actual = shallow(<ReactComponent component={componentWithEverything} depth={3} />, {
 			...options,
 			context: {
 				config: {
@@ -106,19 +115,22 @@ describe('ReactComponent', () => {
 	});
 
 	it('should return null when component has no name', () => {
-		const actual = shallow(<ReactComponent component={{ slug: 'foo', props: {} }} />, options);
+		const actual = shallow(
+			<ReactComponent component={{ slug: 'foo', props: {} }} depth={3} />,
+			options
+		);
 
 		expect(actual.node).toBe(null);
 	});
 
 	test('should not render component in isolation mode by default', () => {
-		const actual = shallow(<ReactComponent component={component} />, options);
+		const actual = shallow(<ReactComponent component={component} depth={3} />, options);
 
 		expect(actual.prop('heading').props.slotProps.isolated).toBeFalsy();
 	});
 
 	test('should render component in isolation mode', () => {
-		const actual = shallow(<ReactComponent component={component} />, {
+		const actual = shallow(<ReactComponent component={component} depth={3} />, {
 			context: {
 				...options.context,
 				isolatedComponent: true,
@@ -128,8 +140,14 @@ describe('ReactComponent', () => {
 		expect(actual.prop('heading').props.slotProps.isolated).toBeTruthy();
 	});
 
+	it('should pass depth to heading', () => {
+		const actual = shallow(<ReactComponent component={component} depth={3} />, options);
+
+		expect(actual.prop('heading').props.depth).toBe(3);
+	});
+
 	it('should not render heading as deprecated by default', () => {
-		const actual = shallow(<ReactComponent component={component} />, options);
+		const actual = shallow(<ReactComponent component={component} depth={3} />, options);
 
 		expect(actual.prop('heading').props.deprecated).toBeFalsy();
 	});
@@ -150,6 +168,7 @@ describe('ReactComponent', () => {
 						},
 					},
 				}}
+				depth={3}
 			/>,
 			options
 		);

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -29,6 +29,7 @@ exports[`ReactComponent should pass rendered description, usage, examples, etc. 
   heading={
     <SectionHeading
       deprecated={false}
+      depth={3}
       id="foo"
       slotName="componentToolbar"
       slotProps={

--- a/src/rsg-components/Section/Section.js
+++ b/src/rsg-components/Section/Section.js
@@ -5,12 +5,12 @@ import Components from 'rsg-components/Components';
 import Sections from 'rsg-components/Sections';
 import SectionRenderer from 'rsg-components/Section/SectionRenderer';
 
-export default function Section({ section, primary }, { isolatedSection = false }) {
+export default function Section({ section, primary, depth }, { isolatedSection = false }) {
 	const { name, slug, content, components, sections } = section;
 
 	const contentJsx = content && <Examples examples={content} name={name} />;
-	const componentsJsx = components && <Components components={components} />;
-	const sectionsJsx = sections && <Sections sections={sections} />;
+	const componentsJsx = components && <Components components={components} depth={depth + 1} />;
+	const sectionsJsx = sections && <Sections sections={sections} depth={depth + 1} />;
 
 	return (
 		<SectionRenderer
@@ -21,6 +21,7 @@ export default function Section({ section, primary }, { isolatedSection = false 
 			sections={sectionsJsx}
 			isolated={isolatedSection}
 			primary={primary}
+			depth={depth}
 		/>
 	);
 }
@@ -28,6 +29,7 @@ export default function Section({ section, primary }, { isolatedSection = false 
 Section.propTypes = {
 	section: PropTypes.object.isRequired,
 	primary: PropTypes.bool,
+	depth: PropTypes.number.isRequired,
 };
 
 Section.contextTypes = {

--- a/src/rsg-components/Section/Section.js
+++ b/src/rsg-components/Section/Section.js
@@ -5,7 +5,7 @@ import Components from 'rsg-components/Components';
 import Sections from 'rsg-components/Sections';
 import SectionRenderer from 'rsg-components/Section/SectionRenderer';
 
-export default function Section({ section, primary, depth }, { isolatedSection = false }) {
+export default function Section({ section, depth }, { isolatedSection = false }) {
 	const { name, slug, content, components, sections } = section;
 
 	const contentJsx = content && <Examples examples={content} name={name} />;
@@ -20,7 +20,6 @@ export default function Section({ section, primary, depth }, { isolatedSection =
 			components={componentsJsx}
 			sections={sectionsJsx}
 			isolated={isolatedSection}
-			primary={primary}
 			depth={depth}
 		/>
 	);
@@ -28,7 +27,6 @@ export default function Section({ section, primary, depth }, { isolatedSection =
 
 Section.propTypes = {
 	section: PropTypes.object.isRequired,
-	primary: PropTypes.bool,
 	depth: PropTypes.number.isRequired,
 };
 

--- a/src/rsg-components/Section/Section.spec.js
+++ b/src/rsg-components/Section/Section.spec.js
@@ -25,13 +25,7 @@ const section = {
 };
 
 it('should render component renderer', () => {
-	const actual = shallow(<Section section={section} />);
-
-	expect(actual).toMatchSnapshot();
-});
-
-it('should render component renderer with primary title', () => {
-	const actual = shallow(<Section section={section} primary />);
+	const actual = shallow(<Section section={section} depth={3} />);
 
 	expect(actual).toMatchSnapshot();
 });
@@ -44,6 +38,7 @@ it('should render components list', () => {
 				slug: 'components',
 				components: [],
 			}}
+			depth={3}
 		/>
 	);
 
@@ -57,6 +52,7 @@ it('should not render components list if not defined', () => {
 				name: 'No components',
 				slug: 'no-components',
 			}}
+			depth={3}
 		/>
 	);
 
@@ -71,6 +67,7 @@ it('should render sections if defined', () => {
 				slug: 'nested-sections',
 				sections: [],
 			}}
+			depth={3}
 		/>
 	);
 
@@ -84,6 +81,7 @@ it('should not render sections if not defined', () => {
 				name: 'No sections',
 				slug: 'no-sections',
 			}}
+			depth={3}
 		/>
 	);
 
@@ -97,8 +95,9 @@ it('render should render component', () => {
 			name={section.name}
 			slug={section.slug}
 			content={<Examples name={section.name} examples={section.content} />}
-			components={<Components components={[]} />}
-			sections={<Sections sections={[]} />}
+			components={<Components components={[]} depth={3} />}
+			sections={<Sections sections={[]} depth={3} />}
+			depth={3}
 		/>
 	);
 
@@ -106,19 +105,13 @@ it('render should render component', () => {
 });
 
 it('render should not render title if name is not set', () => {
-	const actual = shallow(<SectionRenderer classes={{}} />);
+	const actual = shallow(<SectionRenderer classes={{}} depth={3} />);
 
 	expect(actual).toMatchSnapshot();
 });
 
 it('render should render title if name is set', () => {
-	const actual = shallow(<SectionRenderer classes={{}} name="test" slug="test" />);
-
-	expect(actual).toMatchSnapshot();
-});
-
-it('render should render primary title if primary is set', () => {
-	const actual = shallow(<SectionRenderer classes={{}} name="test" slug="test" primary />);
+	const actual = shallow(<SectionRenderer classes={{}} name="test" slug="test" depth={3} />);
 
 	expect(actual).toMatchSnapshot();
 });

--- a/src/rsg-components/Section/SectionRenderer.js
+++ b/src/rsg-components/Section/SectionRenderer.js
@@ -10,11 +10,17 @@ const styles = ({ space }) => ({
 });
 
 export function SectionRenderer(allProps) {
-	const { classes, name, slug, content, components, sections, primary } = allProps;
+	const { classes, name, slug, content, components, sections, primary, depth } = allProps;
 	return (
 		<section className={classes.root}>
 			{name && (
-				<SectionHeading primary={primary} id={slug} slotName="sectionToolbar" slotProps={allProps}>
+				<SectionHeading
+					primary={primary}
+					depth={depth}
+					id={slug}
+					slotName="sectionToolbar"
+					slotProps={allProps}
+				>
 					{name}
 				</SectionHeading>
 			)}
@@ -33,6 +39,7 @@ SectionRenderer.propTypes = {
 	components: PropTypes.node,
 	sections: PropTypes.node,
 	isolated: PropTypes.bool,
+	depth: PropTypes.number.isRequired,
 };
 
 export default Styled(styles)(SectionRenderer);

--- a/src/rsg-components/Section/SectionRenderer.js
+++ b/src/rsg-components/Section/SectionRenderer.js
@@ -10,17 +10,11 @@ const styles = ({ space }) => ({
 });
 
 export function SectionRenderer(allProps) {
-	const { classes, name, slug, content, components, sections, primary, depth } = allProps;
+	const { classes, name, slug, content, components, sections, depth } = allProps;
 	return (
 		<section className={classes.root}>
 			{name && (
-				<SectionHeading
-					primary={primary}
-					depth={depth}
-					id={slug}
-					slotName="sectionToolbar"
-					slotProps={allProps}
-				>
+				<SectionHeading depth={depth} id={slug} slotName="sectionToolbar" slotProps={allProps}>
 					{name}
 				</SectionHeading>
 			)}

--- a/src/rsg-components/Section/__snapshots__/Section.spec.js.snap
+++ b/src/rsg-components/Section/__snapshots__/Section.spec.js.snap
@@ -5,6 +5,7 @@ exports[`render should not render title if name is not set 1`] = `<section />`;
 exports[`render should render component 1`] = `
 <section>
   <SectionHeading
+    depth={3}
     id="foo"
     slotName="sectionToolbar"
     slotProps={
@@ -12,6 +13,7 @@ exports[`render should render component 1`] = `
         "classes": Object {},
         "components": <Components
           components={Array []}
+          depth={3}
       />,
         "content": <Examples
           examples={
@@ -29,8 +31,10 @@ exports[`render should render component 1`] = `
           }
           name="Foo"
       />,
+        "depth": 3,
         "name": "Foo",
         "sections": <Sections
+          depth={3}
           sections={Array []}
       />,
         "slug": "foo",
@@ -57,41 +61,25 @@ exports[`render should render component 1`] = `
   />
   <Components
     components={Array []}
+    depth={3}
   />
   <Sections
+    depth={3}
     sections={Array []}
   />
-</section>
-`;
-
-exports[`render should render primary title if primary is set 1`] = `
-<section>
-  <SectionHeading
-    id="test"
-    primary={true}
-    slotName="sectionToolbar"
-    slotProps={
-      Object {
-        "classes": Object {},
-        "name": "test",
-        "primary": true,
-        "slug": "test",
-      }
-    }
-  >
-    test
-  </SectionHeading>
 </section>
 `;
 
 exports[`render should render title if name is set 1`] = `
 <section>
   <SectionHeading
+    depth={3}
     id="test"
     slotName="sectionToolbar"
     slotProps={
       Object {
         "classes": Object {},
+        "depth": 3,
         "name": "test",
         "slug": "test",
       }
@@ -104,6 +92,7 @@ exports[`render should render title if name is set 1`] = `
 
 exports[`should not render components list if not defined 1`] = `
 <Styled(Section)
+  depth={3}
   isolated={false}
   name="No components"
   slug="no-components"
@@ -112,6 +101,7 @@ exports[`should not render components list if not defined 1`] = `
 
 exports[`should not render sections if not defined 1`] = `
 <Styled(Section)
+  depth={3}
   isolated={false}
   name="No sections"
   slug="no-sections"
@@ -123,6 +113,7 @@ exports[`should render component renderer 1`] = `
   components={
     <Components
       components={Array []}
+      depth={4}
     />
   }
   content={
@@ -143,47 +134,12 @@ exports[`should render component renderer 1`] = `
       name="Foo"
     />
   }
+  depth={3}
   isolated={false}
   name="Foo"
   sections={
     <Sections
-      sections={Array []}
-    />
-  }
-  slug="foo"
-/>
-`;
-
-exports[`should render component renderer with primary title 1`] = `
-<Styled(Section)
-  components={
-    <Components
-      components={Array []}
-    />
-  }
-  content={
-    <Examples
-      examples={
-        Array [
-          Object {
-            "content": "<button>OK</button>",
-            "evalInContext": [Function],
-            "type": "code",
-          },
-          Object {
-            "content": "Hello *world*!",
-            "type": "markdown",
-          },
-        ]
-      }
-      name="Foo"
-    />
-  }
-  isolated={false}
-  name="Foo"
-  primary={true}
-  sections={
-    <Sections
+      depth={4}
       sections={Array []}
     />
   }
@@ -196,8 +152,10 @@ exports[`should render components list 1`] = `
   components={
     <Components
       components={Array []}
+      depth={4}
     />
   }
+  depth={3}
   isolated={false}
   name="Components"
   slug="components"
@@ -206,10 +164,12 @@ exports[`should render components list 1`] = `
 
 exports[`should render sections if defined 1`] = `
 <Styled(Section)
+  depth={3}
   isolated={false}
   name="Nested sections"
   sections={
     <Sections
+      depth={4}
       sections={Array []}
     />
   }

--- a/src/rsg-components/SectionHeading/SectionHeading.js
+++ b/src/rsg-components/SectionHeading/SectionHeading.js
@@ -23,7 +23,6 @@ SectionHeading.propTypes = {
 	id: PropTypes.string.isRequired,
 	slotName: PropTypes.string.isRequired,
 	slotProps: PropTypes.object.isRequired,
-	primary: PropTypes.bool,
 	depth: PropTypes.number.isRequired,
 	deprecated: PropTypes.bool,
 };

--- a/src/rsg-components/SectionHeading/SectionHeading.js
+++ b/src/rsg-components/SectionHeading/SectionHeading.js
@@ -24,5 +24,6 @@ SectionHeading.propTypes = {
 	slotName: PropTypes.string.isRequired,
 	slotProps: PropTypes.object.isRequired,
 	primary: PropTypes.bool,
+	depth: PropTypes.number.isRequired,
 	deprecated: PropTypes.bool,
 };

--- a/src/rsg-components/SectionHeading/SectionHeading.spec.js
+++ b/src/rsg-components/SectionHeading/SectionHeading.spec.js
@@ -30,9 +30,29 @@ it('renderer should render H4 tag for depth of 3', () => {
 	expect(actual).toMatchSnapshot();
 });
 
+it('renderer should render H1 tag if depth of 0', () => {
+	const actual = shallow(
+		<SectionHeadingRenderer {...props} depth={0}>
+			Heading
+		</SectionHeadingRenderer>
+	);
+
+	expect(actual).toMatchSnapshot();
+});
+
 it('renderer should render H6 tag if depth is over 5', () => {
 	const actual = shallow(
 		<SectionHeadingRenderer {...props} depth={7}>
+			Heading
+		</SectionHeadingRenderer>
+	);
+
+	expect(actual).toMatchSnapshot();
+});
+
+it('renderer should add isPrimary styles if is primary', () => {
+	const actual = shallow(
+		<SectionHeadingRenderer {...props} primary depth={0}>
 			Heading
 		</SectionHeadingRenderer>
 	);

--- a/src/rsg-components/SectionHeading/SectionHeading.spec.js
+++ b/src/rsg-components/SectionHeading/SectionHeading.spec.js
@@ -5,11 +5,18 @@ const props = {
 	classes: classes(styles),
 	id: 'heading',
 	href: '/heading',
+	depth: 3,
 };
 
 it('should pass props to slots', () => {
 	const actual = shallow(
-		<SectionHeading id="heading" href="/heading" slotName="slot" slotProps={{ foo: 1, bar: 'baz' }}>
+		<SectionHeading
+			id="heading"
+			depth={1}
+			href="/heading"
+			slotName="slot"
+			slotProps={{ foo: 1, bar: 'baz' }}
+		>
 			Heading
 		</SectionHeading>
 	);
@@ -17,18 +24,8 @@ it('should pass props to slots', () => {
 	expect(actual).toMatchSnapshot();
 });
 
-it('renderer should render H2 tag', () => {
+it('renderer should render H4 tag', () => {
 	const actual = shallow(<SectionHeadingRenderer {...props}>Heading</SectionHeadingRenderer>);
-
-	expect(actual).toMatchSnapshot();
-});
-
-it('renderer should render H1 tag', () => {
-	const actual = shallow(
-		<SectionHeadingRenderer {...props} primary>
-			Heading
-		</SectionHeadingRenderer>
-	);
 
 	expect(actual).toMatchSnapshot();
 });

--- a/src/rsg-components/SectionHeading/SectionHeading.spec.js
+++ b/src/rsg-components/SectionHeading/SectionHeading.spec.js
@@ -24,8 +24,18 @@ it('should pass props to slots', () => {
 	expect(actual).toMatchSnapshot();
 });
 
-it('renderer should render H4 tag', () => {
+it('renderer should render H4 tag for depth of 3', () => {
 	const actual = shallow(<SectionHeadingRenderer {...props}>Heading</SectionHeadingRenderer>);
+
+	expect(actual).toMatchSnapshot();
+});
+
+it('renderer should render H6 tag if depth is over 5', () => {
+	const actual = shallow(
+		<SectionHeadingRenderer {...props} depth={7}>
+			Heading
+		</SectionHeadingRenderer>
+	);
 
 	expect(actual).toMatchSnapshot();
 });

--- a/src/rsg-components/SectionHeading/SectionHeading.spec.js
+++ b/src/rsg-components/SectionHeading/SectionHeading.spec.js
@@ -24,15 +24,15 @@ it('should pass props to slots', () => {
 	expect(actual).toMatchSnapshot();
 });
 
-it('renderer should render H4 tag for depth of 3', () => {
+it('renderer should render H3 tag for depth of 3', () => {
 	const actual = shallow(<SectionHeadingRenderer {...props}>Heading</SectionHeadingRenderer>);
 
 	expect(actual).toMatchSnapshot();
 });
 
-it('renderer should render H1 tag if depth of 0', () => {
+it('renderer should render H1 tag if depth of 1', () => {
 	const actual = shallow(
-		<SectionHeadingRenderer {...props} depth={0}>
+		<SectionHeadingRenderer {...props} depth={1}>
 			Heading
 		</SectionHeadingRenderer>
 	);
@@ -40,19 +40,9 @@ it('renderer should render H1 tag if depth of 0', () => {
 	expect(actual).toMatchSnapshot();
 });
 
-it('renderer should render H6 tag if depth is over 5', () => {
+it('renderer should render H6 tag if depth is over 6', () => {
 	const actual = shallow(
 		<SectionHeadingRenderer {...props} depth={7}>
-			Heading
-		</SectionHeadingRenderer>
-	);
-
-	expect(actual).toMatchSnapshot();
-});
-
-it('renderer should add isPrimary styles if is primary', () => {
-	const actual = shallow(
-		<SectionHeadingRenderer {...props} primary depth={0}>
 			Heading
 		</SectionHeadingRenderer>
 	);

--- a/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
+++ b/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
@@ -16,6 +16,7 @@ export function SectionHeadingRenderer({
 	const headingLevel = primary ? 1 : Math.min(6, depth + 1);
 	const Tag = `h${headingLevel}`;
 	const headingClasses = cx(classes.heading, classes[`heading${headingLevel}`], {
+		[classes.isPrimary]: primary,
 		[classes.isDeprecated]: deprecated,
 	});
 	return (
@@ -42,6 +43,9 @@ export const styles = ({ color, space, fontSize, fontFamily }) => ({
 			isolate: false,
 			textDecoration: 'underline',
 		},
+	},
+	isPrimary: {
+		fontSize: fontSize.h1,
 	},
 	heading1: {
 		fontSize: fontSize.h1,

--- a/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
+++ b/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
@@ -9,14 +9,12 @@ export function SectionHeadingRenderer({
 	toolbar,
 	id,
 	href,
-	primary,
 	depth,
 	deprecated,
 }) {
-	const headingLevel = primary ? 1 : Math.min(6, depth + 1);
+	const headingLevel = Math.min(6, depth);
 	const Tag = `h${headingLevel}`;
 	const headingClasses = cx(classes.heading, classes[`heading${headingLevel}`], {
-		[classes.isPrimary]: primary,
 		[classes.isDeprecated]: deprecated,
 	});
 	return (
@@ -43,9 +41,6 @@ export const styles = ({ color, space, fontSize, fontFamily }) => ({
 			isolate: false,
 			textDecoration: 'underline',
 		},
-	},
-	isPrimary: {
-		fontSize: fontSize.h1,
 	},
 	heading1: {
 		fontSize: fontSize.h1,
@@ -80,7 +75,6 @@ SectionHeadingRenderer.propTypes = {
 	toolbar: PropTypes.node,
 	id: PropTypes.string.isRequired,
 	href: PropTypes.string.isRequired,
-	primary: PropTypes.bool,
 	depth: PropTypes.number.isRequired,
 	deprecated: PropTypes.bool,
 };

--- a/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
+++ b/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
@@ -10,11 +10,12 @@ export function SectionHeadingRenderer({
 	id,
 	href,
 	primary,
+	depth,
 	deprecated,
 }) {
-	const Tag = primary ? 'h1' : 'h2';
-	const headingClasses = cx(classes.heading, {
-		[classes.isPrimary]: primary,
+	const headingLevel = primary ? 1 : Math.min(6, depth + 1);
+	const Tag = `h${headingLevel}`;
+	const headingClasses = cx(classes.heading, classes[`heading${headingLevel}`], {
 		[classes.isDeprecated]: deprecated,
 	});
 	return (
@@ -35,7 +36,6 @@ export const styles = ({ color, space, fontSize, fontFamily }) => ({
 	},
 	heading: {
 		color: color.base,
-		fontSize: fontSize.h2,
 		fontFamily: fontFamily.base,
 		fontWeight: 'normal',
 		'&:hover, &:active': {
@@ -43,8 +43,23 @@ export const styles = ({ color, space, fontSize, fontFamily }) => ({
 			textDecoration: 'underline',
 		},
 	},
-	isPrimary: {
+	heading1: {
 		fontSize: fontSize.h1,
+	},
+	heading2: {
+		fontSize: fontSize.h2,
+	},
+	heading3: {
+		fontSize: fontSize.h3,
+	},
+	heading4: {
+		fontSize: fontSize.h4,
+	},
+	heading5: {
+		fontSize: fontSize.h5,
+	},
+	heading6: {
+		fontSize: fontSize.h6,
 	},
 	isDeprecated: {
 		textDecoration: 'line-through',
@@ -62,6 +77,7 @@ SectionHeadingRenderer.propTypes = {
 	id: PropTypes.string.isRequired,
 	href: PropTypes.string.isRequired,
 	primary: PropTypes.bool,
+	depth: PropTypes.number.isRequired,
 	deprecated: PropTypes.bool,
 };
 

--- a/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
+++ b/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderer should render H1 tag 1`] = `
-<h1
+exports[`renderer should render H4 tag 1`] = `
+<h4
   className="root"
   id="heading"
 >
   <a
-    className="heading isPrimary"
+    className="heading heading4"
     href="/heading"
   >
     Heading
@@ -14,33 +14,16 @@ exports[`renderer should render H1 tag 1`] = `
   <div
     className="toolbar"
   />
-</h1>
-`;
-
-exports[`renderer should render H2 tag 1`] = `
-<h2
-  className="root"
-  id="heading"
->
-  <a
-    className="heading"
-    href="/heading"
-  >
-    Heading
-  </a>
-  <div
-    className="toolbar"
-  />
-</h2>
+</h4>
 `;
 
 exports[`renderer should render heading with deprecated styles 1`] = `
-<h2
+<h4
   className="root"
   id="heading"
 >
   <a
-    className="heading isDeprecated"
+    className="heading heading4 isDeprecated"
     href="/heading"
   >
     Heading
@@ -48,7 +31,7 @@ exports[`renderer should render heading with deprecated styles 1`] = `
   <div
     className="toolbar"
   />
-</h2>
+</h4>
 `;
 
 exports[`should pass props to slots 1`] = `
@@ -57,12 +40,18 @@ exports[`should pass props to slots 1`] = `
     Object {
       ".rsg--heading-1:hover, .rsg--heading-1:active": "rsg--heading-1:hover, .rsg--heading-1:active",
       "heading": "rsg--heading-1",
-      "isDeprecated": "rsg--isDeprecated-3",
-      "isPrimary": "rsg--isPrimary-2",
+      "heading1": "rsg--heading1-2",
+      "heading2": "rsg--heading2-3",
+      "heading3": "rsg--heading3-4",
+      "heading4": "rsg--heading4-5",
+      "heading5": "rsg--heading5-6",
+      "heading6": "rsg--heading6-7",
+      "isDeprecated": "rsg--isDeprecated-8",
       "root": "rsg--root-0",
-      "toolbar": "rsg--toolbar-4",
+      "toolbar": "rsg--toolbar-9",
     }
   }
+  depth={1}
   href="/heading"
   id="heading"
   slotName="slot"

--- a/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
+++ b/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
@@ -17,6 +17,23 @@ exports[`renderer should render H4 tag 1`] = `
 </h4>
 `;
 
+exports[`renderer should render H6 tag if depth is over 5 1`] = `
+<h6
+  className="root"
+  id="heading"
+>
+  <a
+    className="heading heading6"
+    href="/heading"
+  >
+    Heading
+  </a>
+  <div
+    className="toolbar"
+  />
+</h6>
+`;
+
 exports[`renderer should render heading with deprecated styles 1`] = `
 <h4
   className="root"

--- a/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
+++ b/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
@@ -1,6 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderer should render H4 tag 1`] = `
+exports[`renderer should add isPrimary styles if is primary 1`] = `
+<h1
+  className="root"
+  id="heading"
+>
+  <a
+    className="heading heading1 isPrimary"
+    href="/heading"
+  >
+    Heading
+  </a>
+  <div
+    className="toolbar"
+  />
+</h1>
+`;
+
+exports[`renderer should render H1 tag if depth of 0 1`] = `
+<h1
+  className="root"
+  id="heading"
+>
+  <a
+    className="heading heading1"
+    href="/heading"
+  >
+    Heading
+  </a>
+  <div
+    className="toolbar"
+  />
+</h1>
+`;
+
+exports[`renderer should render H4 tag for depth of 3 1`] = `
 <h4
   className="root"
   id="heading"
@@ -57,15 +91,16 @@ exports[`should pass props to slots 1`] = `
     Object {
       ".rsg--heading-1:hover, .rsg--heading-1:active": "rsg--heading-1:hover, .rsg--heading-1:active",
       "heading": "rsg--heading-1",
-      "heading1": "rsg--heading1-2",
-      "heading2": "rsg--heading2-3",
-      "heading3": "rsg--heading3-4",
-      "heading4": "rsg--heading4-5",
-      "heading5": "rsg--heading5-6",
-      "heading6": "rsg--heading6-7",
-      "isDeprecated": "rsg--isDeprecated-8",
+      "heading1": "rsg--heading1-3",
+      "heading2": "rsg--heading2-4",
+      "heading3": "rsg--heading3-5",
+      "heading4": "rsg--heading4-6",
+      "heading5": "rsg--heading5-7",
+      "heading6": "rsg--heading6-8",
+      "isDeprecated": "rsg--isDeprecated-9",
+      "isPrimary": "rsg--isPrimary-2",
       "root": "rsg--root-0",
-      "toolbar": "rsg--toolbar-9",
+      "toolbar": "rsg--toolbar-10",
     }
   }
   depth={1}

--- a/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
+++ b/src/rsg-components/SectionHeading/__snapshots__/SectionHeading.spec.js.snap
@@ -1,23 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderer should add isPrimary styles if is primary 1`] = `
-<h1
-  className="root"
-  id="heading"
->
-  <a
-    className="heading heading1 isPrimary"
-    href="/heading"
-  >
-    Heading
-  </a>
-  <div
-    className="toolbar"
-  />
-</h1>
-`;
-
-exports[`renderer should render H1 tag if depth of 0 1`] = `
+exports[`renderer should render H1 tag if depth of 1 1`] = `
 <h1
   className="root"
   id="heading"
@@ -34,13 +17,13 @@ exports[`renderer should render H1 tag if depth of 0 1`] = `
 </h1>
 `;
 
-exports[`renderer should render H4 tag for depth of 3 1`] = `
-<h4
+exports[`renderer should render H3 tag for depth of 3 1`] = `
+<h3
   className="root"
   id="heading"
 >
   <a
-    className="heading heading4"
+    className="heading heading3"
     href="/heading"
   >
     Heading
@@ -48,10 +31,10 @@ exports[`renderer should render H4 tag for depth of 3 1`] = `
   <div
     className="toolbar"
   />
-</h4>
+</h3>
 `;
 
-exports[`renderer should render H6 tag if depth is over 5 1`] = `
+exports[`renderer should render H6 tag if depth is over 6 1`] = `
 <h6
   className="root"
   id="heading"
@@ -69,12 +52,12 @@ exports[`renderer should render H6 tag if depth is over 5 1`] = `
 `;
 
 exports[`renderer should render heading with deprecated styles 1`] = `
-<h4
+<h3
   className="root"
   id="heading"
 >
   <a
-    className="heading heading4 isDeprecated"
+    className="heading heading3 isDeprecated"
     href="/heading"
   >
     Heading
@@ -82,7 +65,7 @@ exports[`renderer should render heading with deprecated styles 1`] = `
   <div
     className="toolbar"
   />
-</h4>
+</h3>
 `;
 
 exports[`should pass props to slots 1`] = `
@@ -91,16 +74,15 @@ exports[`should pass props to slots 1`] = `
     Object {
       ".rsg--heading-1:hover, .rsg--heading-1:active": "rsg--heading-1:hover, .rsg--heading-1:active",
       "heading": "rsg--heading-1",
-      "heading1": "rsg--heading1-3",
-      "heading2": "rsg--heading2-4",
-      "heading3": "rsg--heading3-5",
-      "heading4": "rsg--heading4-6",
-      "heading5": "rsg--heading5-7",
-      "heading6": "rsg--heading6-8",
-      "isDeprecated": "rsg--isDeprecated-9",
-      "isPrimary": "rsg--isPrimary-2",
+      "heading1": "rsg--heading1-2",
+      "heading2": "rsg--heading2-3",
+      "heading3": "rsg--heading3-4",
+      "heading4": "rsg--heading4-5",
+      "heading5": "rsg--heading5-6",
+      "heading6": "rsg--heading6-7",
+      "isDeprecated": "rsg--isDeprecated-8",
       "root": "rsg--root-0",
-      "toolbar": "rsg--toolbar-10",
+      "toolbar": "rsg--toolbar-9",
     }
   }
   depth={1}

--- a/src/rsg-components/Sections/Sections.js
+++ b/src/rsg-components/Sections/Sections.js
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import Section from 'rsg-components/Section';
 import SectionsRenderer from 'rsg-components/Sections/SectionsRenderer';
 
-export default function Sections({ sections, root }) {
+export default function Sections({ sections, root, depth }) {
 	return (
 		<SectionsRenderer>
-			{sections.map((section, idx) => <Section key={idx} section={section} primary={root} />)}
+			{sections.map((section, idx) => (
+				<Section key={idx} section={section} primary={root || depth === 0} depth={depth} />
+			))}
 		</SectionsRenderer>
 	);
 }
@@ -14,4 +16,5 @@ export default function Sections({ sections, root }) {
 Sections.propTypes = {
 	sections: PropTypes.array.isRequired,
 	root: PropTypes.bool,
+	depth: PropTypes.number.isRequired,
 };

--- a/src/rsg-components/Sections/Sections.js
+++ b/src/rsg-components/Sections/Sections.js
@@ -3,12 +3,10 @@ import PropTypes from 'prop-types';
 import Section from 'rsg-components/Section';
 import SectionsRenderer from 'rsg-components/Sections/SectionsRenderer';
 
-export default function Sections({ sections, root, depth }) {
+export default function Sections({ sections, depth }) {
 	return (
 		<SectionsRenderer>
-			{sections.map((section, idx) => (
-				<Section key={idx} section={section} primary={root || depth === 0} depth={depth} />
-			))}
+			{sections.map((section, idx) => <Section key={idx} section={section} depth={depth} />)}
 		</SectionsRenderer>
 	);
 }

--- a/src/rsg-components/Sections/Sections.spec.js
+++ b/src/rsg-components/Sections/Sections.spec.js
@@ -41,13 +41,13 @@ const sections = [
 ];
 
 it('should render component renderer', () => {
-	const actual = shallow(<Sections sections={sections} />);
+	const actual = shallow(<Sections sections={sections} depth={3} />);
 
 	expect(actual).toMatchSnapshot();
 });
 
-it('should render component renderer with primary sections if root is true', () => {
-	const actual = shallow(<Sections sections={sections} root />);
+it('should render component renderer with primary sections if depth is 0', () => {
+	const actual = shallow(<Sections sections={sections} depth={0} />);
 
 	expect(actual).toMatchSnapshot();
 });
@@ -55,9 +55,9 @@ it('should render component renderer with primary sections if root is true', () 
 it('render should render styled component', () => {
 	const actual = shallow(
 		<StyledSectionsRenderer classes={{}}>
-			<Section key={0} section={sections[0]} />
-			<Section key={1} section={sections[1]} />
-			<Section key={2} section={sections[2]} />
+			<Section key={0} section={sections[0]} depth={3} />
+			<Section key={1} section={sections[1]} depth={3} />
+			<Section key={2} section={sections[2]} depth={3} />
 		</StyledSectionsRenderer>
 	);
 
@@ -67,9 +67,9 @@ it('render should render styled component', () => {
 it('render should render component', () => {
 	const actual = shallow(
 		<SectionsRenderer classes={{}}>
-			<Section key={0} section={sections[0]} />
-			<Section key={1} section={sections[1]} />
-			<Section key={2} section={sections[2]} />
+			<Section key={0} section={sections[0]} depth={3} />
+			<Section key={1} section={sections[1]} depth={3} />
+			<Section key={2} section={sections[2]} depth={3} />
 		</SectionsRenderer>
 	);
 

--- a/src/rsg-components/Sections/Sections.spec.js
+++ b/src/rsg-components/Sections/Sections.spec.js
@@ -46,12 +46,6 @@ it('should render component renderer', () => {
 	expect(actual).toMatchSnapshot();
 });
 
-it('should render component renderer with primary sections if depth is 0', () => {
-	const actual = shallow(<Sections sections={sections} depth={0} />);
-
-	expect(actual).toMatchSnapshot();
-});
-
 it('render should render styled component', () => {
 	const actual = shallow(
 		<StyledSectionsRenderer classes={{}}>

--- a/src/rsg-components/Sections/__snapshots__/Sections.spec.js.snap
+++ b/src/rsg-components/Sections/__snapshots__/Sections.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`render should render component 1`] = `
 <section>
   <Section
+    depth={3}
     section={
       Object {
         "components": Array [],
@@ -18,6 +19,7 @@ exports[`render should render component 1`] = `
     }
   />
   <Section
+    depth={3}
     section={
       Object {
         "components": Array [],
@@ -32,6 +34,7 @@ exports[`render should render component 1`] = `
     }
   />
   <Section
+    depth={3}
     section={
       Object {
         "sections": Array [
@@ -59,6 +62,7 @@ exports[`render should render styled component 1`] = `
   }
 >
   <Section
+    depth={3}
     section={
       Object {
         "components": Array [],
@@ -74,6 +78,7 @@ exports[`render should render styled component 1`] = `
     }
   />
   <Section
+    depth={3}
     section={
       Object {
         "components": Array [],
@@ -88,6 +93,7 @@ exports[`render should render styled component 1`] = `
     }
   />
   <Section
+    depth={3}
     section={
       Object {
         "sections": Array [
@@ -109,6 +115,8 @@ exports[`render should render styled component 1`] = `
 exports[`should render component renderer 1`] = `
 <Styled(Sections)>
   <Section
+    depth={3}
+    primary={false}
     section={
       Object {
         "components": Array [],
@@ -124,6 +132,8 @@ exports[`should render component renderer 1`] = `
     }
   />
   <Section
+    depth={3}
+    primary={false}
     section={
       Object {
         "components": Array [],
@@ -138,6 +148,8 @@ exports[`should render component renderer 1`] = `
     }
   />
   <Section
+    depth={3}
+    primary={false}
     section={
       Object {
         "sections": Array [
@@ -156,9 +168,10 @@ exports[`should render component renderer 1`] = `
 </Styled(Sections)>
 `;
 
-exports[`should render component renderer with primary sections if root is true 1`] = `
+exports[`should render component renderer with primary sections if depth is 0 1`] = `
 <Styled(Sections)>
   <Section
+    depth={0}
     primary={true}
     section={
       Object {
@@ -175,6 +188,7 @@ exports[`should render component renderer with primary sections if root is true 
     }
   />
   <Section
+    depth={0}
     primary={true}
     section={
       Object {
@@ -190,6 +204,7 @@ exports[`should render component renderer with primary sections if root is true 
     }
   />
   <Section
+    depth={0}
     primary={true}
     section={
       Object {

--- a/src/rsg-components/Sections/__snapshots__/Sections.spec.js.snap
+++ b/src/rsg-components/Sections/__snapshots__/Sections.spec.js.snap
@@ -116,7 +116,6 @@ exports[`should render component renderer 1`] = `
 <Styled(Sections)>
   <Section
     depth={3}
-    primary={false}
     section={
       Object {
         "components": Array [],
@@ -133,7 +132,6 @@ exports[`should render component renderer 1`] = `
   />
   <Section
     depth={3}
-    primary={false}
     section={
       Object {
         "components": Array [],
@@ -149,63 +147,6 @@ exports[`should render component renderer 1`] = `
   />
   <Section
     depth={3}
-    primary={false}
-    section={
-      Object {
-        "sections": Array [
-          Object {
-            "content": Array [],
-            "name": "One",
-          },
-          Object {
-            "content": Array [],
-            "name": "Two",
-          },
-        ],
-      }
-    }
-  />
-</Styled(Sections)>
-`;
-
-exports[`should render component renderer with primary sections if depth is 0 1`] = `
-<Styled(Sections)>
-  <Section
-    depth={0}
-    primary={true}
-    section={
-      Object {
-        "components": Array [],
-        "content": Array [
-          Object {
-            "content": "<button>OK</button>",
-            "evalInContext": [Function],
-            "type": "code",
-          },
-        ],
-        "name": "Foo",
-      }
-    }
-  />
-  <Section
-    depth={0}
-    primary={true}
-    section={
-      Object {
-        "components": Array [],
-        "content": Array [
-          Object {
-            "content": "Hello *world*!",
-            "type": "markdown",
-          },
-        ],
-        "name": "Bar",
-      }
-    }
-  />
-  <Section
-    depth={0}
-    primary={true}
     section={
       Object {
         "sections": Array [

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -57,7 +57,7 @@ export default class StyleGuide extends Component {
 				toc={<TableOfContents sections={sections} />}
 				hasSidebar={config.showSidebar && !isolatedComponent}
 			>
-				<Sections sections={sections} root />
+				<Sections sections={sections} root depth={0} />
 			</StyleGuideRenderer>
 		);
 	}

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -57,7 +57,7 @@ export default class StyleGuide extends Component {
 				toc={<TableOfContents sections={sections} />}
 				hasSidebar={config.showSidebar && !isolatedComponent}
 			>
-				<Sections sections={sections} root depth={0} />
+				<Sections sections={sections} depth={1} />
 			</StyleGuideRenderer>
 		);
 	}

--- a/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
+++ b/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
@@ -85,6 +85,7 @@ exports[`should render components list 1`] = `
   }
 >
   <Sections
+    depth={0}
     root={true}
     sections={
       Array [

--- a/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
+++ b/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
@@ -85,8 +85,7 @@ exports[`should render components list 1`] = `
   }
 >
   <Sections
-    depth={0}
-    root={true}
+    depth={1}
     sections={
       Array [
         Object {


### PR DESCRIPTION
Added a `depth` prop to section heading and pass down through all sections.

Left in the `root` and `primary` props for now in case anyone is using them in a customised styleguide, but they should be deprecated and removed.

Also updated the sections example to demonstrate deeply nested sections.