### PR TITLE
Refactor: combine existing Code component with the Markdown Code component. #613

### DIFF
--- a/src/rsg-components/Code/Code.spec.js
+++ b/src/rsg-components/Code/Code.spec.js
@@ -1,9 +1,22 @@
 import React from 'react';
 import { CodeRenderer } from './CodeRenderer';
 
-it('renderer should render code', () => {
-	const code = '<button>OK</button>';
-	const actual = shallow(<CodeRenderer classes={{}}>{code}</CodeRenderer>);
+describe('Code blocks', () => {
+	it('should render code', () => {
+		const code = '<button>OK</button>';
+		const actual = shallow(<CodeRenderer classes={{}}>{code}</CodeRenderer>);
 
-	expect(actual).toMatchSnapshot();
+		expect(actual).toMatchSnapshot();
+	});
+
+	it('should render code to be highlighted', () => {
+		const code = '<button>OK</button>';
+		const actual = render(
+			<CodeRenderer classes={{}} className="lang-html">
+				{code}
+			</CodeRenderer>
+		);
+
+		expect(actual).toMatchSnapshot();
+	});
 });

--- a/src/rsg-components/Code/CodeRenderer.js
+++ b/src/rsg-components/Code/CodeRenderer.js
@@ -1,29 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import Styled from 'rsg-components/Styled';
 
 const styles = ({ fontFamily }) => ({
 	code: {
-		display: 'inline',
 		fontFamily: fontFamily.monospace,
 		fontSize: 'inherit',
 		color: 'inherit',
 		background: 'transparent',
+		whiteSpace: 'inherit',
 	},
 });
 
 export function CodeRenderer({ classes, className, children }) {
-	return (
-		<span className={className}>
-			<code className={classes.code}>{children}</code>
-		</span>
-	);
-}
+	const classNames = cx(className, classes.code);
 
+	const isHighlighted = className && className.indexOf('lang-') !== -1;
+	if (isHighlighted) {
+		return <code className={classNames} dangerouslySetInnerHTML={{ __html: children }} />;
+	}
+	return <code className={classNames}>{children}</code>;
+}
 CodeRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
 	className: PropTypes.string,
-	children: PropTypes.node,
+	children: PropTypes.node.isRequired,
 };
 
 export default Styled(styles)(CodeRenderer);

--- a/src/rsg-components/Code/__snapshots__/Code.spec.js.snap
+++ b/src/rsg-components/Code/__snapshots__/Code.spec.js.snap
@@ -1,9 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderer should render code 1`] = `
-<span>
-  <code>
-    &lt;button&gt;OK&lt;/button&gt;
-  </code>
-</span>
+exports[`Code blocks should render code 1`] = `
+<code
+  className=""
+>
+  &lt;button&gt;OK&lt;/button&gt;
+</code>
+`;
+
+exports[`Code blocks should render code to be highlighted 1`] = `
+<code
+  class="lang-html"
+>
+  <button>
+    OK
+  </button>
+</code>
 `;

--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { compiler } from 'markdown-to-jsx';
 import mapValues from 'lodash/mapValues';
@@ -10,24 +9,13 @@ import Para, { styles as paraStyles } from 'rsg-components/Para';
 import MarkdownHeading from 'rsg-components/Markdown/MarkdownHeading';
 import List from 'rsg-components/Markdown/List';
 import Blockquote from 'rsg-components/Markdown/Blockquote';
+import Pre from 'rsg-components/Markdown/Pre';
+import Code from 'rsg-components/Code';
 
 // We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
 // That way we could avoid clashes between our loaders and user loaders.
 // eslint-disable-next-line import/no-unresolved
 require('!!../../../loaders/style-loader!../../../loaders/css-loader!highlight.js/styles/tomorrow.css');
-
-// Code blocks with server-side syntax highlight
-function Code({ children, className }) {
-	const isHighlighted = className && className.indexOf('lang-') !== -1;
-	if (isHighlighted) {
-		return <code className={className} dangerouslySetInnerHTML={{ __html: children }} />;
-	}
-	return <code className={className}>{children}</code>;
-}
-Code.propTypes = {
-	children: PropTypes.node,
-	className: PropTypes.string,
-};
 
 // Custom CSS classes for each tag: <em> → <em className={s.em}> + custom components
 const getBaseOverrides = memoize(classes => {
@@ -110,9 +98,9 @@ const getBaseOverrides = memoize(classes => {
 		},
 		code: {
 			component: Code,
-			props: {
-				className: classes.code,
-			},
+		},
+		pre: {
+			component: Pre,
 		},
 	};
 }, () => 'getBaseOverrides');
@@ -129,7 +117,7 @@ const getInlineOverrides = memoize(classes => {
 	};
 }, () => 'getInlineOverrides');
 
-const styles = ({ space, fontFamily, fontSize, color, borderRadius }) => ({
+const styles = ({ space, fontFamily, fontSize, color }) => ({
 	base: {
 		color: color.base,
 		fontFamily: fontFamily.base,
@@ -146,22 +134,6 @@ const styles = ({ space, fontFamily, fontSize, color, borderRadius }) => ({
 		borderWidth: [[0, 0, 1, 0]],
 		borderColor: color.border,
 		borderStyle: 'solid',
-	},
-	code: {
-		fontFamily: fontFamily.monospace,
-		fontSize: 'inherit',
-		color: 'inherit',
-		background: 'transparent',
-		whiteSpace: 'inherit',
-	},
-	pre: {
-		composes: '$para',
-		backgroundColor: color.codeBackground,
-		border: [[1, color.border, 'solid']],
-		padding: [[space[1], space[2]]],
-		fontSize: fontSize.small,
-		borderRadius,
-		whiteSpace: 'pre',
 	},
 	table: {
 		composes: '$para',

--- a/src/rsg-components/Markdown/Pre/Pre.spec.js
+++ b/src/rsg-components/Markdown/Pre/Pre.spec.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Pre from './index';
+
+describe('Markdown Pre', () => {
+	it('should render a pre', () => {
+		const actual = render(<Pre>This is pre-formatted text.</Pre>);
+
+		expect(actual).toMatchSnapshot();
+	});
+});

--- a/src/rsg-components/Markdown/Pre/PreRenderer.js
+++ b/src/rsg-components/Markdown/Pre/PreRenderer.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { styles as paraStyles } from 'rsg-components/Para';
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ space, color, fontSize, fontFamily, borderRadius }) => ({
+	pre: {
+		...paraStyles({ space, color, fontFamily }).para,
+		fontSize: fontSize.small,
+		whiteSpace: 'pre',
+		backgroundColor: color.codeBackground,
+		padding: [[space[1], space[2]]],
+		border: [[1, color.border, 'solid']],
+		borderRadius,
+	},
+});
+
+export function PreRenderer({ classes, children }) {
+	return <pre className={classes.pre}>{children}</pre>;
+}
+PreRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+	children: PropTypes.node.isRequired,
+};
+
+export default Styled(styles)(PreRenderer);

--- a/src/rsg-components/Markdown/Pre/PreRenderer.js
+++ b/src/rsg-components/Markdown/Pre/PreRenderer.js
@@ -1,18 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { styles as paraStyles } from 'rsg-components/Para';
 import Styled from 'rsg-components/Styled';
 
 const styles = ({ space, color, fontSize, fontFamily, borderRadius }) => ({
 	pre: {
-		...paraStyles({ space, color, fontFamily }).para,
+		fontFamily: fontFamily.base,
 		fontSize: fontSize.small,
+		lineHeight: 1.5,
+		color: color.base,
 		whiteSpace: 'pre',
 		backgroundColor: color.codeBackground,
 		padding: [[space[1], space[2]]],
 		border: [[1, color.border, 'solid']],
 		borderRadius,
+		marginTop: 0,
+		marginBottom: space[2],
 	},
 });
 

--- a/src/rsg-components/Markdown/Pre/__snapshots__/Pre.spec.js.snap
+++ b/src/rsg-components/Markdown/Pre/__snapshots__/Pre.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Markdown Pre should render a pre 1`] = `
+<pre
+  class="rsg--pre-0"
+>
+  This is pre-formatted text.
+</pre>
+`;

--- a/src/rsg-components/Markdown/Pre/index.js
+++ b/src/rsg-components/Markdown/Pre/index.js
@@ -1,0 +1,1 @@
+export { default } from 'rsg-components/Markdown/Pre/PreRenderer';

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] = `
 
-<p class="rsg--para-13">
+<p class="rsg--para-11">
   pizza
 </p>
 
@@ -10,9 +10,9 @@ exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] =
 
 exports[`Markdown should render Markdown in span in inline mode 1`] = `
 
-<span class="rsg--text-23 rsg--inheritSize-24 rsg--baseColor-28">
+<span class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26">
   Hello
-  <em class="rsg--text-23 rsg--inheritSize-24 rsg--baseColor-28 rsg--em-30">
+  <em class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26 rsg--em-28">
     world
   </em>
   !
@@ -23,28 +23,28 @@ exports[`Markdown should render Markdown in span in inline mode 1`] = `
 exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 <div>
-  <div class="rsg--spacing-15">
-    <h1 class="rsg--heading-16 rsg--heading1-17">
+  <div class="rsg--spacing-13">
+    <h1 class="rsg--heading-14 rsg--heading1-15">
       Header
     </h1>
   </div>
-  <p class="rsg--para-13">
+  <p class="rsg--para-11">
     Text with
-    <em class="rsg--text-23 rsg--inheritSize-24 rsg--baseColor-28 rsg--em-30">
+    <em class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26 rsg--em-28">
       some
     </em>
-    <strong class="rsg--text-23 rsg--inheritSize-24 rsg--baseColor-28 rsg--strong-31">
+    <strong class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26 rsg--strong-29">
       formatting
     </strong>
     and a
     <a href="/foo"
-       class="rsg--link-14"
+       class="rsg--link-12"
     >
       link
     </a>
     .
   </p>
-  <p class="rsg--para-13">
+  <p class="rsg--para-11">
     <img alt="Image"
          src="/bar.png"
     >
@@ -56,7 +56,7 @@ exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 exports[`Markdown should render a blockquote 1`] = `
 
 <blockquote class="rsg--blockquote-36">
-  <p class="rsg--para-13">
+  <p class="rsg--para-11">
     This is a blockquote.
 And this is a second line.
   </p>
@@ -66,22 +66,22 @@ And this is a second line.
 
 exports[`Markdown should render check-lists correctly 1`] = `
 
-<ul class="rsg--list-33">
-  <li class="rsg--li-35">
+<ul class="rsg--list-31">
+  <li class="rsg--li-33">
     <input type="checkbox"
            class="rsg--input-2"
            readonly
     >
     list 1
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     <input type="checkbox"
            class="rsg--input-2"
            readonly
     >
     list 2
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     <input type="checkbox"
            class="rsg--input-2"
            checked
@@ -95,8 +95,8 @@ exports[`Markdown should render check-lists correctly 1`] = `
 
 exports[`Markdown should render code blocks without escaping 1`] = `
 
-<pre class="rsg--pre-5 rsg--para-1">
-  <code class="lang-html rsg--code-4">
+<pre class="rsg--pre-34">
+  <code class="lang-html rsg--code-35">
     <foo>
     </foo>
   </code>
@@ -107,33 +107,33 @@ exports[`Markdown should render code blocks without escaping 1`] = `
 exports[`Markdown should render headings correctly 1`] = `
 
 <div>
-  <div class="rsg--spacing-15">
-    <h1 class="rsg--heading-16 rsg--heading1-17">
+  <div class="rsg--spacing-13">
+    <h1 class="rsg--heading-14 rsg--heading1-15">
       one
     </h1>
   </div>
-  <div class="rsg--spacing-15">
-    <h2 class="rsg--heading-16 rsg--heading2-18">
+  <div class="rsg--spacing-13">
+    <h2 class="rsg--heading-14 rsg--heading2-16">
       two
     </h2>
   </div>
-  <div class="rsg--spacing-15">
-    <h3 class="rsg--heading-16 rsg--heading3-19">
+  <div class="rsg--spacing-13">
+    <h3 class="rsg--heading-14 rsg--heading3-17">
       three
     </h3>
   </div>
-  <div class="rsg--spacing-15">
-    <h4 class="rsg--heading-16 rsg--heading4-20">
+  <div class="rsg--spacing-13">
+    <h4 class="rsg--heading-14 rsg--heading4-18">
       four
     </h4>
   </div>
-  <div class="rsg--spacing-15">
-    <h5 class="rsg--heading-16 rsg--heading5-21">
+  <div class="rsg--spacing-13">
+    <h5 class="rsg--heading-14 rsg--heading5-19">
       five
     </h5>
   </div>
-  <div class="rsg--spacing-15">
-    <h6 class="rsg--heading-16 rsg--heading6-22">
+  <div class="rsg--spacing-13">
+    <h6 class="rsg--heading-14 rsg--heading6-20">
       six
     </h6>
   </div>
@@ -143,9 +143,9 @@ exports[`Markdown should render headings correctly 1`] = `
 
 exports[`Markdown should render inline code with escaping 1`] = `
 
-<p class="rsg--para-13">
+<p class="rsg--para-11">
   Foo
-  <code class="rsg--code-4">
+  <code class="rsg--code-35">
     &lt;bar&gt;
   </code>
   baz
@@ -155,10 +155,10 @@ exports[`Markdown should render inline code with escaping 1`] = `
 
 exports[`Markdown should render links 1`] = `
 
-<p class="rsg--para-13">
+<p class="rsg--para-11">
   a
   <a href="http://test.com"
-     class="rsg--link-14"
+     class="rsg--link-12"
   >
     link
   </a>
@@ -168,25 +168,25 @@ exports[`Markdown should render links 1`] = `
 
 exports[`Markdown should render mixed nested lists correctly 1`] = `
 
-<ul class="rsg--list-33">
-  <li class="rsg--li-35">
+<ul class="rsg--list-31">
+  <li class="rsg--li-33">
     list 1
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     list 2
-    <ol class="rsg--list-33 rsg--ordered-34">
-      <li class="rsg--li-35">
+    <ol class="rsg--list-31 rsg--ordered-32">
+      <li class="rsg--li-33">
         Sub-list
       </li>
-      <li class="rsg--li-35">
+      <li class="rsg--li-33">
         Sub-list
       </li>
-      <li class="rsg--li-35">
+      <li class="rsg--li-33">
         Sub-list
       </li>
     </ol>
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     list 3
   </li>
 </ul>
@@ -195,14 +195,14 @@ exports[`Markdown should render mixed nested lists correctly 1`] = `
 
 exports[`Markdown should render ordered lists correctly 1`] = `
 
-<ol class="rsg--list-33 rsg--ordered-34">
-  <li class="rsg--li-35">
+<ol class="rsg--list-31 rsg--ordered-32">
+  <li class="rsg--li-33">
     list
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     item
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     three
   </li>
 </ol>
@@ -211,14 +211,14 @@ exports[`Markdown should render ordered lists correctly 1`] = `
 
 exports[`Markdown should render unordered lists correctly 1`] = `
 
-<ul class="rsg--list-33">
-  <li class="rsg--li-35">
+<ul class="rsg--list-31">
+  <li class="rsg--li-33">
     list
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     item
   </li>
-  <li class="rsg--li-35">
+  <li class="rsg--li-33">
     three
   </li>
 </ul>

--- a/src/rsg-components/Name/NameRenderer.js
+++ b/src/rsg-components/Name/NameRenderer.js
@@ -4,9 +4,8 @@ import Code from 'rsg-components/Code';
 import Styled from 'rsg-components/Styled';
 import cx from 'classnames';
 
-export const styles = ({ fontFamily, fontSize, color }) => ({
+export const styles = ({ fontSize, color }) => ({
 	name: {
-		fontFamily: fontFamily.monospace,
 		fontSize: fontSize.small,
 		color: color.name,
 	},
@@ -20,7 +19,11 @@ export function NameRenderer({ classes, children, deprecated }) {
 	const classNames = cx(classes.name, {
 		[classes.isDeprecated]: deprecated,
 	});
-	return <Code className={classNames}>{children}</Code>;
+	return (
+		<span className={classNames}>
+			<Code>{children}</Code>
+		</span>
+	);
 }
 
 NameRenderer.propTypes = {

--- a/src/rsg-components/Name/__snapshots__/Name.spec.js.snap
+++ b/src/rsg-components/Name/__snapshots__/Name.spec.js.snap
@@ -1,17 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renderer should render argument name 1`] = `
-<Styled(Code)
+<span
   className="name"
 >
-  Foo
-</Styled(Code)>
+  <Styled(Code)>
+    Foo
+  </Styled(Code)>
+</span>
 `;
 
 exports[`renderer should render deprecated argument name 1`] = `
-<Styled(Code)
+<span
   className="name isDeprecated"
 >
-  Foo
-</Styled(Code)>
+  <Styled(Code)>
+    Foo
+  </Styled(Code)>
+</span>
 `;

--- a/src/rsg-components/Type/Type.spec.js
+++ b/src/rsg-components/Type/Type.spec.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { TypeRenderer } from './TypeRenderer';
+import { TypeRenderer, styles } from './TypeRenderer';
+
+const props = {
+	classes: classes(styles),
+};
 
 it('renderer should render type', () => {
-	const actual = shallow(<TypeRenderer classes={{}}>Array</TypeRenderer>);
+	const actual = shallow(<TypeRenderer {...props}>Array</TypeRenderer>);
 
 	expect(actual).toMatchSnapshot();
 });

--- a/src/rsg-components/Type/TypeRenderer.js
+++ b/src/rsg-components/Type/TypeRenderer.js
@@ -3,16 +3,19 @@ import PropTypes from 'prop-types';
 import Code from 'rsg-components/Code';
 import Styled from 'rsg-components/Styled';
 
-const styles = ({ fontFamily, fontSize, color }) => ({
+export const styles = ({ fontSize, color }) => ({
 	type: {
-		fontFamily: fontFamily.monospace,
 		fontSize: fontSize.small,
 		color: color.type,
 	},
 });
 
 export function TypeRenderer({ classes, children }) {
-	return <Code className={classes.type}>{children}</Code>;
+	return (
+		<span className={classes.type}>
+			<Code>{children}</Code>
+		</span>
+	);
 }
 
 TypeRenderer.propTypes = {

--- a/src/rsg-components/Type/__snapshots__/Type.spec.js.snap
+++ b/src/rsg-components/Type/__snapshots__/Type.spec.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renderer should render type 1`] = `
-<Styled(Code)>
-  Array
-</Styled(Code)>
+<span
+  className="type"
+>
+  <Styled(Code)>
+    Array
+  </Styled(Code)>
+</span>
 `;


### PR DESCRIPTION
... to allow easier overriding by consumers of Markdown components.

* Support both escaped and non-escaped code blocks
* Introduce Markdown > Pre component also for preformatted code