### PR TITLE
bin: Don't report 'On your network' on localhost

### DIFF
--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -195,7 +195,9 @@ function printServerInstructions(config, options) {
 	console.log(`You can now view your style guide in the browser:`);
 	console.log();
 	console.log(`  ${chalk.bold('Local:')}            ${urls.localUrlForTerminal}`);
-	console.log(`  ${chalk.bold('On your network:')}  ${urls.lanUrlForTerminal}`);
+	if (urls.lanUrlForTerminal) {
+		console.log(`  ${chalk.bold('On your network:')}  ${urls.lanUrlForTerminal}`);
+	}
 	console.log();
 }
 


### PR DESCRIPTION
When explicitly setting the serverHost to 127.0.0.1 or localhost,
urls.lanUrlForTerminal is undefined. It makes no sense to print out
undefined, therefore only show the 'On your network' line when it's
defined.