### PR TITLE
Allow overriding default webpack dev server options

### DIFF
--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -7,7 +7,7 @@ const makeWebpackConfig = require('./make-webpack-config');
 
 module.exports = function createServer(config, env) {
 	const webpackConfig = makeWebpackConfig(config, env);
-	const webpackDevServerConfig = merge(webpackConfig.devServer, {
+	const webpackDevServerConfig = merge({
 		noInfo: true,
 		compress: true,
 		clientLogLevel: 'none',
@@ -19,7 +19,7 @@ module.exports = function createServer(config, env) {
 		contentBase: config.assetsDir,
 		watchContentBase: config.assetsDir !== undefined,
 		stats: webpackConfig.stats || {},
-	});
+	}, webpackConfig.devServer);
 
 	const compiler = webpack(webpackConfig);
 	const devServer = new WebpackDevServer(compiler, webpackDevServerConfig);

--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -18,9 +18,9 @@ module.exports = function createServer(config, env) {
 		},
 		watchContentBase: config.assetsDir !== undefined,
 		stats: webpackConfig.stats || {},
-	}, webpackConfig.devServer);
-
-	webpackDevServerConfig.contentBase = config.assetsDir;
+	}, webpackConfig.devServer, { 
+		contentBase: config.assetsDir 
+	});
 
 	const compiler = webpack(webpackConfig);
 	const devServer = new WebpackDevServer(compiler, webpackDevServerConfig);

--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -16,10 +16,11 @@ module.exports = function createServer(config, env) {
 		watchOptions: {
 			ignored: /node_modules/,
 		},
-		contentBase: config.assetsDir,
 		watchContentBase: config.assetsDir !== undefined,
 		stats: webpackConfig.stats || {},
 	}, webpackConfig.devServer);
+
+	webpackDevServerConfig.contentBase = config.assetsDir;
 
 	const compiler = webpack(webpackConfig);
 	const devServer = new WebpackDevServer(compiler, webpackDevServerConfig);


### PR DESCRIPTION
There is currently no way to override webpack dev server options. For example, we specifically want the dev server to look at `node_modules/` too (to develop using linked dependencies) and there isn't a way to do that.

