### PR TITLE
Add documentation on how to dev on examples other then basic (which i…

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -52,6 +52,18 @@ npm run test:jest -- -u
 * We’re using [Prettier](https://github.com/prettier/prettier) to format JavaScript, so don’t worry much about code formatting.
 * Don’t commit generated files, like minified JavaScript.
 * Don’t change version number and change log.
+* If you're updating examples other then `examples/basic`, you'll need to modify your watch and start commands:
+
+```bash
+npm run compile:watch & npm start:customised # if making changes to examples/customized
+npm run compile:watch & npm start:sections # if making changes to examples/sections
+```
+
+See the `scripts` section of the top level `package.json`. If an example doesn't have a script just point to it's config:
+
+```bash
+node bin/styleguidist.js server --config examples/path/to/example/styleguide.config.js
+```bash
 
 ## Need help?
 

--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -63,7 +63,7 @@ See the `scripts` section of the top level `package.json`. If an example doesn't
 
 ```bash
 node bin/styleguidist.js server --config examples/path/to/example/styleguide.config.js
-```bash
+```
 
 ## Need help?
 

--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -55,8 +55,8 @@ npm run test:jest -- -u
 * If you're updating examples other then `examples/basic`, you'll need to modify your watch and start commands:
 
 ```bash
-npm run compile:watch & npm start:customised # if making changes to examples/customized
-npm run compile:watch & npm start:sections # if making changes to examples/sections
+npm run compile:watch & npm run start:customised # if making changes to examples/customised
+npm run compile:watch & npm run start:sections # if making changes to examples/sections
 ```
 
 See the `scripts` section of the top level `package.json`. If an example doesn't have a script just point to it's config:

--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -58,8 +58,9 @@ npm run test:jest -- -u
 npm run compile:watch & npm run start:customised # if making changes to examples/customised
 npm run compile:watch & npm run start:sections # if making changes to examples/sections
 ```
+See the `scripts` section of the top level [package.json](https://github.com/styleguidist/react-styleguidist/blob/master/package.json#L135)
 
-See the `scripts` section of the top level `package.json`. If an example doesn't have a script just point to it's config:
+. If an example doesn't have a script just point to its config:
 
 ```bash
 node bin/styleguidist.js server --config examples/path/to/example/styleguide.config.js


### PR DESCRIPTION
Discovered when working on https://github.com/styleguidist/react-styleguidist/pull/878 PR .. while it's discernible from from examining the package.json scripts, it's pretty intuitive to want to cd in to examples/* directories and initialize those apps there (which results in pointing to THAT particular example's node_modules version of styleguidist, so changes to top level dev styleguidist won't have any effect). These directions might have made things easier for me. Adds the following to Other notes
section:

![image](https://user-images.githubusercontent.com/142403/37675248-056e5d1e-2c32-11e8-878f-c274e54a7a49.png)
