### PR TITLE
Bump markdown-to-jsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9098,9 +9098,9 @@
       "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw="
     },
     "markdown-to-jsx": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.6.0.tgz",
-      "integrity": "sha1-MR9bezwYzv0GageABTFzDTpisCk=",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.6.1.tgz",
+      "integrity": "sha1-hYs3+KklJrHzQHWT/3fJWSdyC+8=",
       "requires": {
         "prop-types": "15.6.1",
         "unquote": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
     "lowercase-keys": "^1.0.1",
-    "markdown-to-jsx": "^6.6.0",
+    "markdown-to-jsx": "^6.6.1",
     "mini-html-webpack-plugin": "^0.2.3",
     "minimist": "^1.2.0",
     "ora": "^2.0.0",


### PR DESCRIPTION
Resolves #928.

Updates markdown-to-jsx to [version 6.6.1](https://github.com/probablyup/markdown-to-jsx/releases/tag/6.6.1), which has [a bugfix](https://github.com/probablyup/markdown-to-jsx/issues/168) for some rendering issues involving nested divs in markdown.