### PR TITLE
Use hr component in markdown

### DIFF
--- a/src/rsg-components/Argument/__snapshots__/Argument.spec.js.snap
+++ b/src/rsg-components/Argument/__snapshots__/Argument.spec.js.snap
@@ -14,7 +14,7 @@ exports[`should render argument 1`] = `
     Array
   </Styled(Type)>
    — 
-  <Styled(Markdown)
+  <Markdown
     inline={true}
     text="Converts foo to bar"
   />
@@ -46,7 +46,7 @@ exports[`should render argument without type 1`] = `
       Foo
     </Styled(Name)>
   </span>
-  <Styled(Markdown)
+  <Markdown
     inline={true}
     text="Converts foo to bar"
   />
@@ -62,7 +62,7 @@ exports[`should render return value 1`] = `
     Array
   </Styled(Type)>
    — 
-  <Styled(Markdown)
+  <Markdown
     inline={true}
     text="Converts foo to bar"
   />

--- a/src/rsg-components/ExamplePlaceholder/__snapshots__/ExamplePlaceholder.spec.js.snap
+++ b/src/rsg-components/ExamplePlaceholder/__snapshots__/ExamplePlaceholder.spec.js.snap
@@ -9,7 +9,7 @@ exports[`should render a link 1`] = `
 `;
 
 exports[`should render an example placeholder after click 1`] = `
-<Styled(Markdown)
+<Markdown
   text="
 Create **Readme.md** or **Pizza.md** file in the component’s folder like this:
 

--- a/src/rsg-components/Examples/__snapshots__/Examples.spec.js.snap
+++ b/src/rsg-components/Examples/__snapshots__/Examples.spec.js.snap
@@ -13,7 +13,7 @@ exports[`should render examples 1`] = `
     key="1/0"
     name="button"
   />
-  <Styled(Markdown)
+  <Markdown
     key="1"
     text="Hello *world*!"
   />

--- a/src/rsg-components/JsDoc/__snapshots__/JsDoc.spec.js.snap
+++ b/src/rsg-components/JsDoc/__snapshots__/JsDoc.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JsDoc should render Markdown 1`] = `
-<Styled(Markdown)
+<Markdown
   text="**Deprecated:** Use *another* method
 
 [See 1](#TestLink)

--- a/src/rsg-components/Markdown/Hr/Hr.spec.js
+++ b/src/rsg-components/Markdown/Hr/Hr.spec.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Hr from './index';
+
+describe('Markdown Hr', () => {
+	it('should render a horizontal rule', () => {
+		const actual = render(<Hr />);
+
+		expect(actual).toMatchSnapshot();
+	});
+});

--- a/src/rsg-components/Markdown/Hr/HrRenderer.js
+++ b/src/rsg-components/Markdown/Hr/HrRenderer.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ space, color }) => ({
+	hr: {
+		borderBottom: [[1, color.border, 'solid']],
+		marginTop: 0,
+		marginBottom: space[2],
+	},
+});
+
+export function HrRenderer({ classes }) {
+	return <hr className={classes.hr} />;
+}
+HrRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+};
+
+export default Styled(styles)(HrRenderer);

--- a/src/rsg-components/Markdown/Hr/__snapshots__/Hr.spec.js.snap
+++ b/src/rsg-components/Markdown/Hr/__snapshots__/Hr.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Markdown Hr should render a horizontal rule 1`] = `
+<hr
+  class="rsg--hr-0"
+/>
+`;

--- a/src/rsg-components/Markdown/Hr/index.js
+++ b/src/rsg-components/Markdown/Hr/index.js
@@ -1,0 +1,1 @@
+export { default } from 'rsg-components/Markdown/Hr/HrRenderer';

--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -12,6 +12,7 @@ import Blockquote from 'rsg-components/Markdown/Blockquote';
 import Pre from 'rsg-components/Markdown/Pre';
 import Code from 'rsg-components/Code';
 import Checkbox from 'rsg-components/Markdown/Checkbox';
+import Hr from 'rsg-components/Markdown/Hr';
 import { Table, TableHead, TableBody, TableRow, TableCell } from 'rsg-components/Markdown/Table';
 
 // We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
@@ -107,6 +108,9 @@ const getBaseOverrides = memoize(classes => {
 		input: {
 			component: Checkbox,
 		},
+		hr: {
+			component: Hr,
+		},
 		table: {
 			component: Table,
 		},
@@ -150,12 +154,6 @@ const styles = ({ space, fontFamily, color }) => ({
 		fontSize: 'inherit',
 	},
 	para: paraStyles({ space, color, fontFamily }).para,
-	hr: {
-		composes: '$para',
-		borderWidth: [[0, 0, 1, 0]],
-		borderColor: color.border,
-		borderStyle: 'solid',
-	},
 });
 
 function Markdown({ classes, text, inline }) {

--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types';
 import { compiler } from 'markdown-to-jsx';
-import mapValues from 'lodash/mapValues';
-import memoize from 'lodash/memoize';
-import Styled from 'rsg-components/Styled';
+
 import Link from 'rsg-components/Link';
 import Text from 'rsg-components/Text';
-import Para, { styles as paraStyles } from 'rsg-components/Para';
+import Para from 'rsg-components/Para';
 import MarkdownHeading from 'rsg-components/Markdown/MarkdownHeading';
 import List from 'rsg-components/Markdown/List';
 import Blockquote from 'rsg-components/Markdown/Blockquote';
@@ -20,151 +18,126 @@ import { Table, TableHead, TableBody, TableRow, TableCell } from 'rsg-components
 // eslint-disable-next-line import/no-unresolved
 require('!!../../../loaders/style-loader!../../../loaders/css-loader!highlight.js/styles/tomorrow.css');
 
-// Custom CSS classes for each tag: <em> → <em className={s.em}> + custom components
-const getBaseOverrides = memoize(classes => {
-	const styleOverrides = mapValues(classes, value => ({
-		props: {
-			className: value,
-		},
-	}));
-
-	return {
-		...styleOverrides,
-		a: {
-			component: Link,
-		},
-		h1: {
-			component: MarkdownHeading,
-			props: {
-				level: 1,
-			},
-		},
-		h2: {
-			component: MarkdownHeading,
-			props: {
-				level: 2,
-			},
-		},
-		h3: {
-			component: MarkdownHeading,
-			props: {
-				level: 3,
-			},
-		},
-		h4: {
-			component: MarkdownHeading,
-			props: {
-				level: 4,
-			},
-		},
-		h5: {
-			component: MarkdownHeading,
-			props: {
-				level: 5,
-			},
-		},
-		h6: {
-			component: MarkdownHeading,
-			props: {
-				level: 6,
-			},
-		},
-		p: {
-			component: Para,
-			props: {
-				semantic: 'p',
-			},
-		},
-		em: {
-			component: Text,
-			props: {
-				semantic: 'em',
-			},
-		},
-		strong: {
-			component: Text,
-			props: {
-				semantic: 'strong',
-			},
-		},
-		ul: {
-			component: List,
-		},
-		ol: {
-			component: List,
-			props: {
-				ordered: true,
-			},
-		},
-		blockquote: {
-			component: Blockquote,
-		},
-		code: {
-			component: Code,
-		},
-		pre: {
-			component: Pre,
-		},
-		input: {
-			component: Checkbox,
-		},
-		hr: {
-			component: Hr,
-		},
-		table: {
-			component: Table,
-		},
-		thead: {
-			component: TableHead,
-		},
-		th: {
-			component: TableCell,
-			props: {
-				header: true,
-			},
-		},
-		tbody: {
-			component: TableBody,
-		},
-		tr: {
-			component: TableRow,
-		},
-		td: {
-			component: TableCell,
-		},
-	};
-}, () => 'getBaseOverrides');
-
-// Inline mode: replace <p> (usual root component) with <span>
-const getInlineOverrides = memoize(classes => {
-	const overrides = getBaseOverrides(classes);
-
-	return {
-		...overrides,
-		p: {
-			component: Text,
-		},
-	};
-}, () => 'getInlineOverrides');
-
-const styles = ({ space, fontFamily, color }) => ({
-	base: {
-		color: color.base,
-		fontFamily: fontFamily.base,
-		fontSize: 'inherit',
+const baseOverrides = {
+	a: {
+		component: Link,
 	},
-	para: paraStyles({ space, color, fontFamily }).para,
-});
+	h1: {
+		component: MarkdownHeading,
+		props: {
+			level: 1,
+		},
+	},
+	h2: {
+		component: MarkdownHeading,
+		props: {
+			level: 2,
+		},
+	},
+	h3: {
+		component: MarkdownHeading,
+		props: {
+			level: 3,
+		},
+	},
+	h4: {
+		component: MarkdownHeading,
+		props: {
+			level: 4,
+		},
+	},
+	h5: {
+		component: MarkdownHeading,
+		props: {
+			level: 5,
+		},
+	},
+	h6: {
+		component: MarkdownHeading,
+		props: {
+			level: 6,
+		},
+	},
+	p: {
+		component: Para,
+		props: {
+			semantic: 'p',
+		},
+	},
+	em: {
+		component: Text,
+		props: {
+			semantic: 'em',
+		},
+	},
+	strong: {
+		component: Text,
+		props: {
+			semantic: 'strong',
+		},
+	},
+	ul: {
+		component: List,
+	},
+	ol: {
+		component: List,
+		props: {
+			ordered: true,
+		},
+	},
+	blockquote: {
+		component: Blockquote,
+	},
+	code: {
+		component: Code,
+	},
+	pre: {
+		component: Pre,
+	},
+	input: {
+		component: Checkbox,
+	},
+	hr: {
+		component: Hr,
+	},
+	table: {
+		component: Table,
+	},
+	thead: {
+		component: TableHead,
+	},
+	th: {
+		component: TableCell,
+		props: {
+			header: true,
+		},
+	},
+	tbody: {
+		component: TableBody,
+	},
+	tr: {
+		component: TableRow,
+	},
+	td: {
+		component: TableCell,
+	},
+};
 
-function Markdown({ classes, text, inline }) {
-	const overrides = inline ? getInlineOverrides(classes) : getBaseOverrides(classes);
+const inlineOverrides = {
+	...baseOverrides,
+	p: {
+		component: Text,
+	},
+};
+
+function Markdown({ text, inline }) {
+	const overrides = inline ? inlineOverrides : baseOverrides;
 	return compiler(text, { overrides, forceBlock: true });
 }
 
 Markdown.propTypes = {
-	classes: PropTypes.object.isRequired,
 	text: PropTypes.string.isRequired,
 	inline: PropTypes.bool,
 };
 
-export default Styled(styles)(Markdown);
+export default Markdown;

--- a/src/rsg-components/Markdown/Markdown.spec.js
+++ b/src/rsg-components/Markdown/Markdown.spec.js
@@ -126,6 +126,13 @@ Text with *some* **formatting** and a [link](/foo).
 		expect(html(actual)).toMatchSnapshot();
 	});
 
+	it('should render a horizontal rule', () => {
+		const markdown = `---`;
+		const actual = render(<Markdown text={markdown} />);
+
+		expect(html(actual)).toMatchSnapshot();
+	});
+
 	it('should render a table', () => {
 		const markdown = `
 | heading 1 | heading 2 |

--- a/src/rsg-components/Markdown/Markdown.spec.js
+++ b/src/rsg-components/Markdown/Markdown.spec.js
@@ -3,145 +3,136 @@ import { html } from 'cheerio';
 import Markdown from './Markdown';
 
 describe('Markdown', () => {
+	const expectSnapshotToMatch = markdown => {
+		const actual = render(<Markdown text={markdown} />);
+
+		expect(html(actual)).toMatchSnapshot();
+	};
+
+	it('should forward DOM attributes onto resulting HTML', () => {
+		const markdown =
+			'<a href="test.com" id="preserve-my-id" class="preserve-my-class">Something</a>';
+
+		const actual = mount(<Markdown text={markdown} />);
+
+		expect(actual.find('a').props().id).toEqual('preserve-my-id');
+		expect(actual.find('a').props().className).toContain('preserve-my-class');
+	});
+
 	it('should render links', () => {
-		const markdown = 'a [link](http://test.com)';
-
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+		expectSnapshotToMatch('a [link](http://test.com)');
 	});
 
-	it('should render Markdown with custom CSS classes', () => {
-		const markdown = `
-# Header
-
-Text with *some* **formatting** and a [link](/foo).
-
-![Image](/bar.png)`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
-	});
-
-	it('should render Markdown in a p tag even for one paragraph', () => {
-		const actual = render(<Markdown text="pizza" />);
-
-		expect(html(actual)).toMatchSnapshot();
-	});
-
-	it('should render Markdown in span in inline mode', () => {
-		const markdown = 'Hello *world*!';
-		const actual = render(<Markdown text={markdown} inline />);
-
-		expect(html(actual)).toMatchSnapshot();
-	});
-
-	it('should render headings correctly', () => {
-		const markdown = `
+	it('should render headings', () => {
+		expectSnapshotToMatch(`
 # one
 ## two
 ### three
 #### four
 ##### five
 ###### six
-`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+`);
 	});
 
-	it('should render unordered lists correctly', () => {
-		const markdown = `
+	it('should render paragraphs', () => {
+		expectSnapshotToMatch(`
+a paragraph
+
+another paragraph
+		`);
+	});
+
+	it('should render emphasis and strong text', () => {
+		expectSnapshotToMatch(`
+this text is **strong**
+
+and this is _emphasized_
+		`);
+	});
+
+	it('should render unordered lists', () => {
+		expectSnapshotToMatch(`
 * list
 * item
 * three
-`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+`);
 	});
 
-	it('should render ordered lists correctly', () => {
-		const markdown = `
+	it('should render ordered lists', () => {
+		expectSnapshotToMatch(`
 1. list
 1. item
 1. three
-`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+`);
 	});
 
-	it('should render check-lists correctly', () => {
-		const markdown = `
-* [ ] list 1
-* [ ] list 2
-* [x] list 3
-`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
-	});
-
-	it('should render mixed nested lists correctly', () => {
-		const markdown = `
+	it('should render mixed nested lists', () => {
+		expectSnapshotToMatch(`
 * list 1
 * list 2
   1. Sub-list
   1. Sub-list
   1. Sub-list
 * list 3
-`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+`);
 	});
 
-	it('should render code blocks without escaping', () => {
-		const markdown = `
-\`\`\`html
-<foo></foo>
-\`\`\`
-`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
-	});
-
-	it('should render inline code with escaping', () => {
-		const markdown = 'Foo `<bar>` baz';
-
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+	it('should render check-lists', () => {
+		expectSnapshotToMatch(`
+* [ ] to do 1
+* [ ] to do 2
+* [x] to do 3
+`);
 	});
 
 	it('should render a blockquote', () => {
-		const markdown = `
+		expectSnapshotToMatch(`
 > This is a blockquote.
 > And this is a second line.
-`;
-		const actual = render(<Markdown text={markdown} />);
+`);
+	});
 
-		expect(html(actual)).toMatchSnapshot();
+	it('should render pre-formatted text', () => {
+		expectSnapshotToMatch(`
+    this is preformatted
+    so is this
+`);
+	});
+
+	it('should render code blocks without escaping', () => {
+		expectSnapshotToMatch(`
+\`\`\`html
+<foo></foo>
+\`\`\`
+`);
+	});
+
+	it('should render inline code with escaping', () => {
+		expectSnapshotToMatch('Foo `<bar>` baz');
 	});
 
 	it('should render a horizontal rule', () => {
-		const markdown = `---`;
-		const actual = render(<Markdown text={markdown} />);
-
-		expect(html(actual)).toMatchSnapshot();
+		expectSnapshotToMatch(`---`);
 	});
 
 	it('should render a table', () => {
-		const markdown = `
+		expectSnapshotToMatch(`
 | heading 1 | heading 2 |
 | --------- | --------- |
 | foo		| bar		|
 | more foo	| more bar	|
-`;
-		const actual = render(<Markdown text={markdown} />);
+`);
+	});
+});
+
+describe('Markdown inline', () => {
+	const expectSnapshotToMatch = markdown => {
+		const actual = render(<Markdown text={markdown} inline />);
 
 		expect(html(actual)).toMatchSnapshot();
+	};
+
+	it('should render text in a span', () => {
+		expectSnapshotToMatch('Hello world!');
 	});
 });

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -1,62 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] = `
-
-<p class="rsg--para-0">
-  pizza
-</p>
-
-`;
-
-exports[`Markdown should render Markdown in span in inline mode 1`] = `
+exports[`Markdown inline should render text in a span 1`] = `
 
 <span class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16">
-  Hello
-  <em class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--em-18">
-    world
-  </em>
-  !
+  Hello world!
 </span>
-
-`;
-
-exports[`Markdown should render Markdown with custom CSS classes 1`] = `
-
-<div>
-  <div class="rsg--spacing-3">
-    <h1 class="rsg--heading-4 rsg--heading1-5">
-      Header
-    </h1>
-  </div>
-  <p class="rsg--para-0">
-    Text with
-    <em class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--em-18">
-      some
-    </em>
-    <strong class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--strong-19">
-      formatting
-    </strong>
-    and a
-    <a href="/foo"
-       class="rsg--link-2"
-    >
-      link
-    </a>
-    .
-  </p>
-  <p class="rsg--para-0">
-    <img alt="Image"
-         src="/bar.png"
-    >
-  </p>
-</div>
 
 `;
 
 exports[`Markdown should render a blockquote 1`] = `
 
-<blockquote class="rsg--blockquote-27">
-  <p class="rsg--para-0">
+<blockquote class="rsg--blockquote-25">
+  <p class="rsg--para-2">
     This is a blockquote.
 And this is a second line.
   </p>
@@ -105,7 +60,7 @@ exports[`Markdown should render a table 1`] = `
 
 `;
 
-exports[`Markdown should render check-lists correctly 1`] = `
+exports[`Markdown should render check-lists 1`] = `
 
 <ul class="rsg--list-21">
   <li class="rsg--li-23">
@@ -113,14 +68,14 @@ exports[`Markdown should render check-lists correctly 1`] = `
            readonly
            class="rsg--input-24"
     >
-    list 1
+    to do 1
   </li>
   <li class="rsg--li-23">
     <input type="checkbox"
            readonly
            class="rsg--input-24"
     >
-    list 2
+    to do 2
   </li>
   <li class="rsg--li-23">
     <input type="checkbox"
@@ -128,7 +83,7 @@ exports[`Markdown should render check-lists correctly 1`] = `
            readonly
            class="rsg--input-24"
     >
-    list 3
+    to do 3
   </li>
 </ul>
 
@@ -136,8 +91,8 @@ exports[`Markdown should render check-lists correctly 1`] = `
 
 exports[`Markdown should render code blocks without escaping 1`] = `
 
-<pre class="rsg--pre-25">
-  <code class="lang-html rsg--code-26">
+<pre class="rsg--pre-26">
+  <code class="lang-html rsg--code-27">
     <foo>
     </foo>
   </code>
@@ -145,7 +100,26 @@ exports[`Markdown should render code blocks without escaping 1`] = `
 
 `;
 
-exports[`Markdown should render headings correctly 1`] = `
+exports[`Markdown should render emphasis and strong text 1`] = `
+
+<div>
+  <p class="rsg--para-2">
+    this text is
+    <strong class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--strong-19">
+      strong
+    </strong>
+  </p>
+  <p class="rsg--para-2">
+    and this is
+    <em class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--em-18">
+      emphasized
+    </em>
+  </p>
+</div>
+
+`;
+
+exports[`Markdown should render headings 1`] = `
 
 <div>
   <div class="rsg--spacing-3">
@@ -184,9 +158,9 @@ exports[`Markdown should render headings correctly 1`] = `
 
 exports[`Markdown should render inline code with escaping 1`] = `
 
-<p class="rsg--para-0">
+<p class="rsg--para-2">
   Foo
-  <code class="rsg--code-26">
+  <code class="rsg--code-27">
     &lt;bar&gt;
   </code>
   baz
@@ -196,10 +170,10 @@ exports[`Markdown should render inline code with escaping 1`] = `
 
 exports[`Markdown should render links 1`] = `
 
-<p class="rsg--para-0">
+<p class="rsg--para-2">
   a
   <a href="http://test.com"
-     class="rsg--link-2"
+     class="rsg--link-0"
   >
     link
   </a>
@@ -207,7 +181,7 @@ exports[`Markdown should render links 1`] = `
 
 `;
 
-exports[`Markdown should render mixed nested lists correctly 1`] = `
+exports[`Markdown should render mixed nested lists 1`] = `
 
 <ul class="rsg--list-21">
   <li class="rsg--li-23">
@@ -234,7 +208,7 @@ exports[`Markdown should render mixed nested lists correctly 1`] = `
 
 `;
 
-exports[`Markdown should render ordered lists correctly 1`] = `
+exports[`Markdown should render ordered lists 1`] = `
 
 <ol class="rsg--list-21 rsg--ordered-22">
   <li class="rsg--li-23">
@@ -250,7 +224,31 @@ exports[`Markdown should render ordered lists correctly 1`] = `
 
 `;
 
-exports[`Markdown should render unordered lists correctly 1`] = `
+exports[`Markdown should render paragraphs 1`] = `
+
+<div>
+  <p class="rsg--para-2">
+    a paragraph
+  </p>
+  <p class="rsg--para-2">
+    another paragraph
+  </p>
+</div>
+
+`;
+
+exports[`Markdown should render pre-formatted text 1`] = `
+
+<pre class="rsg--pre-26">
+  <code class="rsg--code-27">
+    this is preformatted
+so is this
+  </code>
+</pre>
+
+`;
+
+exports[`Markdown should render unordered lists 1`] = `
 
 <ul class="rsg--list-21">
   <li class="rsg--li-23">

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] = `
 
-<p class="rsg--para-3">
+<p class="rsg--para-0">
   pizza
 </p>
 
@@ -10,9 +10,9 @@ exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] =
 
 exports[`Markdown should render Markdown in span in inline mode 1`] = `
 
-<span class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18">
+<span class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16">
   Hello
-  <em class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18 rsg--em-20">
+  <em class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--em-18">
     world
   </em>
   !
@@ -23,28 +23,28 @@ exports[`Markdown should render Markdown in span in inline mode 1`] = `
 exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 <div>
-  <div class="rsg--spacing-5">
-    <h1 class="rsg--heading-6 rsg--heading1-7">
+  <div class="rsg--spacing-3">
+    <h1 class="rsg--heading-4 rsg--heading1-5">
       Header
     </h1>
   </div>
-  <p class="rsg--para-3">
+  <p class="rsg--para-0">
     Text with
-    <em class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18 rsg--em-20">
+    <em class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--em-18">
       some
     </em>
-    <strong class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18 rsg--strong-21">
+    <strong class="rsg--text-11 rsg--inheritSize-12 rsg--baseColor-16 rsg--strong-19">
       formatting
     </strong>
     and a
     <a href="/foo"
-       class="rsg--link-4"
+       class="rsg--link-2"
     >
       link
     </a>
     .
   </p>
-  <p class="rsg--para-3">
+  <p class="rsg--para-0">
     <img alt="Image"
          src="/bar.png"
     >
@@ -55,8 +55,8 @@ exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 exports[`Markdown should render a blockquote 1`] = `
 
-<blockquote class="rsg--blockquote-29">
-  <p class="rsg--para-3">
+<blockquote class="rsg--blockquote-27">
+  <p class="rsg--para-0">
     This is a blockquote.
 And this is a second line.
   </p>
@@ -66,37 +66,37 @@ And this is a second line.
 
 exports[`Markdown should render a horizontal rule 1`] = `
 
-<hr class="rsg--hr-30">
+<hr class="rsg--hr-28">
 
 `;
 
 exports[`Markdown should render a table 1`] = `
 
-<table class="rsg--table-31">
-  <thead class="rsg--thead-32">
+<table class="rsg--table-29">
+  <thead class="rsg--thead-30">
     <tr>
-      <th class="rsg--th-34 rsg--td-33">
+      <th class="rsg--th-32 rsg--td-31">
         heading 1
       </th>
-      <th class="rsg--th-34 rsg--td-33">
+      <th class="rsg--th-32 rsg--td-31">
         heading 2
       </th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td class="rsg--td-33">
+      <td class="rsg--td-31">
         foo
       </td>
-      <td class="rsg--td-33">
+      <td class="rsg--td-31">
         bar
       </td>
     </tr>
     <tr>
-      <td class="rsg--td-33">
+      <td class="rsg--td-31">
         more foo
       </td>
-      <td class="rsg--td-33">
+      <td class="rsg--td-31">
         more bar
       </td>
     </tr>
@@ -107,26 +107,26 @@ exports[`Markdown should render a table 1`] = `
 
 exports[`Markdown should render check-lists correctly 1`] = `
 
-<ul class="rsg--list-23">
-  <li class="rsg--li-25">
+<ul class="rsg--list-21">
+  <li class="rsg--li-23">
     <input type="checkbox"
            readonly
-           class="rsg--input-26"
+           class="rsg--input-24"
     >
     list 1
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     <input type="checkbox"
            readonly
-           class="rsg--input-26"
+           class="rsg--input-24"
     >
     list 2
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     <input type="checkbox"
            checked
            readonly
-           class="rsg--input-26"
+           class="rsg--input-24"
     >
     list 3
   </li>
@@ -136,8 +136,8 @@ exports[`Markdown should render check-lists correctly 1`] = `
 
 exports[`Markdown should render code blocks without escaping 1`] = `
 
-<pre class="rsg--pre-27">
-  <code class="lang-html rsg--code-28">
+<pre class="rsg--pre-25">
+  <code class="lang-html rsg--code-26">
     <foo>
     </foo>
   </code>
@@ -148,33 +148,33 @@ exports[`Markdown should render code blocks without escaping 1`] = `
 exports[`Markdown should render headings correctly 1`] = `
 
 <div>
-  <div class="rsg--spacing-5">
-    <h1 class="rsg--heading-6 rsg--heading1-7">
+  <div class="rsg--spacing-3">
+    <h1 class="rsg--heading-4 rsg--heading1-5">
       one
     </h1>
   </div>
-  <div class="rsg--spacing-5">
-    <h2 class="rsg--heading-6 rsg--heading2-8">
+  <div class="rsg--spacing-3">
+    <h2 class="rsg--heading-4 rsg--heading2-6">
       two
     </h2>
   </div>
-  <div class="rsg--spacing-5">
-    <h3 class="rsg--heading-6 rsg--heading3-9">
+  <div class="rsg--spacing-3">
+    <h3 class="rsg--heading-4 rsg--heading3-7">
       three
     </h3>
   </div>
-  <div class="rsg--spacing-5">
-    <h4 class="rsg--heading-6 rsg--heading4-10">
+  <div class="rsg--spacing-3">
+    <h4 class="rsg--heading-4 rsg--heading4-8">
       four
     </h4>
   </div>
-  <div class="rsg--spacing-5">
-    <h5 class="rsg--heading-6 rsg--heading5-11">
+  <div class="rsg--spacing-3">
+    <h5 class="rsg--heading-4 rsg--heading5-9">
       five
     </h5>
   </div>
-  <div class="rsg--spacing-5">
-    <h6 class="rsg--heading-6 rsg--heading6-12">
+  <div class="rsg--spacing-3">
+    <h6 class="rsg--heading-4 rsg--heading6-10">
       six
     </h6>
   </div>
@@ -184,9 +184,9 @@ exports[`Markdown should render headings correctly 1`] = `
 
 exports[`Markdown should render inline code with escaping 1`] = `
 
-<p class="rsg--para-3">
+<p class="rsg--para-0">
   Foo
-  <code class="rsg--code-28">
+  <code class="rsg--code-26">
     &lt;bar&gt;
   </code>
   baz
@@ -196,10 +196,10 @@ exports[`Markdown should render inline code with escaping 1`] = `
 
 exports[`Markdown should render links 1`] = `
 
-<p class="rsg--para-3">
+<p class="rsg--para-0">
   a
   <a href="http://test.com"
-     class="rsg--link-4"
+     class="rsg--link-2"
   >
     link
   </a>
@@ -209,25 +209,25 @@ exports[`Markdown should render links 1`] = `
 
 exports[`Markdown should render mixed nested lists correctly 1`] = `
 
-<ul class="rsg--list-23">
-  <li class="rsg--li-25">
+<ul class="rsg--list-21">
+  <li class="rsg--li-23">
     list 1
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     list 2
-    <ol class="rsg--list-23 rsg--ordered-24">
-      <li class="rsg--li-25">
+    <ol class="rsg--list-21 rsg--ordered-22">
+      <li class="rsg--li-23">
         Sub-list
       </li>
-      <li class="rsg--li-25">
+      <li class="rsg--li-23">
         Sub-list
       </li>
-      <li class="rsg--li-25">
+      <li class="rsg--li-23">
         Sub-list
       </li>
     </ol>
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     list 3
   </li>
 </ul>
@@ -236,14 +236,14 @@ exports[`Markdown should render mixed nested lists correctly 1`] = `
 
 exports[`Markdown should render ordered lists correctly 1`] = `
 
-<ol class="rsg--list-23 rsg--ordered-24">
-  <li class="rsg--li-25">
+<ol class="rsg--list-21 rsg--ordered-22">
+  <li class="rsg--li-23">
     list
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     item
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     three
   </li>
 </ol>
@@ -252,14 +252,14 @@ exports[`Markdown should render ordered lists correctly 1`] = `
 
 exports[`Markdown should render unordered lists correctly 1`] = `
 
-<ul class="rsg--list-23">
-  <li class="rsg--li-25">
+<ul class="rsg--list-21">
+  <li class="rsg--li-23">
     list
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     item
   </li>
-  <li class="rsg--li-25">
+  <li class="rsg--li-23">
     three
   </li>
 </ul>

--- a/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] = `
 
-<p class="rsg--para-4">
+<p class="rsg--para-3">
   pizza
 </p>
 
@@ -10,9 +10,9 @@ exports[`Markdown should render Markdown in a p tag even for one paragraph 1`] =
 
 exports[`Markdown should render Markdown in span in inline mode 1`] = `
 
-<span class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19">
+<span class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18">
   Hello
-  <em class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19 rsg--em-21">
+  <em class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18 rsg--em-20">
     world
   </em>
   !
@@ -23,28 +23,28 @@ exports[`Markdown should render Markdown in span in inline mode 1`] = `
 exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 <div>
-  <div class="rsg--spacing-6">
-    <h1 class="rsg--heading-7 rsg--heading1-8">
+  <div class="rsg--spacing-5">
+    <h1 class="rsg--heading-6 rsg--heading1-7">
       Header
     </h1>
   </div>
-  <p class="rsg--para-4">
+  <p class="rsg--para-3">
     Text with
-    <em class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19 rsg--em-21">
+    <em class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18 rsg--em-20">
       some
     </em>
-    <strong class="rsg--text-14 rsg--inheritSize-15 rsg--baseColor-19 rsg--strong-22">
+    <strong class="rsg--text-13 rsg--inheritSize-14 rsg--baseColor-18 rsg--strong-21">
       formatting
     </strong>
     and a
     <a href="/foo"
-       class="rsg--link-5"
+       class="rsg--link-4"
     >
       link
     </a>
     .
   </p>
-  <p class="rsg--para-4">
+  <p class="rsg--para-3">
     <img alt="Image"
          src="/bar.png"
     >
@@ -55,12 +55,18 @@ exports[`Markdown should render Markdown with custom CSS classes 1`] = `
 
 exports[`Markdown should render a blockquote 1`] = `
 
-<blockquote class="rsg--blockquote-30">
-  <p class="rsg--para-4">
+<blockquote class="rsg--blockquote-29">
+  <p class="rsg--para-3">
     This is a blockquote.
 And this is a second line.
   </p>
 </blockquote>
+
+`;
+
+exports[`Markdown should render a horizontal rule 1`] = `
+
+<hr class="rsg--hr-30">
 
 `;
 
@@ -101,26 +107,26 @@ exports[`Markdown should render a table 1`] = `
 
 exports[`Markdown should render check-lists correctly 1`] = `
 
-<ul class="rsg--list-24">
-  <li class="rsg--li-26">
+<ul class="rsg--list-23">
+  <li class="rsg--li-25">
     <input type="checkbox"
            readonly
-           class="rsg--input-27"
+           class="rsg--input-26"
     >
     list 1
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     <input type="checkbox"
            readonly
-           class="rsg--input-27"
+           class="rsg--input-26"
     >
     list 2
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     <input type="checkbox"
            checked
            readonly
-           class="rsg--input-27"
+           class="rsg--input-26"
     >
     list 3
   </li>
@@ -130,8 +136,8 @@ exports[`Markdown should render check-lists correctly 1`] = `
 
 exports[`Markdown should render code blocks without escaping 1`] = `
 
-<pre class="rsg--pre-28">
-  <code class="lang-html rsg--code-29">
+<pre class="rsg--pre-27">
+  <code class="lang-html rsg--code-28">
     <foo>
     </foo>
   </code>
@@ -142,33 +148,33 @@ exports[`Markdown should render code blocks without escaping 1`] = `
 exports[`Markdown should render headings correctly 1`] = `
 
 <div>
-  <div class="rsg--spacing-6">
-    <h1 class="rsg--heading-7 rsg--heading1-8">
+  <div class="rsg--spacing-5">
+    <h1 class="rsg--heading-6 rsg--heading1-7">
       one
     </h1>
   </div>
-  <div class="rsg--spacing-6">
-    <h2 class="rsg--heading-7 rsg--heading2-9">
+  <div class="rsg--spacing-5">
+    <h2 class="rsg--heading-6 rsg--heading2-8">
       two
     </h2>
   </div>
-  <div class="rsg--spacing-6">
-    <h3 class="rsg--heading-7 rsg--heading3-10">
+  <div class="rsg--spacing-5">
+    <h3 class="rsg--heading-6 rsg--heading3-9">
       three
     </h3>
   </div>
-  <div class="rsg--spacing-6">
-    <h4 class="rsg--heading-7 rsg--heading4-11">
+  <div class="rsg--spacing-5">
+    <h4 class="rsg--heading-6 rsg--heading4-10">
       four
     </h4>
   </div>
-  <div class="rsg--spacing-6">
-    <h5 class="rsg--heading-7 rsg--heading5-12">
+  <div class="rsg--spacing-5">
+    <h5 class="rsg--heading-6 rsg--heading5-11">
       five
     </h5>
   </div>
-  <div class="rsg--spacing-6">
-    <h6 class="rsg--heading-7 rsg--heading6-13">
+  <div class="rsg--spacing-5">
+    <h6 class="rsg--heading-6 rsg--heading6-12">
       six
     </h6>
   </div>
@@ -178,9 +184,9 @@ exports[`Markdown should render headings correctly 1`] = `
 
 exports[`Markdown should render inline code with escaping 1`] = `
 
-<p class="rsg--para-4">
+<p class="rsg--para-3">
   Foo
-  <code class="rsg--code-29">
+  <code class="rsg--code-28">
     &lt;bar&gt;
   </code>
   baz
@@ -190,10 +196,10 @@ exports[`Markdown should render inline code with escaping 1`] = `
 
 exports[`Markdown should render links 1`] = `
 
-<p class="rsg--para-4">
+<p class="rsg--para-3">
   a
   <a href="http://test.com"
-     class="rsg--link-5"
+     class="rsg--link-4"
   >
     link
   </a>
@@ -203,25 +209,25 @@ exports[`Markdown should render links 1`] = `
 
 exports[`Markdown should render mixed nested lists correctly 1`] = `
 
-<ul class="rsg--list-24">
-  <li class="rsg--li-26">
+<ul class="rsg--list-23">
+  <li class="rsg--li-25">
     list 1
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     list 2
-    <ol class="rsg--list-24 rsg--ordered-25">
-      <li class="rsg--li-26">
+    <ol class="rsg--list-23 rsg--ordered-24">
+      <li class="rsg--li-25">
         Sub-list
       </li>
-      <li class="rsg--li-26">
+      <li class="rsg--li-25">
         Sub-list
       </li>
-      <li class="rsg--li-26">
+      <li class="rsg--li-25">
         Sub-list
       </li>
     </ol>
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     list 3
   </li>
 </ul>
@@ -230,14 +236,14 @@ exports[`Markdown should render mixed nested lists correctly 1`] = `
 
 exports[`Markdown should render ordered lists correctly 1`] = `
 
-<ol class="rsg--list-24 rsg--ordered-25">
-  <li class="rsg--li-26">
+<ol class="rsg--list-23 rsg--ordered-24">
+  <li class="rsg--li-25">
     list
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     item
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     three
   </li>
 </ol>
@@ -246,14 +252,14 @@ exports[`Markdown should render ordered lists correctly 1`] = `
 
 exports[`Markdown should render unordered lists correctly 1`] = `
 
-<ul class="rsg--list-24">
-  <li class="rsg--li-26">
+<ul class="rsg--list-23">
+  <li class="rsg--li-25">
     list
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     item
   </li>
-  <li class="rsg--li-26">
+  <li class="rsg--li-25">
     three
   </li>
 </ul>

--- a/src/rsg-components/Message/__snapshots__/Message.spec.js.snap
+++ b/src/rsg-components/Message/__snapshots__/Message.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renderer should render message 1`] = `
 <div>
-  <Styled(Markdown)
+  <Markdown
     text="Hello *world*!"
   />
 </div>
@@ -10,7 +10,7 @@ exports[`renderer should render message 1`] = `
 
 exports[`renderer should render message for array 1`] = `
 <div>
-  <Styled(Markdown)
+  <Markdown
     text="Hello *world*!
 Foo _bar_"
   />

--- a/src/rsg-components/Methods/__snapshots__/Methods.spec.js.snap
+++ b/src/rsg-components/Methods/__snapshots__/Methods.spec.js.snap
@@ -150,7 +150,7 @@ exports[`PropsRenderer should render parameters 1`] = `
       key="2"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Public"
         />
         <JsDoc />
@@ -185,7 +185,7 @@ exports[`PropsRenderer should render public method 1`] = `
       key="2"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Public"
         />
         <JsDoc />

--- a/src/rsg-components/Props/__snapshots__/Props.spec.js.snap
+++ b/src/rsg-components/Props/__snapshots__/Props.spec.js.snap
@@ -573,7 +573,7 @@ exports[`props columns should render PropTypes.shape with description 1`] = `
               Required
             </Styled(Text)>
              — 
-            <Styled(Markdown)
+            <Markdown
               inline={true}
               text="Number"
             />
@@ -589,7 +589,7 @@ exports[`props columns should render PropTypes.shape with description 1`] = `
               any
             </Styled(Type)>
              — 
-            <Styled(Markdown)
+            <Markdown
               inline={true}
               text="Any"
             />
@@ -833,7 +833,7 @@ exports[`props columns should render arguments from JsDoc tags 1`] = `
       key="3"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Test description"
         />
         <JsDoc
@@ -907,7 +907,7 @@ exports[`props columns should render description in Markdown 1`] = `
       key="3"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Label"
         />
         <JsDoc />
@@ -1067,7 +1067,7 @@ exports[`props columns should render name as deprecated when tag deprecated is p
       key="3"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Test description"
         />
         <JsDoc
@@ -1114,7 +1114,7 @@ exports[`props columns should render return from JsDoc tags 1`] = `
       key="3"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Test description"
         />
         <JsDoc
@@ -1174,7 +1174,7 @@ exports[`props columns should render return from JsDoc tags 2`] = `
       key="3"
     >
       <div>
-        <Styled(Markdown)
+        <Markdown
           text="Test description"
         />
         <JsDoc

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`ReactComponent should pass rendered description, usage, examples, etc. to the renderer 1`] = `
 <Styled(ReactComponent)
   description={
-    <Styled(Markdown)
+    <Markdown
       text="Bar"
     />
   }

--- a/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
+++ b/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
@@ -9,7 +9,7 @@ exports[`renderer should render logo, table of contents and passed children 1`] 
       Content
     </h1>
     <footer>
-      <Styled(Markdown)
+      <Markdown
         text="Generated with [React Styleguidist](http://react-styleguidist.js.org/)"
       />
     </footer>

--- a/src/rsg-components/Welcome/__snapshots__/Welcome.spec.js.snap
+++ b/src/rsg-components/Welcome/__snapshots__/Welcome.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renderer should render welcome screen 1`] = `
 <div>
-  <Styled(Markdown)
+  <Markdown
     text="
 # Welcome to React Styleguidist!
 


### PR DESCRIPTION
This makes it easier for consumers to override individual components in the markdown of their styleguide, specifically <hr> in this PR.

* Remove the now un-needed styles from the Markdown component
* Simplify the Markdown tests and add full coverage for overridden components