### PR TITLE
Fix broken link on the docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -392,7 +392,7 @@ module.exports = {
 
 See an example of [customized style guide](https://github.com/styleguidist/react-styleguidist/tree/master/examples/customised).
 
-If you want to wrap, rather than replace a component, make sure to import the default implementation using the full path to `react-styleguidist`. See an example of [wrapping a Styleguidist component](https://github.com/styleguidist/react-styleguidist/tree/master/examples/customised/styleguide/components/Sections).
+If you want to wrap, rather than replace a component, make sure to import the default implementation using the full path to `react-styleguidist`. See an example of [wrapping a Styleguidist component](https://github.com/styleguidist/react-styleguidist/tree/master/examples/customised/styleguide/components/Sections.js).
 
 **Note**: these components are not guaranteed to be safe from breaking changes in react-styleguidist updates.
 


### PR DESCRIPTION
This PR fixes a link which is returning a `404`.