### PR TITLE
Add editorConfig to Editor

### DIFF
--- a/src/rsg-components/Editor/Editor.js
+++ b/src/rsg-components/Editor/Editor.js
@@ -28,8 +28,14 @@ export default class Editor extends Component {
 		this.handleChange = debounce(this.handleChange.bind(this), UPDATE_DELAY);
 	}
 
-	shouldComponentUpdate() {
-		return false;
+	shouldComponentUpdate(nextProps) {
+		return !!(this.getEditorConfig(nextProps).readOnly && nextProps.code !== this.props.code);
+	}
+
+	getEditorConfig(props) {
+		const { editorConfig } = props;
+		const contextEditorConfig = this.context.config.editorConfig;
+		return Object.assign({}, contextEditorConfig, editorConfig);
 	}
 
 	handleChange(editor, metadata, newCode) {
@@ -40,13 +46,12 @@ export default class Editor extends Component {
 	}
 
 	render() {
-		const { code, editorConfig } = this.props;
-		const contextEditorConfig = this.context.config.editorConfig;
+		const { code } = this.props;
 		return (
 			<CodeMirror
 				value={code}
 				onChange={this.handleChange}
-				options={Object.assign({}, contextEditorConfig, editorConfig)}
+				options={this.getEditorConfig(this.props)}
 			/>
 		);
 	}

--- a/src/rsg-components/Editor/Editor.js
+++ b/src/rsg-components/Editor/Editor.js
@@ -33,9 +33,10 @@ export default class Editor extends Component {
 	}
 
 	getEditorConfig(props) {
-		const { editorConfig } = props;
-		const contextEditorConfig = this.context.config.editorConfig;
-		return Object.assign({}, contextEditorConfig, editorConfig);
+		return {
+			...this.context.config.editorConfig,
+			...props.editorConfig,
+		};
 	}
 
 	handleChange(editor, metadata, newCode) {

--- a/src/rsg-components/Editor/Editor.js
+++ b/src/rsg-components/Editor/Editor.js
@@ -16,7 +16,8 @@ const UPDATE_DELAY = 10;
 export default class Editor extends Component {
 	static propTypes = {
 		code: PropTypes.string.isRequired,
-		onChange: PropTypes.func.isRequired,
+		onChange: PropTypes.func,
+		editorConfig: PropTypes.object,
 	};
 	static contextTypes = {
 		config: PropTypes.object.isRequired,
@@ -32,12 +33,21 @@ export default class Editor extends Component {
 	}
 
 	handleChange(editor, metadata, newCode) {
-		this.props.onChange(newCode);
+		const { onChange } = this.props;
+		if (onChange) {
+			onChange(newCode);
+		}
 	}
 
 	render() {
-		const { code } = this.props;
-		const { editorConfig } = this.context.config;
-		return <CodeMirror value={code} onChange={this.handleChange} options={editorConfig} />;
+		const { code, editorConfig } = this.props;
+		const contextEditorConfig = this.context.config.editorConfig;
+		return (
+			<CodeMirror
+				value={code}
+				onChange={this.handleChange}
+				options={Object.assign({}, contextEditorConfig, editorConfig)}
+			/>
+		);
 	}
 }

--- a/src/rsg-components/Editor/Editor.spec.js
+++ b/src/rsg-components/Editor/Editor.spec.js
@@ -11,6 +11,7 @@ const options = {
 			showCode: false,
 			highlightTheme: 'base16-light',
 			editorConfig: {
+				lineWrapping: true,
 				mode: 'js',
 			},
 		},
@@ -30,7 +31,10 @@ describe('EditorLoaderRenderer', () => {
 
 describe('Editor', () => {
 	it('should renderer and editor', () => {
-		const actual = shallow(<Editor code={code} onChange={() => {}} />, options);
+		const actual = shallow(
+			<Editor code={code} editorConfig={{ readOnly: true, mode: 'text/html' }} />,
+			options
+		);
 
 		expect(actual).toMatchSnapshot();
 	});

--- a/src/rsg-components/Editor/Editor.spec.js
+++ b/src/rsg-components/Editor/Editor.spec.js
@@ -57,4 +57,20 @@ describe('Editor', () => {
 			done();
 		}, 13);
 	});
+
+	it('should not update if not read only', () => {
+		const actual = shallow(<Editor code={code} />, options);
+
+		const shouldUpdate = actual.instance().shouldComponentUpdate({ code: newCode });
+		expect(shouldUpdate).toBe(false);
+	});
+
+	it('should update if read only and code has changed', () => {
+		const actual = shallow(<Editor code={code} editorConfig={{ readOnly: true }} />, options);
+
+		const shouldUpdate = actual
+			.instance()
+			.shouldComponentUpdate({ code: newCode, editorConfig: { readOnly: true } });
+		expect(shouldUpdate).toBe(true);
+	});
 });

--- a/src/rsg-components/Editor/__snapshots__/Editor.spec.js.snap
+++ b/src/rsg-components/Editor/__snapshots__/Editor.spec.js.snap
@@ -5,7 +5,9 @@ exports[`Editor should renderer and editor 1`] = `
   onChange={[Function]}
   options={
     Object {
-      "mode": "js",
+      "lineWrapping": true,
+      "mode": "text/html",
+      "readOnly": true,
     }
   }
   value=


### PR DESCRIPTION
Fixes #973.

Added new `editorConfig` prop to `Editor` which overrides context so that `Editor` can be used by future plugins.