### PR TITLE
Docs: Use `npx` instead of custom scripts

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -654,6 +654,6 @@ module.exports = {
 
 > **Note:** `CommonsChunkPlugins`, `HtmlWebpackPlugin`, `UglifyJsPlugin`, `HotModuleReplacementPlugin` plugins will be ignored because Styleguidist already includes them or they may break Styleguidist.
 
-> **Note:** Run style guide in verbose mode to see the actual webpack config used by Styleguidist: `npm run styleguide -- --verbose`.
+> **Note:** Run style guide in verbose mode to see the actual webpack config used by Styleguidist: `npx styleguidist server -- --verbose`.
 
 See [Configuring webpack](Webpack.md) for examples.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -654,6 +654,6 @@ module.exports = {
 
 > **Note:** `CommonsChunkPlugins`, `HtmlWebpackPlugin`, `UglifyJsPlugin`, `HotModuleReplacementPlugin` plugins will be ignored because Styleguidist already includes them or they may break Styleguidist.
 
-> **Note:** Run style guide in verbose mode to see the actual webpack config used by Styleguidist: `npx styleguidist server -- --verbose`.
+> **Note:** Run style guide in verbose mode to see the actual webpack config used by Styleguidist: `npx styleguidist server --verbose`.
 
 See [Configuring webpack](Webpack.md) for examples.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,26 +20,13 @@ npm install --save-dev react-styleguidist
 
 [Point Styleguidist to your React components](Components.md) and [tell it how to load your code](Webpack.md).
 
-## 3. Add npm scripts for convenience
-
-Add these scripts to your `package.json`:
-
-```diff
-{
-  "scripts": {
-+    "styleguide": "styleguidist server",
-+    "styleguide:build": "styleguidist build"
-  }
-}
-```
-
-## 4. Start your style guide
+## 3. Start your style guide
 
 Run **`npx styleguidist server`** to start a style guide dev server.
 
 Run **`npx styleguidist build`** to build a static version.
 
-## 5. Start documenting your components
+## 4. Start documenting your components
 
 See how to [document your components](Documenting.md)
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -35,9 +35,9 @@ Add these scripts to your `package.json`:
 
 ## 4. Start your style guide
 
-Run **`npm run styleguide`** to start a style guide dev server.
+Run **`npx styleguidist server`** to start a style guide dev server.
 
-Run **`npm run styleguide:build`** to build a static version.
+Run **`npx styleguidist server:build`** to build a static version.
 
 ## 5. Start documenting your components
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -37,7 +37,7 @@ Add these scripts to your `package.json`:
 
 Run **`npx styleguidist server`** to start a style guide dev server.
 
-Run **`npx styleguidist server:build`** to build a static version.
+Run **`npx styleguidist build`** to build a static version.
 
 ## 5. Start documenting your components
 

--- a/docs/Thirdparties.md
+++ b/docs/Thirdparties.md
@@ -215,7 +215,7 @@ module.exports = {
 }
 ```
 
-This will automatically apply your theme to your styled-components. When you fire up the styleguide, `npm run styleguide`, you should see your components render as expected.
+This will automatically apply your theme to your styled-components. When you fire up the styleguide, `npx styleguidist server`, you should see your components render as expected.
 
 ### Fela
 

--- a/examples/basic/Readme.md
+++ b/examples/basic/Readme.md
@@ -10,7 +10,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/basic
 npm install
-npm run styleguide
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/cra/Readme.md
+++ b/examples/cra/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/cra
 npm install
-npm run styleguide
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/customised/Readme.md
+++ b/examples/customised/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/customised
 npm install
-npm run styleguide
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/express/Readme.md
+++ b/examples/express/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/express
 npm install
-npx styleguidist server-server
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/express/Readme.md
+++ b/examples/express/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/express
 npm install
-npm run styleguide-server
+npx styleguidist server-server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/preact/Readme.md
+++ b/examples/preact/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/preact
 npm install
-npm run styleguide
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -13,7 +13,7 @@ npm install
 Run Styleguidist
 
 ```
-npm run styleguide
+npx styleguidist server
 ```
 
 (Optional) Run the react-native app via simulator (or [Expo Client](https://expo.io/learn))

--- a/examples/sections/Readme.md
+++ b/examples/sections/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/sections
 npm install
-npm run styleguide
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/webpack/Readme.md
+++ b/examples/webpack/Readme.md
@@ -8,7 +8,7 @@ How to start locally:
 git clone https://github.com/styleguidist/react-styleguidist.git
 cd react-styleguidist/examples/webpack
 npm install
-npm run styleguide
+npx styleguidist server
 ```
 
 Then open [http://localhost:6060](http://localhost:6060) in your browser.


### PR DESCRIPTION
This PR updates the documentation to use `npx` instead of custom npm scripts.

Closes #836 