### PR TITLE
Wrap Examples in Fragment

### DIFF
--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -119,7 +119,11 @@ export default class Preview extends Component {
 
 	compileCode(code) {
 		try {
-			return compileCode(code, this.context.config.compilerConfig);
+			const wrappedCode = `
+const __F = React.Fragment || <div />;
+<__F>${code}</__F>
+	`;
+			return compileCode(wrappedCode, this.context.config.compilerConfig);
 		} catch (err) {
 			this.handleError(err);
 		}


### PR DESCRIPTION
Here's a quick & dirty initial implementation to close #840 

![image](https://user-images.githubusercontent.com/244704/36619891-92d50fb8-18be-11e8-8d7f-1485c330da2c.png)

This wraps every example, but we could regex the error message and only wrap if we get the "adjacent JSX" error, but that seems like added complexity for not much gain.

If this implementation looks OK, I can add tests and close this out.

TODO:
 - [] Tests