### PR TITLE
feat: change template container id to prevent clashes

### DIFF
--- a/scripts/templates/index.html
+++ b/scripts/templates/index.html
@@ -6,6 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	</head>
 	<body>
-		<div id="app"></div>
+		<div id="rsg-root"></div>
 	</body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,17 @@ let codeRevision = 0;
 const render = () => {
 	// eslint-disable-next-line import/no-unresolved
 	const styleguide = require('!!../loaders/styleguide-loader!./index.js');
-	ReactDOM.render(renderStyleguide(styleguide, codeRevision), document.getElementById('app'));
+	let containerId = 'rsg-root';
+
+	if (document.getElementById('app')) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			"The use of 'app' element id in the template is deprecated. Please, update your template file to use 'rsg-root' as the container id."
+		);
+		containerId = 'app';
+	}
+
+	ReactDOM.render(renderStyleguide(styleguide, codeRevision), document.getElementById(containerId));
 };
 
 window.addEventListener('hashchange', render);


### PR DESCRIPTION
This PR addresses issue #753 with the following changes:

* use 'rsg-root' id insted of 'app' on the main container
* print deprecation warning to the console if 'app' id is used in custom template