### PR TITLE
Fix the bug when section name is not english

### DIFF
--- a/src/utils/__tests__/getInfoFromHash.spec.js
+++ b/src/utils/__tests__/getInfoFromHash.spec.js
@@ -11,7 +11,7 @@ describe('getInfoFromHash', () => {
 		expect(result).toEqual({});
 	});
 
-	it('should return the right targetName when router name is not english such as chinese', () => {
+	it('should return the decoded targetName when router name is not english such as chinese', () => {
 		const result = getInfoFromHash('#!/Api%20%E7%BB%84%E4%BB%B6');
 		expect(result).toEqual({ targetName: 'Api 组件', targetIndex: undefined });
 	});

--- a/src/utils/__tests__/getInfoFromHash.spec.js
+++ b/src/utils/__tests__/getInfoFromHash.spec.js
@@ -10,4 +10,9 @@ describe('getInfoFromHash', () => {
 		const result = getInfoFromHash('Button');
 		expect(result).toEqual({});
 	});
+
+	it('should return the right targetName when router name is not english such as chinese', () => {
+		const result = getInfoFromHash('#!/Api%20%E7%BB%84%E4%BB%B6');
+		expect(result).toEqual({ targetName: 'Api 组件', targetIndex: undefined });
+	});
 });

--- a/src/utils/__tests__/getInfoFromHash.spec.js
+++ b/src/utils/__tests__/getInfoFromHash.spec.js
@@ -11,7 +11,7 @@ describe('getInfoFromHash', () => {
 		expect(result).toEqual({});
 	});
 
-	it('should return the decoded targetName when router name is not english such as chinese', () => {
+	it('should return the decoded targetName when router name is not English such as Chinese', () => {
 		const result = getInfoFromHash('#!/Api%20%E7%BB%84%E4%BB%B6');
 		expect(result).toEqual({ targetName: 'Api 组件', targetIndex: undefined });
 	});

--- a/src/utils/getInfoFromHash.js
+++ b/src/utils/getInfoFromHash.js
@@ -14,7 +14,7 @@ export default function getInfoFromHash(hash) {
 		const tokens = hash.substr(3).split('/');
 		const index = parseInt(tokens[1], 10);
 		return {
-			targetName: tokens[0],
+			targetName: decodeURIComponent(tokens[0]),
 			targetIndex: isNaN(index) ? undefined : index,
 		};
 	}


### PR DESCRIPTION
Fix the bug when section name is not english such as chinese, then switch router will be failed.

![image](https://user-images.githubusercontent.com/5652404/37812528-805e8b32-2e9b-11e8-85c0-dd8065ed13ae.png)

repeat step:
1. set option `pagePerSection: true`
2. change some section name to chinese like `测试`
3. click the link to the section
4. click other section link
5. click the chinese section again