### PR TITLE
Add limited support for named exports. Add docs relating to this support.

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -48,74 +48,116 @@ Styleguidist _loads_ your components and _exposes_ them globally for your exampl
 
 ### Identifier
 
-It will try to use the `displayName` of your component as the identifier.
+It will try to use the `displayName` of your component as the identifier. If it cannot understand a `displayName` (for example if it is dynamically generated), it will fall back to something it can understand.
+
+<table>
+  <tr>
+    <th>Path</th>
+    <th>Code</th>
+    <th>displayName</th>
+    <th>Fallback</th>
+    <th>Global identifier</th>
+  </tr>
+  <tr>
+    <td>/component.js</td>
+    <td>
+      <pre style="margin:0;">export default function Component() { ... }</pre>
+    </td>
+    <td>Component</td>
+    <td>-</td>
+    <td>Component</td>
+  </tr>
+  <tr>
+    <td>/component.js</td>
+    <td>
+      <pre style="margin:0;">
+export default function Component() { ... }
+Component.displayName = 'SomeName';</pre>
+    </td>
+    <td>SomeName</td>
+    <td>-</td>
+    <td>SomeName</td>
+  </tr>
+  <tr>
+    <td>/component.js</td>
+    <td>
+      <pre style="margin:0;">
+export default function Component() { ... }
+Component.displayName = dynamicNamer();</pre>
+    </td>
+    <td>Component
+    </td>
+    <td>- </td>
+    <td>Component</td>
+  </tr>
+  <tr>
+    <td>/component.js</td>
+    <td>
+      <pre style="margin:0;">
+const name = 'Component';
+const componentMap = {
+  [name]: function() { ... }
+};
+export default componentMap[name];</pre>
+    </td>
+    <td>Cannot understand</td>
+    <td>File name</td>
+    <td>Component</td>
+  </tr>
+  <tr>
+    <td>/component/index.js</td>
+    <td>
+      <pre style="margin:0;">
+const name = 'Component';
+const componentMap = {
+  [name]: function() { ... }
+};
+export default componentMap[name];</pre>
+    </td>
+    <td>Cannot understand</td>
+    <td>Folder name</td>
+    <td>Component</td>
+  </tr>
+</table>
+
+
+### Default vs named exports
+
+Stylegudist will use an ECMAScript module’s `default` export or CommonJS `module.exports` if they are defined.
 
 ```javascript
-// /path/to/component-one.js
+// /component.js
 export default function Component() { ... }
 // will be exposed globally as Component
 
-// /path/to/component-two.js
-export default function Component() { ... }
-Component.displayName = 'ComponentTwo'
-// will be exposed globally as ComponentTwo
+// /component.js
+function Component() { ... }
+module.exports = Component;
+// will be exposed globally as Component
 ```
 
-If it cannot understand a `displayName` (for example if it is dynamically generated), it will fall back to something it can understand.
-
-```javascript
-// /path/to/component-three.js
-export default function Component() { ... }
-Component.displayName = getDisplayName() // can't understand this
-// will fall back to the name at declaration and expose globally as Component
-
-// /path/to/component-four.js
-const name = 'Component';
-const componentMap = {
-  [name]: function() { ... } // can't understand this
-}
-export default componentMap[name]; // can't understand this either
-// will fall back on the file name, convert it to PascalCase
-// and expose globally as ComponentFour
-```
-
-### default vs named exports
-
-Styleguidist defaults to exposing the `default` export from your component file. It understands functions exported as CommonJs `module.exports` as default exports.
-
-```javascript
-// /path/to/component-five.js
-export default function ComponentFive() { ... }
-// will be exposed globally as ComponentFive
-
-// /path/to/component-six.js
-function ComponentSix() { ... }
-module.exports = ComponentSix;
-// will be exposed globally as ComponentSix
-```
-
-If you do not use `default` exports, Styleguidist will expose named exports from modules as follows...
+If you use only named exports, Styleguidist will expose named exports from modules as follows...
 
 If there is only one named export, it will expose that.
 
 ```javascript
-// /path/to/component-seven.js
-export function ComponentSeven() { ... }
-// will be exposed globally as ComponentSeven
+// /component.js
+export function Component() { ... }
+// will be exposed globally as Component
 ```
 
 If there are several named exports, it will expose the named export which has the same name as the understood identifier.
 
 ```javascript
-// /path/to/component-eight.js
+// /component.js
 export function someUtil() { ... }
 // will not be exposed
 
-export function ComponentEight() { ... }
-// will be exposed globally as ComponentEight
+export function Component() { ... }
+// will be exposed globally as Component
 ```
 
-If you export several React components as named exports from a single module, Styleguidist is likely to behave unreliably. If it cannot understand which named export to expose, it will fall back to exposing the module as a whole.
+If you export several React components as named exports from a single module, Styleguidist is likely to behave unreliably. If it cannot understand which named export to expose, you may not be able to access that export.
 
 ## Sections
 

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -50,75 +50,15 @@ Styleguidist _loads_ your components and _exposes_ them globally for your exampl
 
 It will try to use the `displayName` of your component as the identifier. If it cannot understand a `displayName` (for example if it is dynamically generated), it will fall back to something it can understand.
 
-<table>
-  <tr>
-    <th>Path</th>
-    <th>Code</th>
-    <th>displayName</th>
-    <th>Fallback</th>
-    <th>Global identifier</th>
-  </tr>
-  <tr>
-    <td>/component.js</td>
-    <td>
-      <pre style="margin:0;">export default function Component() { ... }</pre>
-    </td>
-    <td>Component</td>
-    <td>-</td>
-    <td>Component</td>
-  </tr>
-  <tr>
-    <td>/component.js</td>
-    <td>
-      <pre style="margin:0;">
-export default function Component() { ... }
-Component.displayName = 'SomeName';</pre>
-    </td>
-    <td>SomeName</td>
-    <td>-</td>
-    <td>SomeName</td>
-  </tr>
-  <tr>
-    <td>/component.js</td>
-    <td>
-      <pre style="margin:0;">
-export default function Component() { ... }
-Component.displayName = dynamicNamer();</pre>
-    </td>
-    <td>Component
-    </td>
-    <td>- </td>
-    <td>Component</td>
-  </tr>
-  <tr>
-    <td>/component.js</td>
-    <td>
-      <pre style="margin:0;">
-const name = 'Component';
-const componentMap = {
-  [name]: function() { ... }
-};
-export default componentMap[name];</pre>
-    </td>
-    <td>Cannot understand</td>
-    <td>File name</td>
-    <td>Component</td>
-  </tr>
-  <tr>
-    <td>/component/index.js</td>
-    <td>
-      <pre style="margin:0;">
-const name = 'Component';
-const componentMap = {
-  [name]: function() { ... }
-};
-export default componentMap[name];</pre>
-    </td>
-    <td>Cannot understand</td>
-    <td>Folder name</td>
-    <td>Component</td>
-  </tr>
-</table>
+In each of the following cases, the global identifier will be `Component`.
+
+| Path | Code | Styleguidist understands |
+| ---- | ---- | ------------------------ |
+| /whatever.js | `export default function Component() { ... }` | displayName |
+| /whatever.js | `export default function SomeName() { ... }`<br>`SomeName.displayName = 'Component';` | displayName |
+| /whatever.js | `export default function Component() { ... }`<br>`Component.displayName = dynamicNamer();` | displayName at declaration
+| /component.js | `const name = 'SomeName';`<br>`const componentMap = {`<br>`[name]: function() { ... }`<br>`};`<br>`export default componentMap[name];` | File name |
+| /component/index.js | `const name = 'SomeName';`<br>`const componentMap = {`<br>`[name]: function() { ... }`<br>`};`<br>`export default componentMap[name];` | Folder name |
 
 
 ### Default vs named exports

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -5,6 +5,7 @@
 <!-- toc -->
 
 * [Finding components](#finding-components)
+* [Loading and exposing components](#loading-and-exposing-components)
 * [Sections](#sections)
 * [Limitations](#limitations)
 
@@ -40,6 +41,81 @@ module.exports = {
 > **Note:** Use [ignore](Configuration.md#ignore) option to exclude some files from the style guide.
 
 > **Note:** Use [getComponentPathLine](Configuration.md#getcomponentpathline) option to change a path you see below a component name.
+
+## Loading and exposing components
+
+Styleguidist _loads_ your components and _exposes_ them globally for your examples to consume.
+
+### Identifier
+
+It will try to use the `displayName` of your component as the identifier.
+
+```javascript
+// /path/to/component-one.js
+export default function Component() { ... }
+// will be exposed globally as Component
+
+// /path/to/component-two.js
+export default function Component() { ... }
+Component.displayName = 'ComponentTwo'
+// will be exposed globally as ComponentTwo
+```
+
+If it cannot understand a `displayName` (for example if it is dynamically generated), it will fall back to something it can understand.
+
+```javascript
+// /path/to/component-three.js
+export default function Component() { ... }
+Component.displayName = getDisplayName() // can't understand this
+// will fall back to the name at declaration and expose globally as Component
+
+// /path/to/component-four.js
+const name = 'Component';
+const componentMap = {
+  [name]: function() { ... } // can't understand this
+}
+export default componentMap[name]; // can't understand this either
+// will fall back on the file name, convert it to PascalCase
+// and expose globally as ComponentFour
+```
+
+### default vs named exports
+
+Styleguidist defaults to exposing the `default` export from your component file. It understands functions exported as CommonJs `module.exports` as default exports.
+
+```javascript
+// /path/to/component-five.js
+export default function ComponentFive() { ... }
+// will be exposed globally as ComponentFive
+
+// /path/to/component-six.js
+function ComponentSix() { ... }
+module.exports = ComponentSix;
+// will be exposed globally as ComponentSix
+```
+
+If you do not use `default` exports, Styleguidist will expose named exports from modules as follows...
+
+If there is only one named export, it will expose that.
+
+```javascript
+// /path/to/component-seven.js
+export function ComponentSeven() { ... }
+// will be exposed globally as ComponentSeven
+```
+
+If there are several named exports, it will expose the named export which has the same name as the understood identifier.
+
+```javascript
+// /path/to/component-eight.js
+export function someUtil() { ... }
+// will not be exposed
+
+export function ComponentEight() { ... }
+// will be exposed globally as ComponentEight
+```
+
+If you export several React components as named exports from a single module, Styleguidist is likely to behave unreliably. If it cannot understand which named export to expose, it will fall back to exposing the module as a whole.
 
 ## Sections
 

--- a/docs/Thirdparties.md
+++ b/docs/Thirdparties.md
@@ -17,7 +17,7 @@
 
 ## How Styleguidist works
 
-Styleguidist always uses the default export to _load_ your components but it uses [react-docgen](https://github.com/reactjs/react-docgen) to _generate documentation_ which may require changes in your code to work properly.
+Styleguidist _loads_ your components (see [Loading and exposing components](Components.md#loading-and-exposing-components) for more) but it uses [react-docgen](https://github.com/reactjs/react-docgen) to _generate documentation_ which may require changes in your code to work properly.
 
 React-docgen reads your components as static text files and looks for patterns like class or function declarations that looks like React components. It does not run any JavaScript code, so, if your component is dynamically generated, is wrapped in a higher-order component, or is split into several files, then react-docgen may not understand it.
 

--- a/src/utils/__mocks__/getComponent.js
+++ b/src/utils/__mocks__/getComponent.js
@@ -1,3 +1,0 @@
-export const returnValue = 'You called getComponent';
-
-export default jest.fn(() => returnValue);

--- a/src/utils/__mocks__/getComponent.js
+++ b/src/utils/__mocks__/getComponent.js
@@ -1,0 +1,3 @@
+export const returnValue = 'You called getComponent';
+
+export default jest.fn(() => returnValue);

--- a/src/utils/__tests__/getComponent.spec.js
+++ b/src/utils/__tests__/getComponent.spec.js
@@ -1,0 +1,37 @@
+import getComponent from '../getComponent';
+
+describe('getComponent', () => {
+	describe('if there is no default export in the module', () => {
+		describe('if there is only one named export in the module', () => {
+			it('should return that', () => {
+				const module = { oneNamedExport: 'isLonely' };
+				const actual = getComponent(module);
+				expect(actual).toBe(module.oneNamedExport);
+			});
+		});
+		describe('if there is a named export whose name matches the name argument', () => {
+			it('should return that', () => {
+				const name = 'Component';
+				const module = { [name]: 'isNamed', OtherComponent: 'isAlsoNamed' };
+				const actual = getComponent(module, name);
+				expect(actual).toBe(module[name]);
+			});
+		});
+		describe('if there is more than one named export and no matching name', () => {
+			it('should fall back on returning the module as a whole', () => {
+				const name = 'Component';
+				const module = { RandomName: 'isNamed', confusingExport: 123 };
+				const actual = getComponent(module, name);
+				expect(actual).toBe(module);
+			});
+		});
+	});
+
+	describe('if there is a default export', () => {
+		it('should return that', () => {
+			const module = { default: 'useMe' };
+			const actual = getComponent(module);
+			expect(actual).toBe(module.default);
+		});
+	});
+});

--- a/src/utils/__tests__/getComponent.spec.js
+++ b/src/utils/__tests__/getComponent.spec.js
@@ -1,37 +1,47 @@
 import getComponent from '../getComponent';
 
 describe('getComponent', () => {
-	describe('if there is no default export in the module', () => {
-		describe('if there is only one named export in the module', () => {
-			it('should return that', () => {
-				const module = { oneNamedExport: 'isLonely' };
-				const actual = getComponent(module);
-				expect(actual).toBe(module.oneNamedExport);
-			});
-		});
-		describe('if there is a named export whose name matches the name argument', () => {
-			it('should return that', () => {
-				const name = 'Component';
-				const module = { [name]: 'isNamed', OtherComponent: 'isAlsoNamed' };
-				const actual = getComponent(module, name);
-				expect(actual).toBe(module[name]);
-			});
-		});
-		describe('if there is more than one named export and no matching name', () => {
-			it('should fall back on returning the module as a whole', () => {
-				const name = 'Component';
-				const module = { RandomName: 'isNamed', confusingExport: 123 };
-				const actual = getComponent(module, name);
-				expect(actual).toBe(module);
-			});
-		});
-	});
-
-	describe('if there is a default export', () => {
+	describe('if there is a default export in the module', () => {
 		it('should return that', () => {
 			const module = { default: 'useMe' };
 			const actual = getComponent(module);
 			expect(actual).toBe(module.default);
+		});
+	});
+
+	describe('if it is a CommonJS module and exports a function', () => {
+		it('should return the module', () => {
+			const testCases = [() => {}, function() {}, class Class {}];
+			testCases.forEach(testCase => {
+				const actual = getComponent(testCase);
+				expect(actual).toBe(testCase);
+			});
+		});
+	});
+
+	describe('if there is only one named export in the module', () => {
+		it('should return that', () => {
+			const module = { oneNamedExport: 'isLonely' };
+			const actual = getComponent(module);
+			expect(actual).toBe(module.oneNamedExport);
+		});
+	});
+
+	describe('if there is a named export whose name matches the name argument', () => {
+		it('should return that', () => {
+			const name = 'Component';
+			const module = { [name]: 'isNamed', OtherComponent: 'isAlsoNamed' };
+			const actual = getComponent(module, name);
+			expect(actual).toBe(module[name]);
+		});
+	});
+
+	describe('if there is more than one named export and no matching name', () => {
+		it('should fall back on returning the module as a whole', () => {
+			const name = 'Component';
+			const module = { RandomName: 'isNamed', confusingExport: 123 };
+			const actual = getComponent(module, name);
+			expect(actual).toBe(module);
 		});
 	});
 });

--- a/src/utils/__tests__/globalizeComponent.spec.js
+++ b/src/utils/__tests__/globalizeComponent.spec.js
@@ -1,5 +1,4 @@
 import globalizeComponent from '../globalizeComponent';
-import getComponent from '../getComponent';
 
 const component = { module: 'someModule', name: 'SomeName' };
 
@@ -12,11 +11,6 @@ describe('globalizeComponent', () => {
 		expect(global[component.name]).toBeUndefined();
 		globalizeComponent({});
 		expect(global[component.name]).toBeUndefined();
-	});
-
-	it('should call the getComponent function with the correct arguments', () => {
-		globalizeComponent(component);
-		expect(getComponent).toHaveBeenCalledWith(component.module, component.name);
 	});
 
 	it('should set the return value of getComponent as a global variable', () => {

--- a/src/utils/__tests__/globalizeComponent.spec.js
+++ b/src/utils/__tests__/globalizeComponent.spec.js
@@ -1,18 +1,25 @@
 import globalizeComponent from '../globalizeComponent';
 
+jest.mock('../getComponent');
+// eslint-disable-next-line import/first
+import getComponent, { returnValue } from '../getComponent';
+
+const component = { module: 'someModule', name: 'SomeName' };
+
 afterEach(() => {
-	delete global.Foo;
+	delete global[component.name];
 });
 
 describe('globalizeComponent', () => {
-	it('should set component’s module as a global variable', () => {
+	it('should call the getComponent function with the correct arguments', () => {
+		globalizeComponent(component);
+		expect(getComponent).toHaveBeenCalledWith(component.module, component.name);
+	});
+
+	it('should set the return value of getComponent as a global variable', () => {
 		const globalsCount = Object.keys(global).length;
-		globalizeComponent({
-			name: 'Foo',
-			props: {},
-			module: 13,
-		});
+		globalizeComponent(component);
 		expect(Object.keys(global).length).toBe(globalsCount + 1);
-		expect(global.Foo).toBe(13);
+		expect(global[component.name]).toBe(returnValue);
 	});
 });

--- a/src/utils/__tests__/globalizeComponent.spec.js
+++ b/src/utils/__tests__/globalizeComponent.spec.js
@@ -11,15 +11,20 @@ afterEach(() => {
 });
 
 describe('globalizeComponent', () => {
+	it('should not add anything as a global variable if there is no component name', () => {
+		expect(global[component.name]).toBeUndefined();
+		globalizeComponent({});
+		expect(global[component.name]).toBeUndefined();
+	});
+
 	it('should call the getComponent function with the correct arguments', () => {
 		globalizeComponent(component);
 		expect(getComponent).toHaveBeenCalledWith(component.module, component.name);
 	});
 
 	it('should set the return value of getComponent as a global variable', () => {
-		const globalsCount = Object.keys(global).length;
+		expect(global[component.name]).toBeUndefined();
 		globalizeComponent(component);
-		expect(Object.keys(global).length).toBe(globalsCount + 1);
 		expect(global[component.name]).toBe(returnValue);
 	});
 });

--- a/src/utils/__tests__/globalizeComponent.spec.js
+++ b/src/utils/__tests__/globalizeComponent.spec.js
@@ -1,16 +1,13 @@
 import globalizeComponent from '../globalizeComponent';
-
-jest.mock('../getComponent');
-// eslint-disable-next-line import/first
-import getComponent, { returnValue } from '../getComponent';
+import getComponent from '../getComponent';
 
 const component = { module: 'someModule', name: 'SomeName' };
 
-afterEach(() => {
-	delete global[component.name];
-});
-
 describe('globalizeComponent', () => {
+	afterEach(() => {
+		delete global[component.name];
+	});
+
 	it('should not add anything as a global variable if there is no component name', () => {
 		expect(global[component.name]).toBeUndefined();
 		globalizeComponent({});
@@ -25,6 +22,6 @@ describe('globalizeComponent', () => {
 	it('should set the return value of getComponent as a global variable', () => {
 		expect(global[component.name]).toBeUndefined();
 		globalizeComponent(component);
-		expect(global[component.name]).toBe(returnValue);
+		expect(global[component.name]).toBe(component.module);
 	});
 });

--- a/src/utils/getComponent.js
+++ b/src/utils/getComponent.js
@@ -1,21 +1,48 @@
 /**
  * Given a component module and a name,
  * return the appropriate export.
+ * See /docs/Components.md
  *
  * @param  {object} module
  * @param  {string} name
  * @return {function|object}
  */
 export default function getComponent(module, name) {
+	// If the module defines a default export, return that
+	// e.g.
+	// ```
+	// export default function Component() { ... }
+	// ```
 	if (module.default) {
 		return module.default;
 	}
+	// If it is a CommonJS module which exports a function, return that
+	// e.g.
+	// ```
+	// function Component() { ... }
+	// module.exports = Component;
+	// ```
 	if (!module.__esModule && typeof module === 'function') {
 		return module;
 	}
 	const moduleKeys = Object.keys(module);
+	// If the module exports just one named export, return that
+	// e.g.
+	// ```
+	// export function Component() { ... }
+	// ```
 	if (moduleKeys.length === 1) {
 		return module[moduleKeys[0]];
 	}
+	// If the module exports a named export with the same name as the
+	// understood Component identifier, return that
+	// e.g.
+	// ```
+	// // /component.js
+	// export function someUtil() { ... }
+	// export Component() { ... } // if identifier is Component, return this named export
+	// ```
+	//
+	// Else return the module itself
 	return module[name] || module;
 }

--- a/src/utils/getComponent.js
+++ b/src/utils/getComponent.js
@@ -11,19 +11,23 @@ export default function getComponent(module, name) {
 	//
 	// If the module defines a default export, return that
 	// e.g.
+	//
 	// ```
 	// export default function Component() { ... }
 	// ```
+	//
 	if (module.default) {
 		return module.default;
 	}
 
 	// If it is a CommonJS module which exports a function, return that
 	// e.g.
+	//
 	// ```
 	// function Component() { ... }
 	// module.exports = Component;
 	// ```
+	//
 	if (!module.__esModule && typeof module === 'function') {
 		return module;
 	}
@@ -31,9 +35,11 @@ export default function getComponent(module, name) {
 
 	// If the module exports just one named export, return that
 	// e.g.
+	//
 	// ```
 	// export function Component() { ... }
 	// ```
+	//
 	if (moduleKeys.length === 1) {
 		return module[moduleKeys[0]];
 	}
@@ -41,6 +47,7 @@ export default function getComponent(module, name) {
 	// If the module exports a named export with the same name as the
 	// understood Component identifier, return that
 	// e.g.
+	//
 	// ```
 	// // /component.js
 	// export function someUtil() { ... }
@@ -48,5 +55,6 @@ export default function getComponent(module, name) {
 	// ```
 	//
 	// Else return the module itself
+	//
 	return module[name] || module;
 }

--- a/src/utils/getComponent.js
+++ b/src/utils/getComponent.js
@@ -7,12 +7,15 @@
  * @return {function|object}
  */
 export default function getComponent(module, name) {
-	if (!module.default) {
-		const moduleKeys = Object.keys(module);
-		if (moduleKeys.length === 1) {
-			return module[moduleKeys[0]];
-		}
-		return module[name] || module;
+	if (module.default) {
+		return module.default;
 	}
-	return module.default;
+	if (!module.__esModule && typeof module === 'function') {
+		return module;
+	}
+	const moduleKeys = Object.keys(module);
+	if (moduleKeys.length === 1) {
+		return module[moduleKeys[0]];
+	}
+	return module[name] || module;
 }

--- a/src/utils/getComponent.js
+++ b/src/utils/getComponent.js
@@ -1,0 +1,18 @@
+/**
+ * Given a component module and a name,
+ * return the appropriate export.
+ *
+ * @param  {object} module
+ * @param  {string} name
+ * @return {function|object}
+ */
+export default function getComponent(module, name) {
+	if (!module.default) {
+		const moduleKeys = Object.keys(module);
+		if (moduleKeys.length === 1) {
+			return module[moduleKeys[0]];
+		}
+		return module[name] || module;
+	}
+	return module.default;
+}

--- a/src/utils/getComponent.js
+++ b/src/utils/getComponent.js
@@ -8,6 +8,7 @@
  * @return {function|object}
  */
 export default function getComponent(module, name) {
+	//
 	// If the module defines a default export, return that
 	// e.g.
 	// ```
@@ -16,6 +17,7 @@ export default function getComponent(module, name) {
 	if (module.default) {
 		return module.default;
 	}
+
 	// If it is a CommonJS module which exports a function, return that
 	// e.g.
 	// ```
@@ -26,6 +28,7 @@ export default function getComponent(module, name) {
 		return module;
 	}
 	const moduleKeys = Object.keys(module);
+
 	// If the module exports just one named export, return that
 	// e.g.
 	// ```
@@ -34,6 +37,7 @@ export default function getComponent(module, name) {
 	if (moduleKeys.length === 1) {
 		return module[moduleKeys[0]];
 	}
+
 	// If the module exports a named export with the same name as the
 	// understood Component identifier, return that
 	// e.g.

--- a/src/utils/globalizeComponent.js
+++ b/src/utils/globalizeComponent.js
@@ -1,3 +1,5 @@
+import getComponent from './getComponent';
+
 /**
  * Expose component as global variables.
  *
@@ -8,8 +10,5 @@ export default function globalizeComponent(component) {
 		return;
 	}
 
-	global[component.name] =
-		!component.props.path || component.props.path === 'default'
-			? component.module.default || component.module
-			: component.module[component.props.path];
+	global[component.name] = getComponent(component.module, component.name);
 }


### PR DESCRIPTION
### Summary

This responds to the need expressed in #820 and #633 

It preserves the base case of Styleguidist loading `default` exports by default, while adding some limited support for exposing named exports where a module exposes no default export and either:

- just one named export; or
- a named export which matches the component name understood by Styleguidist.

I think these cases are non-controversial. In each case, it is almost guaranteed that the developer intends these named exports to be interpreted as the exported component.

I have added documentation covering this. The documentation is careful to emphasise that this is not a complete solution for named exports - Styleguidist will do its best but in complicated cases will just fall back to exposing the module as a whole, as it currently does.

Super happy to take questions and feedback on this. I love what you guys are doing with this tool.

### Question

In the existing implementation of `globalizeComponent`, there are references to `component.props.path`. I couldn't get this property to show its face with a bunch of different configurations/attempts. I suspect maybe it's a legacy thing which is still hanging around.

If I'm missing something here please let me know and I'll take account of this in the PR.