### PR TITLE
Fix: find() compatibility with IE11

### DIFF
--- a/src/utils/splitExampleCode.js
+++ b/src/utils/splitExampleCode.js
@@ -1,4 +1,5 @@
 import * as acorn from 'acorn';
+import find from 'lodash/find';
 
 // Strip semicolon (;) at the end
 const unsemicolon = s => s.replace(/;\s*$/, '');
@@ -25,7 +26,7 @@ export default function splitExampleCode(code) {
 		return { head: '', example: code };
 	}
 
-	const firstExpression = ast.body.reverse().find(({ type }) => type === 'ExpressionStatement');
+	const firstExpression = find(ast.body.reverse(), { type: 'ExpressionStatement' });
 	if (!firstExpression) {
 		return { head: '', example: code };
 	}


### PR DESCRIPTION
Closes #899 

I replaced the `lib/utils/splitExampleCode.js` file in my affected repo with the code built from this change. Everything seems to be working just fine.