### PR TITLE
Fix: Correct whitespace around error messages with noeditor modifier

### DIFF
--- a/src/rsg-components/Error/ErrorRenderer.js
+++ b/src/rsg-components/Error/ErrorRenderer.js
@@ -7,15 +7,14 @@ const styles = ({ fontFamily, fontSize, color, space }) => ({
 		margin: space[2],
 		lineHeight: 1.2,
 		fontSize: fontSize.small,
-		backgroundColor: color.error,
 	},
 	stack: {
-		color: color.errorBackground,
+		color: color.error,
 		whiteSpace: 'pre',
 		fontFamily: fontFamily.monospace,
 	},
 	message: {
-		color: color.errorBackground,
+		color: color.error,
 		fontFamily: fontFamily.base,
 	},
 });

--- a/src/rsg-components/PlaygroundError/PlaygroundErrorRenderer.js
+++ b/src/rsg-components/PlaygroundError/PlaygroundErrorRenderer.js
@@ -2,15 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Styled from 'rsg-components/Styled';
 
-const styles = ({ fontFamily, fontSize, color, space }) => ({
+const styles = ({ fontFamily, fontSize, color }) => ({
 	root: {
-		margin: [[-space[2], -space[2], -(space[2] + space[0])]],
-		padding: space[2],
+		margin: 0,
 		lineHeight: 1.2,
 		fontSize: fontSize.small,
 		fontFamily: fontFamily.monospace,
 		color: color.error,
-		backgroundColor: color.errorBackground,
 		whiteSpace: 'pre',
 	},
 });

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -18,9 +18,8 @@ export const color = {
 	border: '#e8e8e8',
 	name: '#7f9a44',
 	type: '#b77daa',
-	error: '#fff',
+	error: '#c00',
 	baseBackground: '#fff',
-	errorBackground: '#c00',
 	codeBackground: '#f5f5f5',
 	sidebarBackground: '#f5f5f5',
 };


### PR DESCRIPTION
Removes red background and hacks with negative margins that were required for it to work.

Closes #576, #667

![image 2017-11-07 at 5 14 03 pm](https://user-images.githubusercontent.com/70067/32504050-241ceee4-c3df-11e7-8a53-f1e141c8062d.png)

![image 2017-11-07 at 5 15 06 pm](https://user-images.githubusercontent.com/70067/32504142-6c996896-c3df-11e7-8e62-620d1b21ef54.png)
