### PR TITLE
(feat): Adds componentDidCatch() to top-level component

### DIFF
--- a/src/rsg-components/Error/Error.spec.js
+++ b/src/rsg-components/Error/Error.spec.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ErrorRenderer } from './ErrorRenderer';
+
+it('renderer should render error message', () => {
+	const error = { toString: () => 'error' };
+	const info = { componentStack: { toString: () => 'info' } };
+	const actual = shallow(<ErrorRenderer classes={{}} error={error} info={info} />);
+
+	expect(actual).toMatchSnapshot();
+});

--- a/src/rsg-components/Error/ErrorRenderer.js
+++ b/src/rsg-components/Error/ErrorRenderer.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ fontFamily, fontSize, color, space }) => ({
+	root: {
+		margin: space[2],
+		lineHeight: 1.2,
+		fontSize: fontSize.small,
+		backgroundColor: color.error,
+	},
+	stack: {
+		color: color.errorBackground,
+		whiteSpace: 'pre',
+		fontFamily: fontFamily.monospace,
+	},
+	message: {
+		color: color.errorBackground,
+		fontFamily: fontFamily.base,
+	},
+});
+
+export function ErrorRenderer({ classes, error, info }) {
+	return (
+		<div className={classes.root}>
+			<pre className={classes.stack}>
+				{error.toString()}
+				{info.componentStack.toString()}
+			</pre>
+			<div className={classes.message}>
+				<p>
+					This may be due to an error in a component you are overriding, or a bug in React
+					Styleguidist.
+				</p>
+				<p>
+					If you believe this is a bug,&nbsp;
+					<a
+						style={{ color: 'inherit' }}
+						href="https://github.com/styleguidist/react-styleguidist/issues"
+					>
+						please submit an issue
+					</a>.
+				</p>
+			</div>
+		</div>
+	);
+}
+
+ErrorRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+	error: PropTypes.object.isRequired,
+	info: PropTypes.shape({
+		componentStack: PropTypes.object.isRequired,
+	}).isRequired,
+};
+
+export default Styled(styles)(ErrorRenderer);

--- a/src/rsg-components/Error/__snapshots__/Error.spec.js.snap
+++ b/src/rsg-components/Error/__snapshots__/Error.spec.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderer should render error message 1`] = `
+<div>
+  <pre>
+    error
+    info
+  </pre>
+  <div>
+    <p>
+      This may be due to an error in a component you are overriding, or a bug in React Styleguidist.
+    </p>
+    <p>
+      If you believe this is a bug, 
+      <a
+        href="https://github.com/styleguidist/react-styleguidist/issues"
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        please submit an issue
+      </a>
+      .
+    </p>
+  </div>
+</div>
+`;

--- a/src/rsg-components/Error/index.js
+++ b/src/rsg-components/Error/index.js
@@ -1,0 +1,1 @@
+export { default } from './ErrorRenderer.js';

--- a/src/rsg-components/PlaygroundError/PlaygroundErrorRenderer.js
+++ b/src/rsg-components/PlaygroundError/PlaygroundErrorRenderer.js
@@ -21,7 +21,7 @@ export function PlaygroundErrorRenderer({ classes, message }) {
 
 PlaygroundErrorRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
-	message: PropTypes.string.isRequired,
+	message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
 };
 
 export default Styled(styles)(PlaygroundErrorRenderer);

--- a/src/rsg-components/PlaygroundError/PlaygroundErrorRenderer.js
+++ b/src/rsg-components/PlaygroundError/PlaygroundErrorRenderer.js
@@ -21,7 +21,7 @@ export function PlaygroundErrorRenderer({ classes, message }) {
 
 PlaygroundErrorRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
-	message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+	message: PropTypes.string.isRequired,
 };
 
 export default Styled(styles)(PlaygroundErrorRenderer);

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -70,7 +70,7 @@ export default class StyleGuide extends Component {
 								This may be due to an error in a component you are overriding, or a bug in
 								react-styleguidist.<br />If you believe this is a bug, please submit an issue:&nbsp;
 								<a
-									style={{ color: 'white' }}
+									style={{ color: 'inherit' }}
 									href="https://github.com/styleguidist/react-styleguidist/issues"
 								>
 									https://github.com/styleguidist/react-styleguidist/issues

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -4,6 +4,7 @@ import TableOfContents from 'rsg-components/TableOfContents';
 import StyleGuideRenderer from 'rsg-components/StyleGuide/StyleGuideRenderer';
 import Sections from 'rsg-components/Sections';
 import Welcome from 'rsg-components/Welcome';
+import PlaygroundError from 'rsg-components/PlaygroundError';
 import { HOMEPAGE } from '../../../scripts/consts';
 
 export default class StyleGuide extends Component {
@@ -32,6 +33,11 @@ export default class StyleGuide extends Component {
 		isolatedComponent: false,
 	};
 
+	state = {
+		error: false,
+		info: null,
+	};
+
 	getChildContext() {
 		return {
 			codeRevision: this.props.codeRevision,
@@ -43,8 +49,38 @@ export default class StyleGuide extends Component {
 		};
 	}
 
+	componentDidCatch(error, info) {
+		this.setState({
+			error,
+			info,
+		});
+	}
+
 	render() {
 		const { config, sections, welcomeScreen, patterns, isolatedComponent } = this.props;
+
+		if (this.state.error) {
+			return (
+				<PlaygroundError
+					classes={{}}
+					message={
+						<div style={{ margin: 10 }}>
+							{`${this.state.error} ${this.state.info.componentStack}`}
+							<p>
+								This may be due to an error in a component you are overriding, or a bug in
+								react-styleguidist.<br />If you believe this is a bug, please submit an issue:&nbsp;
+								<a
+									style={{ color: 'white' }}
+									href="https://github.com/styleguidist/react-styleguidist/issues"
+								>
+									https://github.com/styleguidist/react-styleguidist/issues
+								</a>
+							</p>
+						</div>
+					}
+				/>
+			);
+		}
 
 		if (welcomeScreen) {
 			return <Welcome patterns={patterns} />;

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -4,8 +4,8 @@ import TableOfContents from 'rsg-components/TableOfContents';
 import StyleGuideRenderer from 'rsg-components/StyleGuide/StyleGuideRenderer';
 import Sections from 'rsg-components/Sections';
 import Welcome from 'rsg-components/Welcome';
+import Error from 'rsg-components/Error';
 import { HOMEPAGE } from '../../../scripts/consts';
-import { space, color, fontFamily } from '../../styles/theme';
 
 export default class StyleGuide extends Component {
 	static propTypes = {
@@ -60,35 +60,7 @@ export default class StyleGuide extends Component {
 		const { config, sections, welcomeScreen, patterns, isolatedComponent } = this.props;
 
 		if (this.state.error) {
-			return (
-				<div
-					style={{
-						margin: space[2],
-						color: color.errorBackground,
-						background: color.error,
-					}}
-				>
-					<pre style={{ fontFamily: fontFamily.monospace }}>
-						{this.state.error.toString()}
-						{this.state.info.componentStack.toString()}
-					</pre>
-					<div style={{ fontFamily: fontFamily.base }}>
-						<p>
-							This may be due to an error in a component you are overriding, or a bug in React
-							Styleguidist.
-						</p>
-						<p>
-							If you believe this is a bug,&nbsp;
-							<a
-								style={{ color: 'inherit' }}
-								href="https://github.com/styleguidist/react-styleguidist/issues"
-							>
-								please submit an issue
-							</a>.
-						</p>
-					</div>
-				</div>
-			);
+			return <Error error={this.state.error} info={this.state.info} />;
 		}
 
 		if (welcomeScreen) {

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -4,7 +4,6 @@ import TableOfContents from 'rsg-components/TableOfContents';
 import StyleGuideRenderer from 'rsg-components/StyleGuide/StyleGuideRenderer';
 import Sections from 'rsg-components/Sections';
 import Welcome from 'rsg-components/Welcome';
-import PlaygroundError from 'rsg-components/PlaygroundError';
 import { HOMEPAGE } from '../../../scripts/consts';
 
 export default class StyleGuide extends Component {
@@ -61,24 +60,20 @@ export default class StyleGuide extends Component {
 
 		if (this.state.error) {
 			return (
-				<PlaygroundError
-					classes={{}}
-					message={
-						<div style={{ margin: 10 }}>
-							{`${this.state.error} ${this.state.info.componentStack}`}
-							<p>
-								This may be due to an error in a component you are overriding, or a bug in
-								react-styleguidist.<br />If you believe this is a bug, please submit an issue:&nbsp;
-								<a
-									style={{ color: 'inherit' }}
-									href="https://github.com/styleguidist/react-styleguidist/issues"
-								>
-									https://github.com/styleguidist/react-styleguidist/issues
-								</a>
-							</p>
-						</div>
-					}
-				/>
+				<div style={{ margin: 10, color: 'crimson' }}>
+					<code style={{ whiteSpace: 'pre' }}>{`${this.state.error} ${this.state.info
+						.componentStack}`}</code>
+					<p>
+						This may be due to an error in a component you are overriding, or a bug in React
+						Styleguidist.<br />If you believe this is a bug,&nbsp;
+						<a
+							style={{ color: 'inherit' }}
+							href="https://github.com/styleguidist/react-styleguidist/issues"
+						>
+							please submit an issue
+						</a>.
+					</p>
+				</div>
 			);
 		}
 

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -5,6 +5,7 @@ import StyleGuideRenderer from 'rsg-components/StyleGuide/StyleGuideRenderer';
 import Sections from 'rsg-components/Sections';
 import Welcome from 'rsg-components/Welcome';
 import { HOMEPAGE } from '../../../scripts/consts';
+import { space, color, fontFamily } from '../../styles/theme';
 
 export default class StyleGuide extends Component {
 	static propTypes = {
@@ -60,19 +61,32 @@ export default class StyleGuide extends Component {
 
 		if (this.state.error) {
 			return (
-				<div style={{ margin: 10, color: 'crimson' }}>
-					<code style={{ whiteSpace: 'pre' }}>{`${this.state.error} ${this.state.info
-						.componentStack}`}</code>
-					<p>
-						This may be due to an error in a component you are overriding, or a bug in React
-						Styleguidist.<br />If you believe this is a bug,&nbsp;
-						<a
-							style={{ color: 'inherit' }}
-							href="https://github.com/styleguidist/react-styleguidist/issues"
-						>
-							please submit an issue
-						</a>.
-					</p>
+				<div
+					style={{
+						margin: space[2],
+						color: color.errorBackground,
+						background: color.error,
+					}}
+				>
+					<pre style={{ fontFamily: fontFamily.monospace }}>
+						{this.state.error.toString()}
+						{this.state.info.componentStack.toString()}
+					</pre>
+					<div style={{ fontFamily: fontFamily.base }}>
+						<p>
+							This may be due to an error in a component you are overriding, or a bug in React
+							Styleguidist.
+						</p>
+						<p>
+							If you believe this is a bug,&nbsp;
+							<a
+								style={{ color: 'inherit' }}
+								href="https://github.com/styleguidist/react-styleguidist/issues"
+							>
+								please submit an issue
+							</a>.
+						</p>
+					</div>
 				</div>
 			);
 		}

--- a/src/rsg-components/StyleGuide/StyleGuide.spec.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.spec.js
@@ -46,6 +46,15 @@ it('should render welcome screen', () => {
 	expect(actual).toMatchSnapshot();
 });
 
+it('should render an error when componentDidCatch() is triggered', () => {
+	const wrapper = shallow(<StyleGuide codeRevision={1} config={config} sections={[]} slots={{}} />);
+	wrapper
+		.instance()
+		.componentDidCatch({ toString: () => 'error' }, { componentStack: { toString: () => 'info' } });
+	wrapper.update();
+	expect(wrapper).toMatchSnapshot();
+});
+
 describe('sidebar rendering', () => {
 	it('renderer should have sidebar if showSidebar is not set', () => {
 		const wrapper = shallow(

--- a/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
+++ b/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
@@ -51,68 +51,20 @@ exports[`renderer should render logo, table of contents and passed children 1`] 
 `;
 
 exports[`should render an error when componentDidCatch() is triggered 1`] = `
-<div
-  style={
+<Styled(Error)
+  error={
     Object {
-      "background": "#fff",
-      "color": "#c00",
-      "margin": 16,
+      "toString": [Function],
     }
   }
->
-  <pre
-    style={
-      Object {
-        "fontFamily": Array [
-          "Consolas",
-          "\\"Liberation Mono\\"",
-          "Menlo",
-          "monospace",
-        ],
-      }
+  info={
+    Object {
+      "componentStack": Object {
+        "toString": [Function],
+      },
     }
-  >
-    error
-    info
-  </pre>
-  <div
-    style={
-      Object {
-        "fontFamily": Array [
-          "-apple-system",
-          "BlinkMacSystemFont",
-          "\\"Segoe UI\\"",
-          "\\"Roboto\\"",
-          "\\"Oxygen\\"",
-          "\\"Ubuntu\\"",
-          "\\"Cantarell\\"",
-          "\\"Fira Sans\\"",
-          "\\"Droid Sans\\"",
-          "\\"Helvetica Neue\\"",
-          "sans-serif",
-        ],
-      }
-    }
-  >
-    <p>
-      This may be due to an error in a component you are overriding, or a bug in React Styleguidist.
-    </p>
-    <p>
-      If you believe this is a bug, 
-      <a
-        href="https://github.com/styleguidist/react-styleguidist/issues"
-        style={
-          Object {
-            "color": "inherit",
-          }
-        }
-      >
-        please submit an issue
-      </a>
-      .
-    </p>
-  </div>
-</div>
+  }
+/>
 `;
 
 exports[`should render components list 1`] = `

--- a/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
+++ b/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
@@ -50,6 +50,71 @@ exports[`renderer should render logo, table of contents and passed children 1`] 
 </div>
 `;
 
+exports[`should render an error when componentDidCatch() is triggered 1`] = `
+<div
+  style={
+    Object {
+      "background": "#fff",
+      "color": "#c00",
+      "margin": 16,
+    }
+  }
+>
+  <pre
+    style={
+      Object {
+        "fontFamily": Array [
+          "Consolas",
+          "\\"Liberation Mono\\"",
+          "Menlo",
+          "monospace",
+        ],
+      }
+    }
+  >
+    error
+    info
+  </pre>
+  <div
+    style={
+      Object {
+        "fontFamily": Array [
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "\\"Segoe UI\\"",
+          "\\"Roboto\\"",
+          "\\"Oxygen\\"",
+          "\\"Ubuntu\\"",
+          "\\"Cantarell\\"",
+          "\\"Fira Sans\\"",
+          "\\"Droid Sans\\"",
+          "\\"Helvetica Neue\\"",
+          "sans-serif",
+        ],
+      }
+    }
+  >
+    <p>
+      This may be due to an error in a component you are overriding, or a bug in React Styleguidist.
+    </p>
+    <p>
+      If you believe this is a bug, 
+      <a
+        href="https://github.com/styleguidist/react-styleguidist/issues"
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        please submit an issue
+      </a>
+      .
+    </p>
+  </div>
+</div>
+`;
+
 exports[`should render components list 1`] = `
 <Styled(StyleGuide)
   hasSidebar={true}


### PR DESCRIPTION
Adds `componentDidCatch()` to top-level `<StyleGuide />` component. We could arguably have added an additional `<ErrorBoundary />` layer in case there's an error in the `<StyleGuide />` component itself, but that seemed unlikely.

To test this, you would need to update to React 16 locally (I left that out of this PR because there's still some other pending tasks in #614 ) and then access a property on an undefined object or something in the render method of a component deep in the tree. Here's a screenshot of what it looks like:

![image](https://user-images.githubusercontent.com/244704/31284976-147f607c-aa88-11e7-8724-4b48506dcab9.png)


Note that the console also logs the React-generated error, which is nice.