### PR TITLE
Fix: repair user alias rsg-components when provided

### DIFF
--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -141,9 +141,10 @@ module.exports = function(config, env) {
 	}
 
 	// Add components folder alias at the end so users can override our components to customize the style guide
-	// (their aliases should be before this one)
-	webpackConfig.resolve.alias['rsg-components'] = path.resolve(sourceDir, 'rsg-components');
-
+	// (their aliases should be before this one
+	if (!webpackConfig.resolve.alias['rsg-components']) {
+  		webpackConfig.resolve.alias['rsg-components'] = path.resolve(sourceDir, 'rsg-components');
+	}
 	if (config.dangerouslyUpdateWebpackConfig) {
 		webpackConfig = config.dangerouslyUpdateWebpackConfig(webpackConfig, env);
 	}


### PR DESCRIPTION
Current code doesn't permit to alias `rsg-components`.

Only way of doing it is using `config.styleguideComponents`.

This allow user to set an alias.