### PR TITLE
Use prepare script to allow npm@5+ compiling git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "build": "node bin/styleguidist.js build --config examples/basic/styleguide.config.js",
     "build:customised": "node bin/styleguidist.js build --config examples/customised/styleguide.config.js",
     "build:sections": "node bin/styleguidist.js build --config examples/sections/styleguide.config.js",
-    "prepublishOnly": "npm run compile",
+    "prepare": "npm run compile",
     "test:browser:pre": "npm i --no-save puppeteer",
     "test:browser": "node test/browser.js examples/basic/styleguide/index.html",
     "test:browser:customised": "node test/browser.js examples/customised/styleguide/index.html",


### PR DESCRIPTION
`prepare` will run:
- before publish (for npm4+)
- after install (for npm4+)
- after styleguidist gets installed as dependency from github (for npm5+)
