### PR TITLE
Adds a block formatting context to the preview div so that any floate…

### DIFF
--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -11,8 +11,9 @@ export const styles = ({ space, color, borderRadius }) => ({
 		padding: space[2],
 		border: [[1, color.border, 'solid']],
 		borderRadius,
-		width: '100%', // expands following inline-block
-		display: 'inline-block', // block formatting context required to contain floats
+		// the next 2 lines are required to contain floated components
+		width: '100%',
+		display: 'inline-block',
 	},
 	controls: {
 		display: 'flex',

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -11,8 +11,8 @@ export const styles = ({ space, color, borderRadius }) => ({
 		padding: space[2],
 		border: [[1, color.border, 'solid']],
 		borderRadius,
-		width: '100%',
-		display: 'inline-block',
+		width: '100%', // expands following inline-block
+		display: 'inline-block', // block formatting context required to contain floats
 	},
 	controls: {
 		display: 'flex',

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -11,6 +11,8 @@ export const styles = ({ space, color, borderRadius }) => ({
 		padding: space[2],
 		border: [[1, color.border, 'solid']],
 		borderRadius,
+		width: '100%',
+		display: 'inline-block',
 	},
 	controls: {
 		display: 'flex',


### PR DESCRIPTION
Addresses issue: https://github.com/styleguidist/react-styleguidist/issues/772

@sapegin I looked for a place to add a spec e.g. src/rsg-components/Playground/Playground.spec.js but I didn't see anything else asserting on CSS things in there so I deemed this not a thing that needed specs. Please advise if otherwise. That said, Here are some screenshots to make this PR crystal clear…

Nothing broke:

![image](https://user-images.githubusercontent.com/142403/34841996-fc9c12d8-f6be-11e7-9f34-f4c951f1dfb8.png)
---


Proof .. floated button gets contained (note I added the `float: right` manually in devtools):

![image](https://user-images.githubusercontent.com/142403/34842245-befad936-f6bf-11e7-9f44-141c5542a8bb.png)

---

Here's the preview div with block formatting context rules applied:

![image](https://user-images.githubusercontent.com/142403/34842065-38a3e666-f6bf-11e7-9146-f95d743f869c.png)

---

Lmk if there's anything else you'd like done here. Thanks