### PR TITLE
Downgrade `markdown-to-jsx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
     "lowercase-keys": "^1.0.1",
-    "markdown-to-jsx": "^6.6.0",
+    "markdown-to-jsx": "^6.4.1",
     "mini-html-webpack-plugin": "^0.2.3",
     "minimist": "^1.2.0",
     "ora": "^2.0.0",


### PR DESCRIPTION
As discussed in #922 downgrade the minimal required version of `markdown-to-jsx` such that one can use a version without specific bugs.