### PR TITLE
refactor: introduce Table components for use in Markdown #613

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,6 +2024,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -4606,6 +4607,795 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6339,6 +7129,7 @@
             "anymatch": "1.3.2",
             "exec-sh": "0.2.1",
             "fb-watchman": "2.0.0",
+            "fsevents": "1.1.3",
             "minimatch": "3.0.4",
             "minimist": "1.2.0",
             "walker": "1.0.7",
@@ -6778,6 +7569,7 @@
             "anymatch": "1.3.2",
             "exec-sh": "0.2.1",
             "fb-watchman": "2.0.0",
+            "fsevents": "1.1.3",
             "minimatch": "3.0.4",
             "minimist": "1.2.0",
             "walker": "1.0.7",
@@ -7748,12 +8540,12 @@
       "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw="
     },
     "markdown-to-jsx": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.3.1.tgz",
-      "integrity": "sha1-cAZKKOxU5bOSch5EMRTPKBS46vE=",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.4.1.tgz",
+      "integrity": "sha1-lf5he1eQ/sb04DmaKW46LxD/+q0=",
       "requires": {
         "prop-types": "15.6.0",
-        "unquote": "1.1.0"
+        "unquote": "1.1.1"
       }
     },
     "math-expression-evaluator": {
@@ -8032,6 +8824,12 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "nan": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11459,9 +12257,9 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unquote": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.0.tgz",
-      "integrity": "sha1-mOH8YItrhUx1r7G5WvwJm6adlC8="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "upper-case": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.4",
     "lowercase-keys": "^1.0.0",
-    "markdown-to-jsx": "^6.3.1",
+    "markdown-to-jsx": "^6.4.1",
     "minimist": "^1.2.0",
     "ora": "^1.3.0",
     "prop-types": "^15.6.0",

--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -12,6 +12,7 @@ import Blockquote from 'rsg-components/Markdown/Blockquote';
 import Pre from 'rsg-components/Markdown/Pre';
 import Code from 'rsg-components/Code';
 import Checkbox from 'rsg-components/Markdown/Checkbox';
+import { Table, TableHead, TableCell } from 'rsg-components/Markdown/Table';
 
 // We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
 // That way we could avoid clashes between our loaders and user loaders.
@@ -106,6 +107,21 @@ const getBaseOverrides = memoize(classes => {
 		input: {
 			component: Checkbox,
 		},
+		table: {
+			component: Table,
+		},
+		thead: {
+			component: TableHead,
+		},
+		th: {
+			component: TableCell,
+			props: {
+				header: true,
+			},
+		},
+		td: {
+			component: TableCell,
+		},
 	};
 }, () => 'getBaseOverrides');
 
@@ -121,7 +137,7 @@ const getInlineOverrides = memoize(classes => {
 	};
 }, () => 'getInlineOverrides');
 
-const styles = ({ space, fontFamily, fontSize, color }) => ({
+const styles = ({ space, fontFamily, color }) => ({
 	base: {
 		color: color.base,
 		fontFamily: fontFamily.base,
@@ -134,24 +150,6 @@ const styles = ({ space, fontFamily, fontSize, color }) => ({
 		borderColor: color.border,
 		borderStyle: 'solid',
 	},
-	table: {
-		composes: '$para',
-		borderCollapse: 'collapse',
-	},
-	thead: {
-		composes: '$hr',
-	},
-	tbody: {},
-	td: {
-		fontFamily: fontFamily.base,
-		padding: [[space[0], space[2], space[0], 0]],
-		fontSize: fontSize.base,
-	},
-	th: {
-		composes: '$td',
-		fontWeight: 'bold',
-	},
-	tr: {},
 });
 
 function Markdown({ classes, text, inline }) {

--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -12,7 +12,7 @@ import Blockquote from 'rsg-components/Markdown/Blockquote';
 import Pre from 'rsg-components/Markdown/Pre';
 import Code from 'rsg-components/Code';
 import Checkbox from 'rsg-components/Markdown/Checkbox';
-import { Table, TableHead, TableCell } from 'rsg-components/Markdown/Table';
+import { Table, TableHead, TableBody, TableRow, TableCell } from 'rsg-components/Markdown/Table';
 
 // We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
 // That way we could avoid clashes between our loaders and user loaders.
@@ -118,6 +118,12 @@ const getBaseOverrides = memoize(classes => {
 			props: {
 				header: true,
 			},
+		},
+		tbody: {
+			component: TableBody,
+		},
+		tr: {
+			component: TableRow,
 		},
 		td: {
 			component: TableCell,

--- a/src/rsg-components/Markdown/Markdown.spec.js
+++ b/src/rsg-components/Markdown/Markdown.spec.js
@@ -125,4 +125,16 @@ Text with *some* **formatting** and a [link](/foo).
 
 		expect(html(actual)).toMatchSnapshot();
 	});
+
+	it('should render a table', () => {
+		const markdown = `
+| heading 1 | heading 2 |
+| --------- | --------- |
+| foo		| bar		|
+| more foo	| more bar	|
+`;
+		const actual = render(<Markdown text={markdown} />);
+
+		expect(html(actual)).toMatchSnapshot();
+	});
 });

--- a/src/rsg-components/Markdown/Table/Table.spec.js
+++ b/src/rsg-components/Markdown/Table/Table.spec.js
@@ -1,23 +1,23 @@
 import React from 'react';
 
-import { Table, TableHead, TableCell } from './index';
+import { Table, TableHead, TableBody, TableRow, TableCell } from './index';
 
 describe('Markdown Table', () => {
 	it('should render a table', () => {
 		const actual = render(
 			<Table>
 				<TableHead>
-					<tr>
+					<TableRow>
 						<TableCell header>1st header</TableCell>
 						<TableCell header>2nd header</TableCell>
-					</tr>
+					</TableRow>
 				</TableHead>
-				<tbody>
-					<tr>
+				<TableBody>
+					<TableRow>
 						<TableCell>1st cell</TableCell>
 						<TableCell>2nd cell</TableCell>
-					</tr>
-				</tbody>
+					</TableRow>
+				</TableBody>
 			</Table>
 		);
 

--- a/src/rsg-components/Markdown/Table/Table.spec.js
+++ b/src/rsg-components/Markdown/Table/Table.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Table, TableHead, TableCell } from './index';
+
+describe('Markdown Table', () => {
+	it('should render a table', () => {
+		const actual = render(
+			<Table>
+				<TableHead>
+					<tr>
+						<TableCell header>1st header</TableCell>
+						<TableCell header>2nd header</TableCell>
+					</tr>
+				</TableHead>
+				<tbody>
+					<tr>
+						<TableCell>1st cell</TableCell>
+						<TableCell>2nd cell</TableCell>
+					</tr>
+				</tbody>
+			</Table>
+		);
+
+		expect(actual).toMatchSnapshot();
+	});
+});

--- a/src/rsg-components/Markdown/Table/TableBodyRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableBodyRenderer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export function TableBodyRenderer({ children }) {
+	return <tbody>{children}</tbody>;
+}
+TableBodyRenderer.propTypes = {
+	children: PropTypes.node.isRequired,
+};
+
+export default TableBodyRenderer;

--- a/src/rsg-components/Markdown/Table/TableCellRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableCellRenderer.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 
 import Styled from 'rsg-components/Styled';
 
-const styles = ({ space, fontSize, fontFamily }) => ({
+const styles = ({ space, color, fontSize, fontFamily }) => ({
 	td: {
-		fontFamily: fontFamily.base,
 		padding: [[space[0], space[2], space[0], 0]],
+		fontFamily: fontFamily.base,
 		fontSize: fontSize.base,
+		color: color.base,
+		lineHeight: 1.5,
 	},
 	th: {
 		composes: '$td',

--- a/src/rsg-components/Markdown/Table/TableCellRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableCellRenderer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 
 import Styled from 'rsg-components/Styled';
 
@@ -11,13 +10,14 @@ const styles = ({ space, fontSize, fontFamily }) => ({
 		fontSize: fontSize.base,
 	},
 	th: {
+		composes: '$td',
 		fontWeight: 'bold',
 	},
 });
 
 export function TableCellRenderer({ classes, header, children }) {
 	if (header) {
-		return <th className={cx(classes.td, classes.th)}>{children}</th>;
+		return <th className={classes.th}>{children}</th>;
 	}
 
 	return <td className={classes.td}>{children}</td>;

--- a/src/rsg-components/Markdown/Table/TableCellRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableCellRenderer.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ space, fontSize, fontFamily }) => ({
+	td: {
+		fontFamily: fontFamily.base,
+		padding: [[space[0], space[2], space[0], 0]],
+		fontSize: fontSize.base,
+	},
+	th: {
+		fontWeight: 'bold',
+	},
+});
+
+export function TableCellRenderer({ classes, header, children }) {
+	if (header) {
+		return <th className={cx(classes.td, classes.th)}>{children}</th>;
+	}
+
+	return <td className={classes.td}>{children}</td>;
+}
+TableCellRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+	header: PropTypes.bool,
+	children: PropTypes.node.isRequired,
+};
+TableCellRenderer.defaultProps = {
+	header: false,
+};
+
+export default Styled(styles)(TableCellRenderer);

--- a/src/rsg-components/Markdown/Table/TableHeadRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableHeadRenderer.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ color }) => ({
+	thead: {
+		borderBottom: [[1, color.border, 'solid']],
+	},
+});
+
+export function TableHeadRenderer({ classes, children }) {
+	return <thead className={classes.thead}>{children}</thead>;
+}
+TableHeadRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+	children: PropTypes.node.isRequired,
+};
+
+export default Styled(styles)(TableHeadRenderer);

--- a/src/rsg-components/Markdown/Table/TableRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableRenderer.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { styles as paraStyles } from 'rsg-components/Para';
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ space, color, fontFamily }) => ({
+	table: {
+		...paraStyles({ space, color, fontFamily }).para,
+		borderCollapse: 'collapse',
+	},
+});
+
+export function TableRenderer({ classes, children }) {
+	return <table className={classes.table}>{children}</table>;
+}
+TableRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+	children: PropTypes.node.isRequired,
+};
+
+export default Styled(styles)(TableRenderer);

--- a/src/rsg-components/Markdown/Table/TableRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableRenderer.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { styles as paraStyles } from 'rsg-components/Para';
 import Styled from 'rsg-components/Styled';
 
-const styles = ({ space, color, fontFamily }) => ({
+const styles = ({ space }) => ({
 	table: {
-		...paraStyles({ space, color, fontFamily }).para,
+		marginTop: 0,
+		marginBottom: space[2],
 		borderCollapse: 'collapse',
 	},
 });

--- a/src/rsg-components/Markdown/Table/TableRowRenderer.js
+++ b/src/rsg-components/Markdown/Table/TableRowRenderer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export function TableRowRenderer({ children }) {
+	return <tr>{children}</tr>;
+}
+TableRowRenderer.propTypes = {
+	children: PropTypes.node.isRequired,
+};
+
+export default TableRowRenderer;

--- a/src/rsg-components/Markdown/Table/__snapshots__/Table.spec.js.snap
+++ b/src/rsg-components/Markdown/Table/__snapshots__/Table.spec.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Markdown Table should render a table 1`] = `
+<table
+  class="rsg--table-0"
+>
+  <thead
+    class="rsg--thead-2"
+  >
+    <tr>
+      <th
+        class="rsg--td-3 rsg--th-4"
+      >
+        1st header
+      </th>
+      <th
+        class="rsg--td-3 rsg--th-4"
+      >
+        2nd header
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td
+        class="rsg--td-3"
+      >
+        1st cell
+      </td>
+      <td
+        class="rsg--td-3"
+      >
+        2nd cell
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/src/rsg-components/Markdown/Table/__snapshots__/Table.spec.js.snap
+++ b/src/rsg-components/Markdown/Table/__snapshots__/Table.spec.js.snap
@@ -9,12 +9,12 @@ exports[`Markdown Table should render a table 1`] = `
   >
     <tr>
       <th
-        class="rsg--td-3 rsg--th-4"
+        class="rsg--th-4 rsg--td-3"
       >
         1st header
       </th>
       <th
-        class="rsg--td-3 rsg--th-4"
+        class="rsg--th-4 rsg--td-3"
       >
         2nd header
       </th>

--- a/src/rsg-components/Markdown/Table/index.js
+++ b/src/rsg-components/Markdown/Table/index.js
@@ -1,3 +1,5 @@
 export { default as Table } from 'rsg-components/Markdown/Table/TableRenderer';
 export { default as TableHead } from 'rsg-components/Markdown/Table/TableHeadRenderer';
+export { default as TableBody } from 'rsg-components/Markdown/Table/TableBodyRenderer';
+export { default as TableRow } from 'rsg-components/Markdown/Table/TableRowRenderer';
 export { default as TableCell } from 'rsg-components/Markdown/Table/TableCellRenderer';

--- a/src/rsg-components/Markdown/Table/index.js
+++ b/src/rsg-components/Markdown/Table/index.js
@@ -1,0 +1,3 @@
+export { default as Table } from 'rsg-components/Markdown/Table/TableRenderer';
+export { default as TableHead } from 'rsg-components/Markdown/Table/TableHeadRenderer';
+export { default as TableCell } from 'rsg-components/Markdown/Table/TableCellRenderer';

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -69,10 +69,10 @@ exports[`Markdown should render a table 1`] = `
 <table class="rsg--table-31">
   <thead class="rsg--thead-32">
     <tr>
-      <th class="rsg--td-33 rsg--th-34">
+      <th class="rsg--th-34 rsg--td-33">
         heading 1
       </th>
-      <th class="rsg--td-33 rsg--th-34">
+      <th class="rsg--th-34 rsg--td-33">
         heading 2
       </th>
     </tr>

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] = `
 
-<p class="rsg--para-10">
+<p class="rsg--para-4">
   pizza
 </p>
 
@@ -10,9 +10,9 @@ exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] =
 
 exports[`Markdown should render Markdown in span in inline mode 1`] = `
 
-<span class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25">
+<span class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19">
   Hello
-  <em class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25 rsg--em-27">
+  <em class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19 rsg--em-21">
     world
   </em>
   !
@@ -23,28 +23,28 @@ exports[`Markdown should render Markdown in span in inline mode 1`] = `
 exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 <div>
-  <div class="rsg--spacing-12">
-    <h1 class="rsg--heading-13 rsg--heading1-14">
+  <div class="rsg--spacing-6">
+    <h1 class="rsg--heading-7 rsg--heading1-8">
       Header
     </h1>
   </div>
-  <p class="rsg--para-10">
+  <p class="rsg--para-4">
     Text with
-    <em class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25 rsg--em-27">
+    <em class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19 rsg--em-21">
       some
     </em>
-    <strong class="rsg--text-20 rsg--inheritSize-21 rsg--baseColor-25 rsg--strong-28">
+    <strong class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19 rsg--strong-22">
       formatting
     </strong>
     and a
     <a href="/foo"
-       class="rsg--link-11"
+       class="rsg--link-5"
     >
       link
     </a>
     .
   </p>
-  <p class="rsg--para-10">
+  <p class="rsg--para-4">
     <img alt="Image"
          src="/bar.png"
     >
@@ -55,8 +55,8 @@ exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 exports[`Markdown should render a blockquote 1`] = `
 
-<blockquote class="rsg--blockquote-36">
-  <p class="rsg--para-10">
+<blockquote class="rsg--blockquote-30">
+  <p class="rsg--para-4">
     This is a blockquote.
 And this is a second line.
   </p>
@@ -64,28 +64,63 @@ And this is a second line.
 
 `;
 
+exports[`Markdown should render a table 1`] = `
+
+<table class="rsg--table-31">
+  <thead class="rsg--thead-32">
+    <tr>
+      <th class="rsg--td-33 rsg--th-34">
+        heading 1
+      </th>
+      <th class="rsg--td-33 rsg--th-34">
+        heading 2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="rsg--td-33">
+        foo
+      </td>
+      <td class="rsg--td-33">
+        bar
+      </td>
+    </tr>
+    <tr>
+      <td class="rsg--td-33">
+        more foo
+      </td>
+      <td class="rsg--td-33">
+        more bar
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+`;
+
 exports[`Markdown should render check-lists correctly 1`] = `
 
-<ul class="rsg--list-30">
-  <li class="rsg--li-32">
+<ul class="rsg--list-24">
+  <li class="rsg--li-26">
     <input type="checkbox"
            readonly
-           class="rsg--input-33"
+           class="rsg--input-27"
     >
     list 1
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     <input type="checkbox"
            readonly
-           class="rsg--input-33"
+           class="rsg--input-27"
     >
     list 2
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     <input type="checkbox"
            checked
            readonly
-           class="rsg--input-33"
+           class="rsg--input-27"
     >
     list 3
   </li>
@@ -95,8 +130,8 @@ exports[`Markdown should render check-lists correctly 1`] = `
 
 exports[`Markdown should render code blocks without escaping 1`] = `
 
-<pre class="rsg--pre-34">
-  <code class="lang-html rsg--code-35">
+<pre class="rsg--pre-28">
+  <code class="lang-html rsg--code-29">
     <foo>
     </foo>
   </code>
@@ -107,33 +142,33 @@ exports[`Markdown should render code blocks without escaping 1`] = `
 exports[`Markdown should render headings correctly 1`] = `
 
 <div>
-  <div class="rsg--spacing-12">
-    <h1 class="rsg--heading-13 rsg--heading1-14">
+  <div class="rsg--spacing-6">
+    <h1 class="rsg--heading-7 rsg--heading1-8">
       one
     </h1>
   </div>
-  <div class="rsg--spacing-12">
-    <h2 class="rsg--heading-13 rsg--heading2-15">
+  <div class="rsg--spacing-6">
+    <h2 class="rsg--heading-7 rsg--heading2-9">
       two
     </h2>
   </div>
-  <div class="rsg--spacing-12">
-    <h3 class="rsg--heading-13 rsg--heading3-16">
+  <div class="rsg--spacing-6">
+    <h3 class="rsg--heading-7 rsg--heading3-10">
       three
     </h3>
   </div>
-  <div class="rsg--spacing-12">
-    <h4 class="rsg--heading-13 rsg--heading4-17">
+  <div class="rsg--spacing-6">
+    <h4 class="rsg--heading-7 rsg--heading4-11">
       four
     </h4>
   </div>
-  <div class="rsg--spacing-12">
-    <h5 class="rsg--heading-13 rsg--heading5-18">
+  <div class="rsg--spacing-6">
+    <h5 class="rsg--heading-7 rsg--heading5-12">
       five
     </h5>
   </div>
-  <div class="rsg--spacing-12">
-    <h6 class="rsg--heading-13 rsg--heading6-19">
+  <div class="rsg--spacing-6">
+    <h6 class="rsg--heading-7 rsg--heading6-13">
       six
     </h6>
   </div>
@@ -143,9 +178,9 @@ exports[`Markdown should render headings correctly 1`] = `
 
 exports[`Markdown should render inline code with escaping 1`] = `
 
-<p class="rsg--para-10">
+<p class="rsg--para-4">
   Foo
-  <code class="rsg--code-35">
+  <code class="rsg--code-29">
     &lt;bar&gt;
   </code>
   baz
@@ -155,10 +190,10 @@ exports[`Markdown should render inline code with escaping 1`] = `
 
 exports[`Markdown should render links 1`] = `
 
-<p class="rsg--para-10">
+<p class="rsg--para-4">
   a
   <a href="http://test.com"
-     class="rsg--link-11"
+     class="rsg--link-5"
   >
     link
   </a>
@@ -168,25 +203,25 @@ exports[`Markdown should render links 1`] = `
 
 exports[`Markdown should render mixed nested lists correctly 1`] = `
 
-<ul class="rsg--list-30">
-  <li class="rsg--li-32">
+<ul class="rsg--list-24">
+  <li class="rsg--li-26">
     list 1
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     list 2
-    <ol class="rsg--list-30 rsg--ordered-31">
-      <li class="rsg--li-32">
+    <ol class="rsg--list-24 rsg--ordered-25">
+      <li class="rsg--li-26">
         Sub-list
       </li>
-      <li class="rsg--li-32">
+      <li class="rsg--li-26">
         Sub-list
       </li>
-      <li class="rsg--li-32">
+      <li class="rsg--li-26">
         Sub-list
       </li>
     </ol>
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     list 3
   </li>
 </ul>
@@ -195,14 +230,14 @@ exports[`Markdown should render mixed nested lists correctly 1`] = `
 
 exports[`Markdown should render ordered lists correctly 1`] = `
 
-<ol class="rsg--list-30 rsg--ordered-31">
-  <li class="rsg--li-32">
+<ol class="rsg--list-24 rsg--ordered-25">
+  <li class="rsg--li-26">
     list
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     item
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     three
   </li>
 </ol>
@@ -211,14 +246,14 @@ exports[`Markdown should render ordered lists correctly 1`] = `
 
 exports[`Markdown should render unordered lists correctly 1`] = `
 
-<ul class="rsg--list-30">
-  <li class="rsg--li-32">
+<ul class="rsg--list-24">
+  <li class="rsg--li-26">
     list
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     item
   </li>
-  <li class="rsg--li-32">
+  <li class="rsg--li-26">
     three
   </li>
 </ul>


### PR DESCRIPTION
This makes it easier for consumers to override individual components in their styleguide, specifically tables in this PR.

* Update markdown-to-jsx to v6.4.1 to get some table rendering bug fixes. [Release notes](https://github.com/probablyup/markdown-to-jsx/releases/tag/6.3.2)