### PR TITLE
Replace System.import with import

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,28 +1,29 @@
 {
 	"presets": [
-    ["env", {
-      "targets": {
-        "uglify": true
-      },
-      "modules": false
-    }],
+		[
+			"env",
+			{
+				"targets": {
+					"uglify": true
+				},
+				"modules": false
+			}
+		],
 		"react"
 	],
 	"plugins": [
 		"transform-class-properties",
-		"transform-object-rest-spread"
+		"transform-object-rest-spread",
+		"syntax-dynamic-import"
 	],
 	"env": {
-	  "test": {
-	    "presets": [
-	      "env",
-	      "react"
-	    ],
-      "plugins": [
-        "system-import-transformer",
-        "transform-class-properties",
-        "transform-object-rest-spread"
-      ]
-    }
-  }
+		"test": {
+			"presets": ["env", "react"],
+			"plugins": [
+				"system-import-transformer",
+				"transform-class-properties",
+				"transform-object-rest-spread"
+			]
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.0.0",
     "babel-loader": "^7.1.4",
+    "babel-plugin-syntax-dynamic-import": "~6.18.0",
     "babel-plugin-system-import-transformer": "^3.1.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/src/rsg-components/Editor/EditorLoader.js
+++ b/src/rsg-components/Editor/EditorLoader.js
@@ -7,7 +7,7 @@ export default class EditorLoader extends Component {
 	};
 
 	componentDidMount() {
-		System.import('rsg-components/Editor/Editor').then(module => {
+		import('rsg-components/Editor/Editor').then(module => {
 			this.setState({ editor: module.default });
 		});
 	}


### PR DESCRIPTION
Fixes #900

I've read [Webpack's documentation](https://webpack.js.org/guides/code-splitting/#dynamic-imports) which links to [Babel's documentation](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation) and this seems the way to go.

I've never used dynamic imports before, so feedback is appreciated.