### PR TITLE
Add --open argument to open default browser on start

### DIFF
--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -7,6 +7,7 @@ const ora = require('ora');
 const stringify = require('q-i').stringify;
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const webpackDevServerUtils = require('react-dev-utils/WebpackDevServerUtils');
+const openBrowser = require('react-dev-utils/openBrowser');
 const logger = require('glogg')('rsg');
 const getConfig = require('../scripts/config');
 const setupLogger = require('../scripts/logger');
@@ -124,10 +125,20 @@ function commandServer() {
 			console.error(err);
 		} else {
 			const isHttps = compiler.options.devServer && compiler.options.devServer.https;
+			const urls = webpackDevServerUtils.prepareUrls(
+				isHttps ? 'https' : 'http',
+				config.serverHost,
+				config.serverPort
+			);
+
 			if (config.printServerInstructions) {
 				config.printServerInstructions(config, { isHttps });
 			} else {
-				printServerInstructions(config, { isHttps });
+				printServerInstructions(urls);
+			}
+
+			if (argv.open) {
+				openBrowser(urls.localUrlForBrowser);
 			}
 		}
 	}).compiler;
@@ -177,21 +188,16 @@ function commandHelp() {
 			chalk.underline('Options'),
 			'',
 			'    ' + chalk.yellow('--config') + '        Config file path',
+			'    ' + chalk.yellow('--open') + '          Opens Styleguidist with the default browser.',
 			'    ' + chalk.yellow('--verbose') + '       Print debug information',
 		].join('\n')
 	);
 }
 
 /**
- * @param {object} config
- * @param {options} options
+ * @param {object} urls
  */
-function printServerInstructions(config, options) {
-	const urls = webpackDevServerUtils.prepareUrls(
-		options.isHttps ? 'https' : 'http',
-		config.serverHost,
-		config.serverPort
-	);
+function printServerInstructions(urls) {
 	console.log(`You can now view your style guide in the browser:`);
 	console.log();
 	console.log(`  ${chalk.bold('Local:')}            ${urls.localUrlForTerminal}`);

--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -188,7 +188,7 @@ function commandHelp() {
 			chalk.underline('Options'),
 			'',
 			'    ' + chalk.yellow('--config') + '        Config file path',
-			'    ' + chalk.yellow('--open') + '          Opens Styleguidist with the default browser.',
+			'    ' + chalk.yellow('--open') + '          Open Styleguidist in the default browser',
 			'    ' + chalk.yellow('--verbose') + '       Print debug information',
 		].join('\n')
 	);

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,5 +9,5 @@ These commands are supposed to be placed in `package.json` `scripts` (see [Getti
 CLI Options:
 
 * `--config <file>`: Specify path to a config file.
-* `--open`: Opens Styleguidist with the default browser.
+* `--open`: Open Styleguidist in the default browser.
 * `--verbose`: Print debug information.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,4 +9,5 @@ These commands are supposed to be placed in `package.json` `scripts` (see [Getti
 CLI Options:
 
 * `--config <file>`: Specify path to a config file.
+* `--open`: Opens Styleguidist with the default browser.
 * `--verbose`: Print debug information.


### PR DESCRIPTION
Fixes https://github.com/styleguidist/react-styleguidist/issues/918

I had a look at #748 which uses `opn` directly, but I decided to go another path.

I've used `react-dev-utils`  [openBrowser](https://github.com/facebook/create-react-app/blob/next/packages/react-dev-utils/openBrowser.js), this used by `react-scripts` [here](https://github.com/facebook/create-react-app/blob/next/packages/react-scripts/scripts/start.js) to open the browser, it has some cool things like reusing an existing tab, but it also does some things based on the `BROWSER` env variable, so I have mixed feelings about using it and I'd love to hear what you think.

Since I needed the `urls` to open the browser I changed the `printServerInstructions` function to receive the `urls` as an argument, it should be fine since `config.printServerInstructions` still receives the same arguments.