### PR TITLE
Playground passes evalInContext to Slot

### DIFF
--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -86,7 +86,7 @@ export default class Playground extends Component {
 						name="exampleTabs"
 						active={activeTab}
 						onlyActive
-						props={{ code, onChange: this.handleChange }}
+						props={{ code, onChange: this.handleChange, evalInContext }}
 					/>
 				}
 				toolbar={

--- a/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
+++ b/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
@@ -65,6 +65,7 @@ exports[`should render component renderer 1`] = `
   OK
 </button>
 ,
+          "evalInContext": [Function],
           "onChange": [Function],
         }
       }


### PR DESCRIPTION
Fixes #977

`Playground` passes `evalInContext` to `Slot`