### PR TITLE
Upgrade react-docgen to 3.0.0-beta9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,11 +1485,6 @@
         "to-fast-properties": "1.0.3"
       }
     },
-    "babylon": {
-      "version": "7.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.20.tgz",
-      "integrity": "sha512-kkMTbo/6QmDD+ggF4KaeMLNvf+RfHVtC4mZJcGDZsbQvRqUgG4yWdy6fh3FZbwwLX9BD6PGmAeKN08P5O8pGLQ=="
-    },
     "bail": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
@@ -10509,19 +10504,24 @@
       }
     },
     "react-docgen": {
-      "version": "3.0.0-beta8",
-      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-beta8.tgz",
-      "integrity": "sha1-V4iBZs/9BoH6IPoNc+Vp+n/QTDw=",
+      "version": "3.0.0-beta9",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-beta9.tgz",
+      "integrity": "sha512-3UqwxygAP/eZdDtOKum6vClKWUlceZ7RBVQ3Fe122l1WBYOqHcBzoUZIwN8feaLVo+s2eB/q+NkBfanLgvmt+w==",
       "requires": {
         "async": "2.5.0",
         "babel-runtime": "6.26.0",
-        "babylon": "7.0.0-beta.20",
+        "babylon": "7.0.0-beta.31",
         "commander": "2.11.0",
         "doctrine": "2.0.0",
         "node-dir": "0.1.17",
         "recast": "0.12.6"
       },
       "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ=="
+        },
         "commander": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "q-i": "^1.2.0",
     "react-codemirror2": "^3.0.7",
     "react-dev-utils": "^4.2.1",
-    "react-docgen": "^3.0.0-beta8",
+    "react-docgen": "^3.0.0-beta9",
     "react-docgen-displayname-handler": "^1.0.1",
     "react-group": "^1.0.5",
     "react-icons": "^2.2.7",


### PR DESCRIPTION
Fix #686 by upgrading react-docgen to [3.0.0-beta9](https://github.com/reactjs/react-docgen/releases/tag/v3.0.0-beta9) which includes changes from [2.20.0](https://github.com/reactjs/react-docgen/releases/tag/v2.20.0) as well.