### PR TITLE
Fix navigating back from isolated / focus mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,8 @@ function renderStyleguide() {
 	}
 	document.title = documentTitle;
 
+	// If the current hash location was set to just `/` (e.g. when navigating back from isolated view to overview)
+	// replace the URL with one without hash, to present the user with a single address of the overview screen
 	const hash = location.hash.slice(1);
 	if (hash === '/') {
 		const url = window.location.pathname + window.location.search;

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,12 @@ function renderStyleguide() {
 	}
 	document.title = documentTitle;
 
+	const hash = location.hash.slice(1);
+	if (hash === '/') {
+		const url = window.location.pathname + window.location.search;
+		history.replaceState('', document.title, url);
+	}
+
 	ReactDOM.render(
 		<StyleGuide
 			codeRevision={codeRevision}

--- a/src/rsg-components/slots/IsolateButton.js
+++ b/src/rsg-components/slots/IsolateButton.js
@@ -7,7 +7,7 @@ import { getUrl } from '../../utils/utils';
 
 const IsolateButton = ({ name, example, isolated }) =>
 	isolated ? (
-		<ToolbarButton href={getUrl()} title="Show all components">
+		<ToolbarButton href={getUrl({ anchor: true, slug: '/' })} title="Show all components">
 			<MdFullscreenExit />
 		</ToolbarButton>
 	) : (

--- a/src/rsg-components/slots/__snapshots__/IsolateButton.spec.js.snap
+++ b/src/rsg-components/slots/__snapshots__/IsolateButton.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should renderer a link home in isolated mode 1`] = `
 <Styled(ToolbarButton)
-  href="blank"
+  href="blank#/"
   title="Show all components"
 >
   <MdFullscreenExit />


### PR DESCRIPTION
Current implementation ends up linking to the base url (`window.location.pathname`) which does not include the `#` sign so it will perform an HTTP request.

This PR changes the behavior - it will now navigate to `#/`