### PR TITLE
Apply styles to Preview `<div>`s when defined

### DIFF
--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -149,9 +149,12 @@ export default class Preview extends Component {
 
 	render() {
 		const { error } = this.state;
+		const { styles } = this.context.config;
+		const previewStyle = styles && styles.Preview ? { style: styles.Preview } : null;
+
 		return (
-			<div>
-				<div ref={ref => (this.mountNode = ref)} />
+			<div {...previewStyle}>
+				<div {...previewStyle} ref={ref => (this.mountNode = ref)} />
 				{error && <PlaygroundError message={error} />}
 			</div>
 		);


### PR DESCRIPTION
Fixes https://github.com/styleguidist/react-styleguidist/issues/678

This is a bit of a hack, but it achieves the desired result. Since `styleguide.config.js` contains a `styles` configuration, I am taking any defined Preview styles there and applying them to the two unclassed `<div>`s in `Preview.js` via the `context` object.

I see that this project leverages JSS, so I am open to making changes that more closely align with those patterns. However, without providing `className` hooks or turning each `<div>` into a first-class Styleguidist component, I think that solution will also lead to a bit of a mess. 😄

I am hoping that this quick solution creates a decent jumping off point for the discussion.