### PR TITLE
Fix: let the fontWeight property be inherited from body

### DIFF
--- a/src/styles/setupjss.js
+++ b/src/styles/setupjss.js
@@ -27,6 +27,7 @@ const jss = create({
 				// Allow inheritance because it may be set on body and should be available for user components
 				color: 'inherit',
 				fontFamily: 'inherit',
+				fontWeight: 'inherit',
 				lineHeight: 'inherit',
 				fontSize: 'inherit',
 			},


### PR DESCRIPTION
This fix sets ```fontWeight``` to ```inherit```, that allows custom font weights to be set in user components. Before it had affected components with ```fontWeight: 'normal'``` from Styleguidist UI.