### PR TITLE
Fix broken fragment link to editorConfig settings

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,7 +14,7 @@ By default, Styleguidist will look for `styleguide.config.js` file in your proje
 * [`configureServer`](#configureserver)
 * [`dangerouslyUpdateWebpackConfig`](#dangerouslyupdatewebpackconfig)
 * [`defaultExample`](#defaultexample)
-* [`editorConfig`](#editorConfig)
+* [`editorConfig`](#editorconfig)
 * [`getComponentPathLine`](#getcomponentpathline)
 * [`getExampleFilename`](#getexamplefilename)
 * [`handlers`](#handlers)


### PR DESCRIPTION
The current link is in camelCase which means that the link to `editorConfig` on this page https://react-styleguidist.js.org/docs/configuration.html doesn't work.  This PR normalises the case to `editorconfig`, allowing the [link](https://react-styleguidist.js.org/docs/configuration.html#editorconfig) to work.
