### PR TITLE
add cypress tests for core and single component

### DIFF
--- a/cypress/integration/component_spec.js
+++ b/cypress/integration/component_spec.js
@@ -1,0 +1,100 @@
+describe('Single component', () => {
+	before(() => {
+		// Open simple button component in isolation
+		cy.visit('/#!/Button/1');
+	});
+
+	describe('props and methods section', () => {
+		beforeEach(() => {
+			cy
+				.get('button')
+				.contains('Props & methods')
+				.as('propsBtn');
+
+			cy
+				.get('@propsBtn')
+				.closest('[class^=rsg--tabs]')
+				.as('container');
+		});
+
+		it('is present', () => {
+			cy.get('@propsBtn').should('exist');
+		});
+
+		it('does not show table initially', () => {
+			cy
+				.get('@container')
+				.find('table')
+				.should('not.exist');
+		});
+
+		it('shows the table on button click', () => {
+			cy.get('@propsBtn').click();
+			cy
+				.get('@container')
+				.find('table')
+				.should('contain', 'Prop name');
+		});
+	});
+
+	describe('preview section', () => {
+		beforeEach(() => {
+			cy
+				.get('[class^=rsg--preview]')
+				.as('preview')
+				.closest('[class^=rsg--root]')
+				.as('container')
+				.find('button')
+				.contains('View Code')
+				.as('viewCodeBtn');
+		});
+
+		it('renders component preview', () => {
+			cy
+				.get('@preview')
+				.find('button', { timeout: 10000 })
+				.contains('Push Me')
+				.should('exist');
+		});
+
+		it('has view code button', () => {
+			cy.get('@viewCodeBtn').should('exist');
+		});
+
+		it('does not show code initially', () => {
+			cy
+				.get('@container')
+				.find('.CodeMirror')
+				.should('not.exist');
+		});
+
+		it('shows code on click', () => {
+			cy.get('@viewCodeBtn').click();
+			cy
+				.get('@container')
+				.find('.CodeMirror')
+				.should('exist');
+		});
+
+		it('changes the render after code change', () => {
+			cy
+				.get('@container')
+				.find('.CodeMirror textarea')
+				// CodeMirror actually listens to keystrokes on an empty textarea to update the div with the code
+				// so we have to hack our way around it with a bunch of backspacing, since there's no way to place the cursor
+				.type(
+					`{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace} Harder</Button>`,
+					{
+						force: true,
+					}
+				);
+			// need to wait for CodeMirror to update
+			cy.wait(500);
+			cy
+				.get('@preview')
+				.find('button')
+				.contains('Push Me Harder')
+				.should('exist');
+		});
+	});
+});

--- a/cypress/integration/core_spec.js
+++ b/cypress/integration/core_spec.js
@@ -1,0 +1,19 @@
+describe('Styleguidist core', () => {
+	beforeEach(() => cy.visit('/'));
+
+	it('loads the page', () => {
+		cy.title().should('include', 'React Styleguidist');
+	});
+
+	it('shows multiple components in normal mode', () => {
+		cy.get('[id$=container]').should('have.length.above', 1);
+	});
+
+	it('shows single component in isolated mode', () => {
+		cy
+			.get('[title="Open isolated"]')
+			.first()
+			.click();
+		cy.get('[id$=container]').should('have.length', 1);
+	});
+});

--- a/cypress/integration/initial_spec.js
+++ b/cypress/integration/initial_spec.js
@@ -1,6 +1,0 @@
-describe('Initial test suite', () => {
-	it('loads the page', () => {
-		cy.visit('/');
-		cy.title().should('include', 'React Styleguidist');
-	});
-});


### PR DESCRIPTION
Hey,

wrote up some integration tests with cypress (#776).
They feel a bit fragile, I don't like hooking up to css classes or text contents for testing, but I can't come up with better ways yet.

Had some pain with code editor, since the codemirror is using an empty hidden textarea behind the scenes to track keystrokes and update the divs with representation, so the test for this is a bit hacky.