### PR TITLE
Server now returns app instance and compiler instance

### DIFF
--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -122,7 +122,7 @@ function commandServer() {
 			const isHttps = compiler.options.devServer && compiler.options.devServer.https;
 			printInstructions(isHttps, config.serverHost, config.serverPort);
 		}
-	});
+	}).compiler;
 
 	verbose('Webpack config:', compiler.options);
 

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -89,29 +89,32 @@ The `Button` component will be available in every example without a need to `req
 
 ## How to dynamically load other components in an example?
 
-Although examples don't have direct access to webpack's `require.context` feature, you *can* use it in a separate helper file which you require in your example code. If you wanted to create an example to load and show all of your icon components, you could do this:
+Although examples don't have direct access to webpack's `require.context` feature, you _can_ use it in a separate helper file which you require in your example code. If you wanted to create an example to load and show all of your icon components, you could do this:
 
 ```jsx
 // load-icons.js
-const iconsContext = require.context('./icons/', true, /js$/);
-const icons = Object.keys(iconsContext).reduce( (icons, file) => {
-	const Icon = iconsContext(file).default;
-	const label = file.slice(2, -3); // strip './' and '.js'
-	icons[label] = Icon;
-	return icons;
-}, {});
+const iconsContext = require.context('./icons/', true, /js$/)
+const icons = Object.keys(iconsContext).reduce((icons, file) => {
+  const Icon = iconsContext(file).default
+  const label = file.slice(2, -3) // strip './' and '.js'
+  icons[label] = Icon
+  return icons
+}, {})
 
-export default icons;
+export default icons
 
 // IconGallery.md
-const icons = require('./load-icons').default;
+const icons = require('./load-icons').default
 
 const iconElements = Object.keys(icons).map(iconName => {
-  const Icon = icons[iconName];
-  return <span key={iconName}>{iconName}: {<Icon />}</span>;
-});
-
-<div>{iconElements}</div>
+  const Icon = icons[iconName]
+  return (
+    <span key={iconName}>
+      {iconName}: {<Icon />}
+    </span>
+  )
+})
+;<div>{iconElements}</div>
 ```
 
 ## How to set global styles for user components?

--- a/docs/Thirdparties.md
+++ b/docs/Thirdparties.md
@@ -188,12 +188,16 @@ First, you'll need to create your Wrapper component. For this example we'll put 
 // styleguide/ThemeWrapper.js
 
 import React, { Component } from 'react'
-import { ThemeProvider } from 'styled-components';
-import theme from 'where/your/theme/lives';
+import { ThemeProvider } from 'styled-components'
+import theme from 'where/your/theme/lives'
 
 export default class ThemeWrapper extends Component {
   render() {
-    return <ThemeProvider theme={theme}>{this.props.children}</ThemeProvider>
+    return (
+      <ThemeProvider theme={theme}>
+        {this.props.children}
+      </ThemeProvider>
+    )
   }
 }
 ```

--- a/scripts/__tests__/server.spec.js
+++ b/scripts/__tests__/server.spec.js
@@ -1,0 +1,24 @@
+import server from '../server';
+import getConfig from '../config';
+
+jest.mock('../create-server', () => () => {
+	return {
+		app: {
+			listen: (port, host, cb) => cb(),
+			close: cb => cb(),
+		},
+		compiler: {},
+	};
+});
+
+test('server should return an object containing a server instance', () => {
+	const config = getConfig();
+	const callback = jest.fn();
+	const serverInfo = server(config, callback);
+
+	expect(callback).toBeCalled();
+	expect(serverInfo.app).toBeTruthy();
+	expect(serverInfo.compiler).toBeTruthy();
+	expect(typeof serverInfo.app.listen).toBe('function');
+	expect(typeof serverInfo.app.close).toBe('function');
+});

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -36,7 +36,8 @@ module.exports = function(config) {
 		 * Start style guide dev server.
 		 *
 		 * @param {Function} callback callback(err, config).
-		 * @return {Compiler} Webpack Compiler instance.
+		 * @return {ServerInfo.App} Webpack-Dev-Server.
+		 * @return {ServerInfo.Compiler} Webpack Compiler instance.
 		 */
 		server(callback) {
 			return server(config, err => callback(err, config));

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -8,5 +8,5 @@ module.exports = function server(config, callback) {
 
 	serverInfo.app.listen(config.serverPort, config.serverHost, callback);
 
-	return serverInfo.compiler;
+	return serverInfo;
 };


### PR DESCRIPTION
This exposes both the compiler and the webpack-dev-server app. The reason behind this is so that wrappers built around react-stylguidist API can stop the dev server. 

Real World use case: I'm currently using this forked implementation to automatically capture screenshots for a component. StartServer => Redirect to Component => Capture Screenshot => Close Server.  Unfortunately, without these additions, there is no other way to close the server other than from exiting the process.