### PR TITLE
Run console.clear when Preview component is mounted. 

### DIFF
--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -49,6 +49,7 @@ export default class Preview extends Component {
 	};
 
 	componentDidMount() {
+		console.clear(); // eslint-disable-line no-console
 		this.executeCode();
 	}
 

--- a/src/rsg-components/Preview/Preview.spec.js
+++ b/src/rsg-components/Preview/Preview.spec.js
@@ -45,3 +45,10 @@ it('should render component renderer', () => {
 
 	expect(actual).toMatchSnapshot();
 });
+
+it('should call console.clear when mounted', () => {
+	console.clear = jest.fn();
+	mount(<Preview code={code} evalInContext={evalInContext} />, options);
+
+	expect(console.clear.mock.calls.length).toBe(1);
+});


### PR DESCRIPTION
Hi. Here is a fix for #519. Also, I created a test to check if `console.clear` was called (thanks to @tizmagik for his comments in other PR). Let me know if I've missed something 😉