### PR TITLE
Use editorConfig.theme for CodeMirror theme

### DIFF
--- a/loaders/styleguide-loader.js
+++ b/loaders/styleguide-loader.js
@@ -16,7 +16,6 @@ const slugger = require('./utils/slugger');
 // Config options that should be passed to the client
 const CLIENT_CONFIG_OPTIONS = [
 	'title',
-	'highlightTheme',
 	'showCode',
 	'showUsage',
 	'showSidebar',

--- a/scripts/__tests__/__snapshots__/make-webpack-config.spec.js.snap
+++ b/scripts/__tests__/__snapshots__/make-webpack-config.spec.js.snap
@@ -66,7 +66,9 @@ Object {
   "plugins": Array [
     StyleguidistOptionsPlugin {
       "options": Object {
-        "highlightTheme": "hl-theme",
+        "editorConfig": Object {
+          "theme": "hl-theme",
+        },
         "require": Array [],
         "styleguideDir": "~/scripts/__tests__",
         "template": "template.html",
@@ -133,7 +135,9 @@ Object {
   "plugins": Array [
     StyleguidistOptionsPlugin {
       "options": Object {
-        "highlightTheme": "hl-theme",
+        "editorConfig": Object {
+          "theme": "hl-theme",
+        },
         "require": Array [],
         "styleguideDir": "~/scripts/__tests__",
         "template": "template.html",
@@ -215,5 +219,12 @@ Object {
       ".json",
     ],
   },
+}
+`;
+
+exports[`should use editorConfig theme over highlightTheme 1`] = `
+Object {
+  "rsg-codemirror-theme.css": "codemirror/theme/hl-theme.css",
+  "rsg-components": "~/lib/rsg-components",
 }
 `;

--- a/scripts/__tests__/make-webpack-config.spec.js
+++ b/scripts/__tests__/make-webpack-config.spec.js
@@ -4,7 +4,9 @@ import makeWebpackConfig from '../make-webpack-config';
 const styleguideConfig = {
 	styleguideDir: __dirname,
 	require: [],
-	highlightTheme: 'hl-theme',
+	editorConfig: {
+		theme: 'hl-theme',
+	},
 	title: 'Style Guide',
 	template: 'template.html',
 };
@@ -31,6 +33,14 @@ it('should prepend requires as webpack entries', () => {
 		'development'
 	);
 	expect(result.entry).toMatchSnapshot();
+});
+
+it('should use editorConfig theme over highlightTheme', () => {
+	const result = makeWebpackConfig(
+		{ ...styleguideConfig, highlightTheme: 'deprecated' },
+		'development'
+	);
+	expect(result.resolve.alias).toMatchSnapshot();
 });
 
 it('should enable verbose mode in CleanWebpackPlugin', () => {

--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -31,7 +31,7 @@ module.exports = function(config, env) {
 		resolve: {
 			extensions: ['.js', '.jsx', '.json'],
 			alias: {
-				'rsg-codemirror-theme.css': `codemirror/theme/${config.highlightTheme}.css`,
+				'rsg-codemirror-theme.css': `codemirror/theme/${config.editorConfig.theme}.css`,
 			},
 		},
 		plugins: [


### PR DESCRIPTION
This fixes #788 by firstly testing for `editorConfig.theme` in the config and using that if present.  This falls back to using `highlightTheme` (deprecated) so backwards compatibility is assured.