### PR TITLE
Fix: Use section title for isolation mode if component is not available  (#965)

### DIFF
--- a/src/utils/__tests__/getPageTitle.spec.js
+++ b/src/utils/__tests__/getPageTitle.spec.js
@@ -20,6 +20,12 @@ describe('getPageTitle', () => {
 		expect(result).toMatch(name);
 	});
 
+	it('should return section name for example isolation mode, if no components are passed', () => {
+		const name = 'Section';
+		const result = getPageTitle([{ name }], baseTitle, 'example');
+		expect(result).toMatch(name);
+	});
+
 	it('should return section name for section isolation mode', () => {
 		const name = 'Section';
 		const result = getPageTitle([{ name }], baseTitle, 'section');

--- a/src/utils/getPageTitle.js
+++ b/src/utils/getPageTitle.js
@@ -13,6 +13,10 @@ import { DisplayModes } from '../consts';
  */
 export default function getPageTitle(sections, baseTitle, displayMode) {
 	if (displayMode === DisplayModes.component || displayMode === DisplayModes.example) {
+		if (!sections[0].components || !sections[0].components.length) {
+			return `${sections[0].name} — ${baseTitle}`;
+		}
+
 		return `${sections[0].components[0].name} — ${baseTitle}`;
 	} else if (displayMode === DisplayModes.section) {
 		return `${sections[0].name} — ${baseTitle}`;


### PR DESCRIPTION
Fixes issue #965 returning the section title, if no components are associated to the section that gets passed into the getPateTitle method.

The issue occurs when writing documentation in markdown with examples that don't directly relate to any component, such as typographic guidelines or colour patches.  