### PR TITLE
Docs: Added Create React App + Typescript info

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,8 @@ Real projects using React Styleguidist:
 ## Integration with other tools
 
 * Create React App — just works, see the [Getting Started](https://react-styleguidist.js.org/docs/getting-started.html) guide!
-* [TypeScript](https://github.com/styleguidist/react-docgen-typescript)
+* Create React App + TypeScript, see [Configuring webpack](https://react-styleguidist.js.org/docs/webpack.html)
+* TypeScript, see [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript)
 
 ## Resources
 

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -77,11 +77,12 @@ module.exports = {
 
 [Create React App](https://github.com/facebookincubator/create-react-app) is supported out of the box, you don’t even need to create a style guide config if your components could be found using a default glob pattern, `src/components/**/*.{js,jsx}`.
 
-If you're using Create react App together with Typescript, you have to install [react-docgen-typescript](url) and add a `webpackConfig` and `propsParser` section to your  `styleguide.config.js`:
+If you're using Create react App together with Typescript, you have to install [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) and add a `components`, `webpackConfig` and `propsParser` section to your  `styleguide.config.js`:
 
 ```javascript
 module.exports = {
-  propsParser: require('react-docgen-typescript'.parse,
+  components: 'src/components/**/*.{ts,tsx}'
+  propsParser: require('react-docgen-typescript').parse,
   webpackConfig: require('./node_modules/react-scripts-ts/config/webpack.config.dev.js')
 }
 ```

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -77,13 +77,18 @@ module.exports = {
 
 [Create React App](https://github.com/facebookincubator/create-react-app) is supported out of the box, you don’t even need to create a style guide config if your components could be found using a default glob pattern, `src/components/**/*.{js,jsx}`.
 
-If you're using Create react App together with Typescript, you have to install [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) and add a `components`, `webpackConfig` and `propsParser` section to your  `styleguide.config.js`:
+## Create React App, TypeScript
+
+If you're using [Create React App](https://github.com/facebookincubator/create-react-app) and Typescript, you need to:
+- Install [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript)
+- Create a `styleguide.config.js`, see [this guide](Configuration.md)
+- Add a `components`, `webpackConfig` and `propsParser` section to your `styleguide.config.js`:
 
 ```javascript
 module.exports = {
-  components: 'src/components/**/*.{ts,tsx}'
+  components: 'src/components/**/*.{ts,tsx}',
   propsParser: require('react-docgen-typescript').parse,
-  webpackConfig: require('./node_modules/react-scripts-ts/config/webpack.config.dev.js')
+  webpackConfig: require('react-scripts-ts/config/webpack.config.dev.js')
 }
 ```
 

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -77,6 +77,15 @@ module.exports = {
 
 [Create React App](https://github.com/facebookincubator/create-react-app) is supported out of the box, you don’t even need to create a style guide config if your components could be found using a default glob pattern, `src/components/**/*.{js,jsx}`.
 
+If you're using Create react App together with Typescript, you have to install [react-docgen-typescript](url) and add a `webpackConfig` and `propsParser` section to your  `styleguide.config.js`:
+
+```javascript
+module.exports = {
+  propsParser: require('react-docgen-typescript'.parse,
+  webpackConfig: require('./node_modules/react-scripts-ts/config/webpack.config.dev.js')
+}
+```
+
 ## Non-webpack projects
 
 If your project doesn’t use webpack you still need loaders for your files. You can use [webpack-blocks](https://github.com/andywer/webpack-blocks).


### PR DESCRIPTION
my first pull request @sapegin :) 

added missing info when using Create React App together with TypeScript. Had to read webpack-config from react-scripts-ts/config/webpack.config.dev.js.

 