### PR TITLE
Refactor: Introduce Input component to render in Markdown. #613

### DIFF
--- a/src/rsg-components/Markdown/Input/Input.spec.js
+++ b/src/rsg-components/Markdown/Input/Input.spec.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Input from './index';
+
+describe('Markdown Input', () => {
+	it('should render an input with the specified type', () => {
+		const actual = render(<Input type="checkbox" />);
+
+		expect(actual).toMatchSnapshot();
+	});
+});

--- a/src/rsg-components/Markdown/Input/InputRenderer.js
+++ b/src/rsg-components/Markdown/Input/InputRenderer.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Styled from 'rsg-components/Styled';
+
+const styles = () => ({
+	input: {
+		isolate: false,
+		display: 'inline-block',
+		verticalAlign: 'middle',
+	},
+});
+
+export function InputRenderer({ classes, ...rest }) {
+	return <input {...rest} className={classes.input} />;
+}
+InputRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+};
+
+export default Styled(styles)(InputRenderer);

--- a/src/rsg-components/Markdown/Input/__snapshots__/Input.spec.js.snap
+++ b/src/rsg-components/Markdown/Input/__snapshots__/Input.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Markdown Input should render an input with the specified type 1`] = `
+<input
+  class="rsg--input-0"
+  type="checkbox"
+/>
+`;

--- a/src/rsg-components/Markdown/Input/index.js
+++ b/src/rsg-components/Markdown/Input/index.js
@@ -1,0 +1,1 @@
+export { default } from 'rsg-components/Markdown/Input/InputRenderer';

--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -11,6 +11,7 @@ import List from 'rsg-components/Markdown/List';
 import Blockquote from 'rsg-components/Markdown/Blockquote';
 import Pre from 'rsg-components/Markdown/Pre';
 import Code from 'rsg-components/Code';
+import Input from 'rsg-components/Markdown/Input';
 
 // We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
 // That way we could avoid clashes between our loaders and user loaders.
@@ -102,6 +103,9 @@ const getBaseOverrides = memoize(classes => {
 		pre: {
 			component: Pre,
 		},
+		input: {
+			component: Input,
+		},
 	};
 }, () => 'getBaseOverrides');
 
@@ -124,11 +128,6 @@ const styles = ({ space, fontFamily, fontSize, color }) => ({
 		fontSize: 'inherit',
 	},
 	para: paraStyles({ space, color, fontFamily }).para,
-	input: {
-		isolate: false,
-		display: 'inline-block',
-		verticalAlign: 'middle',
-	},
 	hr: {
 		composes: '$para',
 		borderWidth: [[0, 0, 1, 0]],

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] = `
 
-<p class="rsg--para-11">
+<p class="rsg--para-10">
   pizza
 </p>
 
@@ -10,9 +10,9 @@ exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] =
 
 exports[`Markdown should render Markdown in span in inline mode 1`] = `
 
-<span class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26">
+<span class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25">
   Hello
-  <em class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26 rsg--em-28">
+  <em class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25 rsg--em-27">
     world
   </em>
   !
@@ -23,28 +23,28 @@ exports[`Markdown should render Markdown in span in inline mode 1`] = `
 exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 <div>
-  <div class="rsg--spacing-13">
-    <h1 class="rsg--heading-14 rsg--heading1-15">
+  <div class="rsg--spacing-12">
+    <h1 class="rsg--heading-13 rsg--heading1-14">
       Header
     </h1>
   </div>
-  <p class="rsg--para-11">
+  <p class="rsg--para-10">
     Text with
-    <em class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26 rsg--em-28">
+    <em class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25 rsg--em-27">
       some
     </em>
-    <strong class="rsg--text-21 rsg--inheritSize-22 rsg--baseColor-26 rsg--strong-29">
+    <strong class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25 rsg--strong-28">
       formatting
     </strong>
     and a
     <a href="/foo"
-       class="rsg--link-12"
+       class="rsg--link-11"
     >
       link
     </a>
     .
   </p>
-  <p class="rsg--para-11">
+  <p class="rsg--para-10">
     <img alt="Image"
          src="/bar.png"
     >
@@ -56,7 +56,7 @@ exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 exports[`Markdown should render a blockquote 1`] = `
 
 <blockquote class="rsg--blockquote-36">
-  <p class="rsg--para-11">
+  <p class="rsg--para-10">
     This is a blockquote.
 And this is a second line.
   </p>
@@ -66,26 +66,26 @@ And this is a second line.
 
 exports[`Markdown should render check-lists correctly 1`] = `
 
-<ul class="rsg--list-31">
-  <li class="rsg--li-33">
+<ul class="rsg--list-30">
+  <li class="rsg--li-32">
     <input type="checkbox"
-           class="rsg--input-2"
            readonly
+           class="rsg--input-33"
     >
     list 1
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     <input type="checkbox"
-           class="rsg--input-2"
            readonly
+           class="rsg--input-33"
     >
     list 2
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     <input type="checkbox"
-           class="rsg--input-2"
            checked
            readonly
+           class="rsg--input-33"
     >
     list 3
   </li>
@@ -107,33 +107,33 @@ exports[`Markdown should render code blocks without escaping 1`] = `
 exports[`Markdown should render headings correctly 1`] = `
 
 <div>
-  <div class="rsg--spacing-13">
-    <h1 class="rsg--heading-14 rsg--heading1-15">
+  <div class="rsg--spacing-12">
+    <h1 class="rsg--heading-13 rsg--heading1-14">
       one
     </h1>
   </div>
-  <div class="rsg--spacing-13">
-    <h2 class="rsg--heading-14 rsg--heading2-16">
+  <div class="rsg--spacing-12">
+    <h2 class="rsg--heading-13 rsg--heading2-15">
       two
     </h2>
   </div>
-  <div class="rsg--spacing-13">
-    <h3 class="rsg--heading-14 rsg--heading3-17">
+  <div class="rsg--spacing-12">
+    <h3 class="rsg--heading-13 rsg--heading3-16">
       three
     </h3>
   </div>
-  <div class="rsg--spacing-13">
-    <h4 class="rsg--heading-14 rsg--heading4-18">
+  <div class="rsg--spacing-12">
+    <h4 class="rsg--heading-13 rsg--heading4-17">
       four
     </h4>
   </div>
-  <div class="rsg--spacing-13">
-    <h5 class="rsg--heading-14 rsg--heading5-19">
+  <div class="rsg--spacing-12">
+    <h5 class="rsg--heading-13 rsg--heading5-18">
       five
     </h5>
   </div>
-  <div class="rsg--spacing-13">
-    <h6 class="rsg--heading-14 rsg--heading6-20">
+  <div class="rsg--spacing-12">
+    <h6 class="rsg--heading-13 rsg--heading6-19">
       six
     </h6>
   </div>
@@ -143,7 +143,7 @@ exports[`Markdown should render headings correctly 1`] = `
 
 exports[`Markdown should render inline code with escaping 1`] = `
 
-<p class="rsg--para-11">
+<p class="rsg--para-10">
   Foo
   <code class="rsg--code-35">
     &lt;bar&gt;
@@ -155,10 +155,10 @@ exports[`Markdown should render inline code with escaping 1`] = `
 
 exports[`Markdown should render links 1`] = `
 
-<p class="rsg--para-11">
+<p class="rsg--para-10">
   a
   <a href="http://test.com"
-     class="rsg--link-12"
+     class="rsg--link-11"
   >
     link
   </a>
@@ -168,25 +168,25 @@ exports[`Markdown should render links 1`] = `
 
 exports[`Markdown should render mixed nested lists correctly 1`] = `
 
-<ul class="rsg--list-31">
-  <li class="rsg--li-33">
+<ul class="rsg--list-30">
+  <li class="rsg--li-32">
     list 1
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     list 2
-    <ol class="rsg--list-31 rsg--ordered-32">
-      <li class="rsg--li-33">
+    <ol class="rsg--list-30 rsg--ordered-31">
+      <li class="rsg--li-32">
         Sub-list
       </li>
-      <li class="rsg--li-33">
+      <li class="rsg--li-32">
         Sub-list
       </li>
-      <li class="rsg--li-33">
+      <li class="rsg--li-32">
         Sub-list
       </li>
     </ol>
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     list 3
   </li>
 </ul>
@@ -195,14 +195,14 @@ exports[`Markdown should render mixed nested lists correctly 1`] = `
 
 exports[`Markdown should render ordered lists correctly 1`] = `
 
-<ol class="rsg--list-31 rsg--ordered-32">
-  <li class="rsg--li-33">
+<ol class="rsg--list-30 rsg--ordered-31">
+  <li class="rsg--li-32">
     list
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     item
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     three
   </li>
 </ol>
@@ -211,14 +211,14 @@ exports[`Markdown should render ordered lists correctly 1`] = `
 
 exports[`Markdown should render unordered lists correctly 1`] = `
 
-<ul class="rsg--list-31">
-  <li class="rsg--li-33">
+<ul class="rsg--list-30">
+  <li class="rsg--li-32">
     list
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     item
   </li>
-  <li class="rsg--li-33">
+  <li class="rsg--li-32">
     three
   </li>
 </ul>


### PR DESCRIPTION
So that it easier is for consumers to customize their styleguide by replacing Markdown components.