### PR TITLE
Update `markdown-to-jsx` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9088,9 +9088,9 @@
       "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw="
     },
     "markdown-to-jsx": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.6.0.tgz",
-      "integrity": "sha1-MR9bezwYzv0GageABTFzDTpisCk=",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.6.3.tgz",
+      "integrity": "sha1-zLJII2JX1BFoIriZT7+WBtBF0Yc=",
       "requires": {
         "prop-types": "15.6.1",
         "unquote": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
     "lowercase-keys": "^1.0.1",
-    "markdown-to-jsx": "^6.4.1",
+    "markdown-to-jsx": "^6.6.3",
     "mini-html-webpack-plugin": "^0.2.3",
     "minimist": "^1.2.0",
     "ora": "^2.0.0",


### PR DESCRIPTION
The issue of #922 has been resolved with `markdown-to-jsx@6.6.3` (thanks probablyup), therefore it would make sense to update the dependency.