### PR TITLE
feat: allow use of array of component paths in the config file

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -49,7 +49,7 @@ Each section consists of (all fields are optional):
 
 * `name` — section title.
 * `content` — location of a Markdown file containing the overview content.
-* `components` — a glob pattern string or a function returning a list of components. The same rules apply as for the root `components` option.
+* `components` — a glob pattern string, an array of component paths or a function returning a list of components. The same rules apply as for the root `components` option.
 * `sections` — array of subsections (can be nested).
 * `description` — A small description of this section.
 * `ignore` — string/array of globs that should not be included in the section.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -57,10 +57,11 @@ Styleguidist uses [Bublé](https://buble.surge.sh/guide/) to run ES6 code on the
 
 #### `components`
 
-Type: `String` or `Function`, default: `src/components/**/*.{js,jsx,ts,tsx}`
+Type: `String`, `Function` or `Array`, default: `src/components/**/*.{js,jsx,ts,tsx}`
 
 * when `String`: a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) that matches all your component modules.
 * when `Function`: a function that returns an array of module paths.
+* when `Array`: an array of module paths.
 
 All paths are relative to config folder.
 

--- a/loaders/utils/__tests__/getComponentFiles.spec.js
+++ b/loaders/utils/__tests__/getComponentFiles.spec.js
@@ -24,6 +24,17 @@ it('getComponentFiles() should accept components as a function that returns abso
 	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
 });
 
+it('getComponentFiles() should accept components as an array of file names', () => {
+	const result = getComponentFiles(components, configDir);
+	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
+});
+
+it('getComponentFiles() should accept components as a function that returns absolute paths', () => {
+	const absolutize = files => files.map(file => path.join(configDir, file));
+	const result = getComponentFiles(absolutize(components), configDir);
+	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
+});
+
 it('getComponentFiles() should accept components as a glob', () => {
 	const result = getComponentFiles(glob, configDir);
 	expect(deabs(result)).toEqual([
@@ -42,7 +53,7 @@ it('getComponentFiles() should ignore specified patterns', () => {
 	]);
 });
 
-it('getComponentFiles() should throw if components is not a function or a string', () => {
+it('getComponentFiles() should throw if components is not a function, array or a string', () => {
 	const fn = () => getComponentFiles(42, configDir);
-	expect(fn).toThrowError('should be string or function');
+	expect(fn).toThrowError('should be string, function or array');
 });

--- a/loaders/utils/getComponentFiles.js
+++ b/loaders/utils/getComponentFiles.js
@@ -4,6 +4,7 @@ const path = require('path');
 const glob = require('glob');
 const isFunction = require('lodash/isFunction');
 const isString = require('lodash/isString');
+const isArray = require('lodash/isArray');
 
 /**
  * Return absolute paths of components that should be rendered in the style guide.
@@ -21,11 +22,13 @@ module.exports = function getComponentFiles(components, rootDir, ignore) {
 	let componentFiles;
 	if (isFunction(components)) {
 		componentFiles = components();
+	} else if (isArray(components)) {
+		componentFiles = components;
 	} else if (isString(components)) {
 		componentFiles = glob.sync(path.resolve(rootDir, components), { ignore });
 	} else {
 		throw new Error(
-			`Styleguidist: components should be string or function, received ${typeof components}.`
+			`Styleguidist: components should be string, function or array, received ${typeof components}.`
 		);
 	}
 

--- a/loaders/utils/getComponentFiles.js
+++ b/loaders/utils/getComponentFiles.js
@@ -4,7 +4,6 @@ const path = require('path');
 const glob = require('glob');
 const isFunction = require('lodash/isFunction');
 const isString = require('lodash/isString');
-const isArray = require('lodash/isArray');
 
 /**
  * Return absolute paths of components that should be rendered in the style guide.
@@ -22,7 +21,7 @@ module.exports = function getComponentFiles(components, rootDir, ignore) {
 	let componentFiles;
 	if (isFunction(components)) {
 		componentFiles = components();
-	} else if (isArray(components)) {
+	} else if (Array.isArray(components)) {
 		componentFiles = components;
 	} else if (isString(components)) {
 		componentFiles = glob.sync(path.resolve(rootDir, components), { ignore });


### PR DESCRIPTION
This PR addresses the following issue: #774 

Now along with a string or function it is possible to pass an array of file paths to `components` property of the config.