### PR TITLE
Add 'tab' key to Playground component's style

### DIFF
--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -19,7 +19,7 @@ export const styles = ({ space, color, borderRadius }) => ({
 	toolbar: {
 		marginLeft: 'auto',
 	},
-	tab: {},
+	tab: {}, // expose className to allow using it in 'styles' settings
 });
 
 export function PlaygroundRenderer({

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -19,6 +19,7 @@ export const styles = ({ space, color, borderRadius }) => ({
 	toolbar: {
 		marginLeft: 'auto',
 	},
+	tab: {},
 });
 
 export function PlaygroundRenderer({


### PR DESCRIPTION
According to https://react-styleguidist.js.org/docs/cookbook.html#how-to-change-styles-of-a-style-guide you are able to find component style names using React Developer tools. Unfortunately, last tab uses `classes.tab`, but it's not set in styles, so react renders with class `rsg-undefined`.