### PR TITLE
Reload dev server when assets change

### DIFF
--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -17,6 +17,7 @@ module.exports = function createServer(config, env) {
 			ignored: /node_modules/,
 		},
 		contentBase: config.assetsDir,
+		watchContentBase: config.assetsDir != null,
 		stats: webpackConfig.stats || {},
 	});
 

--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -17,7 +17,7 @@ module.exports = function createServer(config, env) {
 			ignored: /node_modules/,
 		},
 		contentBase: config.assetsDir,
-		watchContentBase: config.assetsDir != null,
+		watchContentBase: config.assetsDir !== undefined,
 		stats: webpackConfig.stats || {},
 	});
 


### PR DESCRIPTION
Address bug #682 by setting the webpack [`watchContentBase`](https://webpack.js.org/configuration/dev-server/#devserver-watchcontentbase) flag to `true` when an `assetDir` is provided.