### PR TITLE
Fix name conflicts by using slugs for routing in isolated mode

### DIFF
--- a/examples/sections/src/components/Button/Readme.md
+++ b/examples/sections/src/components/Button/Readme.md
@@ -1,13 +1,15 @@
 Basic button:
 
 ```jsx
-<Button>Push Me</Button>
+const Button = require('./Button').default
+;<Button>Push Me</Button>
 ```
 
 Big pink button:
 
 ```jsx
-<Button size="large" color="deeppink">
+const Button = require('./Button').default
+;<Button size="large" color="deeppink">
   Lick Me
 </Button>
 ```
@@ -17,12 +19,14 @@ And you _can_ **use** `any` [Markdown](http://daringfireball.net/projects/markdo
 Fenced code blocks with `js`, `jsx` or `javascript` languages are rendered as an interactive playgrounds:
 
 ```jsx
-<Button>Push Me</Button>
+const Button = require('./Button').default
+;<Button>Push Me</Button>
 ```
 
 You can disable an editor by passing a `noeditor` modifier (` ```js noeditor `):
 
 ```jsx noeditor
+const Button = require('./Button').default;
 <Button>Push Me</Button>
 ```
 

--- a/examples/sections/src/components/Toolbar/Button.css
+++ b/examples/sections/src/components/Toolbar/Button.css
@@ -1,0 +1,15 @@
+.toolbar-button {
+	padding: .5em 1.5em;
+	color: #666;
+	background-color: #fff;
+	border: 2px dashed currentColor;
+	border-radius: .3em;
+	text-align: center;
+	vertical-align: middle;
+	cursor: pointer;
+}
+
+.toolbar-button[disabled] {
+	opacity: 0.5;
+	cursor: not-allowed;
+}

--- a/examples/sections/src/components/Toolbar/Button.js
+++ b/examples/sections/src/components/Toolbar/Button.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './Button.css';
+
+/**
+ * The only true button.
+ */
+export default function Button({ color, size, children, disabled }) {
+	const styles = {
+		color,
+		fontSize: Button.sizes[size],
+	};
+
+	return (
+		<button className="toolbar-button" style={styles} disabled={disabled}>
+			{children}
+		</button>
+	);
+}
+Button.propTypes = {
+	/**
+	 * Button label.
+	 */
+	children: PropTypes.string.isRequired,
+	color: PropTypes.string,
+	size: PropTypes.oneOf(['small', 'normal', 'large']),
+	disabled: PropTypes.bool,
+};
+Button.defaultProps = {
+	color: '#333',
+	size: 'normal',
+};
+Button.sizes = {
+	small: '10px',
+	normal: '14px',
+	large: '18px',
+};

--- a/examples/sections/src/components/Toolbar/Readme.md
+++ b/examples/sections/src/components/Toolbar/Readme.md
@@ -1,0 +1,24 @@
+Basic toolbar button:
+
+```jsx
+const Button = require('./Button').default
+;<Button>Push Me</Button>
+```
+
+Big pink toolbar button:
+
+```jsx
+const Button = require('./Button').default
+;<Button size="large" color="deeppink">
+  Lick Me
+</Button>
+```
+
+Disabled toolbar button:
+
+```jsx
+const Button = require('./Button').default
+;<Button size="large" disabled>
+  You can't click me
+</Button>
+```

--- a/examples/sections/src/components/Toolbar/index.js
+++ b/examples/sections/src/components/Toolbar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Button';

--- a/examples/sections/styleguide.config.js
+++ b/examples/sections/styleguide.config.js
@@ -35,6 +35,10 @@ module.exports = {
 					],
 				},
 				{
+					name: 'Toolbar',
+					components: () => ['./src/components/Toolbar/Button.js'],
+				},
+				{
 					name: 'Fields',
 					components: () => [
 						'./src/components/Label/Label.js',

--- a/src/rsg-components/ComponentsList/__snapshots__/ComponentsList.spec.js.snap
+++ b/src/rsg-components/ComponentsList/__snapshots__/ComponentsList.spec.js.snap
@@ -69,12 +69,12 @@ exports[`should set the correct href for items when isolated links should be use
   items={
     Array [
       Object {
-        "href": "blank#!/Button",
+        "href": "blank#!/button",
         "name": "Button",
         "slug": "button",
       },
       Object {
-        "href": "blank#!/Input",
+        "href": "blank#!/input",
         "name": "Input",
         "slug": "input",
       },

--- a/src/rsg-components/Examples/Examples.js
+++ b/src/rsg-components/Examples/Examples.js
@@ -4,7 +4,7 @@ import Playground from 'rsg-components/Playground';
 import Markdown from 'rsg-components/Markdown';
 import ExamplesRenderer from 'rsg-components/Examples/ExamplesRenderer';
 
-export default function Examples({ examples, name }, { codeRevision }) {
+export default function Examples({ examples, name, slug }, { codeRevision }) {
 	return (
 		<ExamplesRenderer>
 			{examples.map((example, index) => {
@@ -16,6 +16,7 @@ export default function Examples({ examples, name }, { codeRevision }) {
 								evalInContext={example.evalInContext}
 								key={`${codeRevision}/${index}`}
 								name={name}
+								slug={slug}
 								index={index}
 								settings={example.settings}
 							/>
@@ -32,6 +33,7 @@ export default function Examples({ examples, name }, { codeRevision }) {
 Examples.propTypes = {
 	examples: PropTypes.array.isRequired,
 	name: PropTypes.string.isRequired,
+	slug: PropTypes.string.isRequired,
 };
 Examples.contextTypes = {
 	codeRevision: PropTypes.number.isRequired,

--- a/src/rsg-components/Examples/Examples.spec.js
+++ b/src/rsg-components/Examples/Examples.spec.js
@@ -16,7 +16,7 @@ const examples = [
 ];
 
 it('should render examples', () => {
-	const actual = shallow(<Examples examples={examples} name="button" />, {
+	const actual = shallow(<Examples examples={examples} name="button" slug="button" />, {
 		context: {
 			codeRevision: 1,
 			displayMode: DisplayModes.example,
@@ -34,7 +34,7 @@ it('should not render a example with unknown type', () => {
 		},
 	];
 
-	const actual = mount(<Examples examples={faultyExample} name="button" />, {
+	const actual = mount(<Examples examples={faultyExample} name="button" slug="button" />, {
 		context: {
 			codeRevision: 1,
 		},

--- a/src/rsg-components/Examples/__snapshots__/Examples.spec.js.snap
+++ b/src/rsg-components/Examples/__snapshots__/Examples.spec.js.snap
@@ -12,6 +12,7 @@ exports[`should render examples 1`] = `
     index={0}
     key="1/0"
     name="button"
+    slug="button"
   />
   <Markdown
     key="1"

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -14,6 +14,7 @@ export default class Playground extends Component {
 		evalInContext: PropTypes.func.isRequired,
 		index: PropTypes.number.isRequired,
 		name: PropTypes.string.isRequired,
+		slug: PropTypes.string.isRequired,
 		settings: PropTypes.object,
 	};
 
@@ -63,7 +64,7 @@ export default class Playground extends Component {
 
 	render() {
 		const { code, activeTab } = this.state;
-		const { evalInContext, index, name, settings } = this.props;
+		const { evalInContext, index, name, slug, settings } = this.props;
 		const { displayMode } = this.context;
 		const preview = <Preview code={code} evalInContext={evalInContext} />;
 		if (settings.noeditor) {
@@ -92,7 +93,7 @@ export default class Playground extends Component {
 				toolbar={
 					<Slot
 						name="exampleToolbar"
-						props={{ name, isolated: displayMode === DisplayModes.example, example: index }}
+						props={{ name, slug, isolated: displayMode === DisplayModes.example, example: index }}
 					/>
 				}
 			/>

--- a/src/rsg-components/Playground/Playground.spec.js
+++ b/src/rsg-components/Playground/Playground.spec.js
@@ -12,6 +12,7 @@ const newCode = '<button>Not OK</button>';
 const props = {
 	index: 0,
 	name: 'name',
+	slug: 'slug',
 	settings: {},
 	evalInContext,
 	code,

--- a/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
+++ b/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
@@ -90,6 +90,7 @@ exports[`should render component renderer 1`] = `
           "example": 0,
           "isolated": false,
           "name": "name",
+          "slug": "slug",
         }
       }
     />

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -75,7 +75,7 @@ export default class ReactComponent extends Component {
 				}
 				examples={
 					examples.length > 0 ? (
-						<Examples examples={examples} name={name} />
+						<Examples examples={examples} name={name} slug={slug} />
 					) : (
 						<ExamplePlaceholder name={name} />
 					)

--- a/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
+++ b/src/rsg-components/ReactComponent/__snapshots__/ReactComponent.spec.js.snap
@@ -28,6 +28,7 @@ exports[`ReactComponent should pass rendered description, usage, examples, etc. 
         ]
       }
       name="Foo"
+      slug="foo"
     />
   }
   heading={

--- a/src/rsg-components/Section/Section.js
+++ b/src/rsg-components/Section/Section.js
@@ -9,7 +9,7 @@ import { DisplayModes } from '../../consts';
 export default function Section({ section, depth }, { displayMode }) {
 	const { name, slug, filepath, content, components, sections, description } = section;
 
-	const contentJsx = content && <Examples examples={content} name={name} />;
+	const contentJsx = content && <Examples examples={content} name={name} slug={slug} />;
 	const componentsJsx = components && <Components components={components} depth={depth + 1} />;
 	const sectionsJsx = sections && <Sections sections={sections} depth={depth + 1} />;
 

--- a/src/rsg-components/Section/Section.spec.js
+++ b/src/rsg-components/Section/Section.spec.js
@@ -141,7 +141,7 @@ it('render should render section', () => {
 			classes={{}}
 			name={section.name}
 			slug={section.slug}
-			content={<Examples name={section.name} examples={section.content} />}
+			content={<Examples name={section.name} slug={section.slug} examples={section.content} />}
 			components={<Components components={[]} depth={3} />}
 			sections={<Sections sections={[]} depth={3} />}
 			depth={3}

--- a/src/rsg-components/Section/__snapshots__/Section.spec.js.snap
+++ b/src/rsg-components/Section/__snapshots__/Section.spec.js.snap
@@ -34,6 +34,7 @@ exports[`render should render section 1`] = `
             ]
           }
           name="Foo"
+          slug="foo"
         />,
         "depth": 3,
         "name": "Foo",
@@ -66,6 +67,7 @@ exports[`render should render section 1`] = `
       ]
     }
     name="Foo"
+    slug="foo"
   />
   <Sections
     depth={3}
@@ -159,6 +161,7 @@ exports[`should render section renderer 1`] = `
         ]
       }
       name="Foo"
+      slug="foo"
     />
   }
   depth={3}

--- a/src/rsg-components/slots/IsolateButton.js
+++ b/src/rsg-components/slots/IsolateButton.js
@@ -5,19 +5,19 @@ import MdFullscreenExit from 'react-icons/lib/md/fullscreen-exit';
 import ToolbarButton from 'rsg-components/ToolbarButton';
 import getUrl from '../../utils/getUrl';
 
-const IsolateButton = ({ name, example, isolated }) =>
+const IsolateButton = ({ slug, example, isolated }) =>
 	isolated ? (
 		<ToolbarButton href={getUrl({ anchor: true, slug: '/' })} title="Show all components">
 			<MdFullscreenExit />
 		</ToolbarButton>
 	) : (
-		<ToolbarButton href={getUrl({ name, example, isolated: true })} title="Open isolated">
+		<ToolbarButton href={getUrl({ slug, example, isolated: true })} title="Open isolated">
 			<MdFullscreen />
 		</ToolbarButton>
 	);
 
 IsolateButton.propTypes = {
-	name: PropTypes.string.isRequired,
+	slug: PropTypes.string.isRequired,
 	example: PropTypes.number,
 	isolated: PropTypes.bool,
 };

--- a/src/rsg-components/slots/IsolateButton.spec.js
+++ b/src/rsg-components/slots/IsolateButton.spec.js
@@ -2,19 +2,19 @@ import React from 'react';
 import IsolateButton from './IsolateButton';
 
 it('should renderer a link to isolated mode', () => {
-	const actual = shallow(<IsolateButton name="Pizza" />);
+	const actual = shallow(<IsolateButton slug="pizza" />);
 
 	expect(actual).toMatchSnapshot();
 });
 
 it('should renderer a link to example isolated mode', () => {
-	const actual = shallow(<IsolateButton name="Pizza" example={3} />);
+	const actual = shallow(<IsolateButton slug="pizza" example={3} />);
 
 	expect(actual).toMatchSnapshot();
 });
 
 it('should renderer a link home in isolated mode', () => {
-	const actual = shallow(<IsolateButton name="Pizza" isolated />);
+	const actual = shallow(<IsolateButton slug="pizza" isolated />);
 
 	expect(actual).toMatchSnapshot();
 });

--- a/src/rsg-components/slots/__snapshots__/IsolateButton.spec.js.snap
+++ b/src/rsg-components/slots/__snapshots__/IsolateButton.spec.js.snap
@@ -11,7 +11,7 @@ exports[`should renderer a link home in isolated mode 1`] = `
 
 exports[`should renderer a link to example isolated mode 1`] = `
 <Styled(ToolbarButton)
-  href="blank#!/Pizza/3"
+  href="blank#!/undefined/3"
   title="Open isolated"
 >
   <MdFullscreen />
@@ -20,7 +20,7 @@ exports[`should renderer a link to example isolated mode 1`] = `
 
 exports[`should renderer a link to isolated mode 1`] = `
 <Styled(ToolbarButton)
-  href="blank#!/Pizza"
+  href="blank#!/undefined"
   title="Open isolated"
 >
   <MdFullscreen />

--- a/src/rsg-components/slots/__snapshots__/IsolateButton.spec.js.snap
+++ b/src/rsg-components/slots/__snapshots__/IsolateButton.spec.js.snap
@@ -11,7 +11,7 @@ exports[`should renderer a link home in isolated mode 1`] = `
 
 exports[`should renderer a link to example isolated mode 1`] = `
 <Styled(ToolbarButton)
-  href="blank#!/undefined/3"
+  href="blank#!/pizza/3"
   title="Open isolated"
 >
   <MdFullscreen />
@@ -20,7 +20,7 @@ exports[`should renderer a link to example isolated mode 1`] = `
 
 exports[`should renderer a link to isolated mode 1`] = `
 <Styled(ToolbarButton)
-  href="blank#!/undefined"
+  href="blank#!/pizza"
   title="Open isolated"
 >
   <MdFullscreen />

--- a/src/utils/__tests__/__snapshots__/getRouteData.spec.js.snap
+++ b/src/utils/__tests__/__snapshots__/getRouteData.spec.js.snap
@@ -16,6 +16,7 @@ Object {
               "example 1",
             ],
           },
+          "slug": "button",
         },
       ],
       "sections": Array [],
@@ -42,6 +43,7 @@ Object {
                   "example 1",
                 ],
               },
+              "slug": "button",
             },
             Object {
               "module": 2,
@@ -49,6 +51,7 @@ Object {
               "props": Object {
                 "displayName": "Image",
               },
+              "slug": "image",
             },
           ],
           "sections": Array [],
@@ -61,6 +64,7 @@ Object {
           ],
           "name": "Section",
           "sections": Array [],
+          "slug": "section",
         },
       ],
     },
@@ -84,6 +88,7 @@ Object {
               "example 1",
             ],
           },
+          "slug": "button",
         },
       ],
     },
@@ -106,6 +111,7 @@ Object {
               "example 1",
             ],
           },
+          "slug": "button",
         },
       ],
     },
@@ -124,6 +130,7 @@ Object {
       ],
       "name": "Section",
       "sections": Array [],
+      "slug": "section",
     },
   ],
 }
@@ -141,6 +148,7 @@ Object {
       ],
       "name": "Section",
       "sections": Array [],
+      "slug": "section",
     },
   ],
 }

--- a/src/utils/__tests__/__snapshots__/renderStyleguide.spec.js.snap
+++ b/src/utils/__tests__/__snapshots__/renderStyleguide.spec.js.snap
@@ -17,6 +17,7 @@ exports[`renderStyleguide should render StyleGuide component 1`] = `
                   "displayName": "Button",
                   "examples": Array [],
                 },
+                "slug": "button",
               },
               Object {
                 "module": "ImageModule",
@@ -25,6 +26,7 @@ exports[`renderStyleguide should render StyleGuide component 1`] = `
                   "displayName": "Image",
                   "examples": Array [],
                 },
+                "slug": "image",
               },
             ],
             "sections": Array [],
@@ -48,6 +50,7 @@ exports[`renderStyleguide should render StyleGuide component 1`] = `
                 "displayName": "Button",
                 "examples": Array [],
               },
+              "slug": "button",
             },
             Object {
               "module": "ImageModule",
@@ -56,6 +59,7 @@ exports[`renderStyleguide should render StyleGuide component 1`] = `
                 "displayName": "Image",
                 "examples": Array [],
               },
+              "slug": "image",
             },
           ],
           "sections": Array [],

--- a/src/utils/__tests__/filterComponentsBySlug.spec.js
+++ b/src/utils/__tests__/filterComponentsBySlug.spec.js
@@ -1,0 +1,18 @@
+import deepfreeze from 'deepfreeze';
+import filterComponentsBySlug from '../filterComponentsBySlug';
+
+const components = deepfreeze([
+	{
+		slug: 'button',
+	},
+	{
+		slug: 'image',
+	},
+]);
+
+describe('filterComponentsBySlug', () => {
+	it('should return components with exact slug', () => {
+		const result = filterComponentsBySlug(components, 'image');
+		expect(result.map(x => x.slug)).toEqual(['image']);
+	});
+});

--- a/src/utils/__tests__/filterComponentsInSectionsBySlug.spec.js
+++ b/src/utils/__tests__/filterComponentsInSectionsBySlug.spec.js
@@ -1,0 +1,28 @@
+import deepfreeze from 'deepfreeze';
+import filterComponentsInSectionsBySlug from '../filterComponentsInSectionsBySlug';
+
+const sections = deepfreeze([
+	{
+		slug: 'general',
+		sections: [
+			{
+				slug: 'particles',
+				components: [
+					{
+						slug: 'button',
+					},
+					{
+						slug: 'image',
+					},
+				],
+			},
+		],
+	},
+]);
+
+describe('filterComponentsInSectionsBySlug', () => {
+	it('should return components at any level with exact slug', () => {
+		const result = filterComponentsInSectionsBySlug(sections, 'image');
+		expect(result.map(x => x.slug)).toEqual(['image']);
+	});
+});

--- a/src/utils/__tests__/findSection.spec.js
+++ b/src/utils/__tests__/findSection.spec.js
@@ -3,15 +3,19 @@ import findSection from '../findSection';
 const sections = [
 	{
 		name: 'General',
+		slug: 'general',
 		sections: [
 			{
 				name: 'Particles',
+				slug: 'particles',
 				components: [
 					{
 						name: 'Button',
+						slug: 'button',
 					},
 					{
 						name: 'Image',
+						slug: 'image',
 					},
 				],
 			},
@@ -21,12 +25,12 @@ const sections = [
 
 describe('findSection', () => {
 	it('should return top level section', () => {
-		const result = findSection(sections, 'General');
+		const result = findSection(sections, 'general');
 		expect(result).toEqual(sections[0]);
 	});
 
 	it('should return nested sections', () => {
-		const result = findSection(sections, 'Particles');
+		const result = findSection(sections, 'particles');
 		expect(result).toEqual(sections[0].sections[0]);
 	});
 

--- a/src/utils/__tests__/getInfoFromHash.spec.js
+++ b/src/utils/__tests__/getInfoFromHash.spec.js
@@ -2,17 +2,17 @@ import getInfoFromHash from '../getInfoFromHash';
 
 describe('getInfoFromHash', () => {
 	it('should return important part of hash if it contains component name', () => {
-		const result = getInfoFromHash('#!/Button');
-		expect(result).toEqual({ targetName: 'Button', targetIndex: undefined });
+		const result = getInfoFromHash('#!/button');
+		expect(result).toEqual({ targetSlug: 'button', targetIndex: undefined });
 	});
 
 	it('should return an empty object if hash contains no component name', () => {
-		const result = getInfoFromHash('Button');
+		const result = getInfoFromHash('button');
 		expect(result).toEqual({});
 	});
 
-	it('should return the decoded targetName when router name is not English such as Chinese', () => {
+	it('should return the decoded targetSlug when router name is not English such as Chinese', () => {
 		const result = getInfoFromHash('#!/Api%20%E7%BB%84%E4%BB%B6');
-		expect(result).toEqual({ targetName: 'Api 组件', targetIndex: undefined });
+		expect(result).toEqual({ targetSlug: 'Api 组件', targetIndex: undefined });
 	});
 });

--- a/src/utils/__tests__/getRouteData.spec.js
+++ b/src/utils/__tests__/getRouteData.spec.js
@@ -9,6 +9,7 @@ const sections = deepfreeze([
 				components: [
 					{
 						name: 'Button',
+						slug: 'button',
 						props: {
 							displayName: 'Button',
 							examples: ['example 0', 'example 1'],
@@ -17,6 +18,7 @@ const sections = deepfreeze([
 					},
 					{
 						name: 'Image',
+						slug: 'image',
 						props: {
 							displayName: 'Image',
 						},
@@ -27,6 +29,7 @@ const sections = deepfreeze([
 			},
 			{
 				name: 'Section',
+				slug: 'section',
 				content: ['example 0', 'example 1'],
 				components: [],
 				sections: [],
@@ -42,22 +45,22 @@ describe('getRouteData', () => {
 	});
 
 	it('should return one component', () => {
-		const result = getRouteData(sections, '#!/Button');
+		const result = getRouteData(sections, '#!/button');
 		expect(result).toMatchSnapshot();
 	});
 
 	it('should return one section', () => {
-		const result = getRouteData(sections, '#!/Section');
+		const result = getRouteData(sections, '#!/section');
 		expect(result).toMatchSnapshot();
 	});
 
 	it('should return one example from a component', () => {
-		const result = getRouteData(sections, '#!/Button/1');
+		const result = getRouteData(sections, '#!/button/1');
 		expect(result).toMatchSnapshot();
 	});
 
 	it('should return one example from a section', () => {
-		const result = getRouteData(sections, '#!/Section/1');
+		const result = getRouteData(sections, '#!/section/1');
 		expect(result).toMatchSnapshot();
 	});
 

--- a/src/utils/__tests__/getUrl.spec.js
+++ b/src/utils/__tests__/getUrl.spec.js
@@ -5,8 +5,8 @@ describe('getUrl', () => {
 		origin: 'http://example.com',
 		pathname: '/styleguide/',
 	};
-	const name = 'FooBar';
-	const slug = 'foobar';
+	const name = 'fobar';
+	const slug = 'fobar';
 
 	it('should return a home URL', () => {
 		const result = getUrl({}, loc);
@@ -20,46 +20,46 @@ describe('getUrl', () => {
 
 	it('should return an anchor URL', () => {
 		const result = getUrl({ name, slug, anchor: true }, loc);
-		expect(result).toBe('/styleguide/#foobar');
+		expect(result).toBe('/styleguide/#fobar');
 	});
 
 	it('should return an absolute anchor URL', () => {
 		const result = getUrl({ name, slug, anchor: true, absolute: true }, loc);
-		expect(result).toBe('http://example.com/styleguide/#foobar');
+		expect(result).toBe('http://example.com/styleguide/#fobar');
 	});
 
 	it('should return an isolated URL', () => {
 		const result = getUrl({ name, slug, isolated: true }, loc);
-		expect(result).toBe('/styleguide/#!/FooBar');
+		expect(result).toBe('/styleguide/#!/fobar');
 	});
 
 	it('should return an absolute isolated URL', () => {
 		const result = getUrl({ name, slug, isolated: true, absolute: true }, loc);
-		expect(result).toBe('http://example.com/styleguide/#!/FooBar');
+		expect(result).toBe('http://example.com/styleguide/#!/fobar');
 	});
 
 	it('should return an isolated example URL', () => {
 		const result = getUrl({ name, slug, example: 3, isolated: true }, loc);
-		expect(result).toBe('/styleguide/#!/FooBar/3');
+		expect(result).toBe('/styleguide/#!/fobar/3');
 	});
 
 	it('should return an isolated example=0 URL', () => {
 		const result = getUrl({ name, slug, example: 0, isolated: true }, loc);
-		expect(result).toBe('/styleguide/#!/FooBar/0');
+		expect(result).toBe('/styleguide/#!/fobar/0');
 	});
 
 	it('should return an absolute isolated example URL', () => {
 		const result = getUrl({ name, slug, example: 3, isolated: true, absolute: true }, loc);
-		expect(result).toBe('http://example.com/styleguide/#!/FooBar/3');
+		expect(result).toBe('http://example.com/styleguide/#!/fobar/3');
 	});
 
 	it('should return a nochrome URL', () => {
 		const result = getUrl({ name, slug, nochrome: true }, loc);
-		expect(result).toBe('/styleguide/?nochrome#!/FooBar');
+		expect(result).toBe('/styleguide/?nochrome#!/fobar');
 	});
 
 	it('should return an absolute nochrome URL', () => {
 		const result = getUrl({ name, slug, nochrome: true, absolute: true }, loc);
-		expect(result).toBe('http://example.com/styleguide/?nochrome#!/FooBar');
+		expect(result).toBe('http://example.com/styleguide/?nochrome#!/fobar');
 	});
 });

--- a/src/utils/__tests__/renderStyleguide.spec.js
+++ b/src/utils/__tests__/renderStyleguide.spec.js
@@ -12,12 +12,14 @@ const styleguide = {
 						displayName: 'Button',
 					},
 					module: 'ButtonModule',
+					slug: 'button',
 				},
 				{
 					props: {
 						displayName: 'Image',
 					},
 					module: 'ImageModule',
+					slug: 'image',
 				},
 			],
 		},
@@ -54,7 +56,7 @@ describe('renderStyleguide', () => {
 	});
 
 	it('should globalize all components in isolated mode', () => {
-		renderStyleguide(styleguide, codeRevision, { hash: '#!/Button' }, doc, history);
+		renderStyleguide(styleguide, codeRevision, { hash: '#!/button' }, doc, history);
 		expect(global.Button).toBe('ButtonModule');
 		expect(global.Image).toBe('ImageModule');
 	});
@@ -71,7 +73,7 @@ describe('renderStyleguide', () => {
 
 	it('should change document title in isolated mode', () => {
 		const title = jest.fn();
-		const location = { hash: '#!/Button' };
+		const location = { hash: '#!/button' };
 		Object.defineProperty(location, 'title', {
 			set: title,
 		});

--- a/src/utils/filterComponentsBySlug.js
+++ b/src/utils/filterComponentsBySlug.js
@@ -1,0 +1,10 @@
+/**
+ * Filters list of components by component slug.
+ *
+ * @param {Array} components
+ * @param {string} slug
+ * @return {Array}
+ */
+export default function filterComponentsBySlug(components, slug) {
+	return components.filter(component => component.slug === slug);
+}

--- a/src/utils/filterComponentsInSectionsBySlug.js
+++ b/src/utils/filterComponentsInSectionsBySlug.js
@@ -1,0 +1,21 @@
+import filterComponentsBySlug from './filterComponentsBySlug';
+
+/**
+ * Recursively filters all components in all sections by component slug.
+ *
+ * @param {object} sections
+ * @param {string} slug
+ * @return {Array}
+ */
+export default function filterComponentsInSectionsByExactName(sections, slug) {
+	const components = [];
+	sections.forEach(section => {
+		if (section.components) {
+			components.push(...filterComponentsBySlug(section.components, slug));
+		}
+		if (section.sections) {
+			components.push(...filterComponentsInSectionsByExactName(section.sections, slug));
+		}
+	});
+	return components;
+}

--- a/src/utils/findSection.js
+++ b/src/utils/findSection.js
@@ -1,12 +1,12 @@
 /**
- * Recursively finds a section with a given name (exact match)
+ * Recursively finds a section with a given slug (exact match)
  *
  * @param  {Array}  sections
- * @param  {string} name
+ * @param  {string} slug
  * @return {object}
  */
-export default function findSection(sections, name) {
-	const found = sections.find(section => section.name === name);
+export default function findSection(sections, slug) {
+	const found = sections.find(section => section.slug === slug);
 	if (found) {
 		return found;
 	}
@@ -15,7 +15,7 @@ export default function findSection(sections, name) {
 		if (!section.sections || section.sections.length === 0) {
 			continue;
 		}
-		const found = findSection(section.sections, name);
+		const found = findSection(section.sections, slug);
 		if (found) {
 			return found;
 		}

--- a/src/utils/getInfoFromHash.js
+++ b/src/utils/getInfoFromHash.js
@@ -3,8 +3,8 @@ import isNaN from 'lodash/isNaN';
 /**
  * Returns an object containing component/section name and, optionally, an example index
  * from hash part or page URL:
- * #!/Button → { targetName: 'Button' }
- * #!/Button/1 → { targetName: 'Button', targetIndex: 1 }
+ * #!/button → { targetSlug: 'button' }
+ * #!/button/1 → { targetSlug: 'button', targetIndex: 1 }
  *
  * @param {string} hash
  * @returns {object}
@@ -14,7 +14,7 @@ export default function getInfoFromHash(hash) {
 		const tokens = hash.substr(3).split('/');
 		const index = parseInt(tokens[1], 10);
 		return {
-			targetName: decodeURIComponent(tokens[0]),
+			targetSlug: decodeURIComponent(tokens[0]),
 			targetIndex: isNaN(index) ? undefined : index,
 		};
 	}

--- a/src/utils/getRouteData.js
+++ b/src/utils/getRouteData.js
@@ -1,6 +1,6 @@
 import isFinite from 'lodash/isFinite';
 import filterComponentExamples from './filterComponentExamples';
-import filterComponentsInSectionsByExactName from './filterComponentsInSectionsByExactName';
+import filterComponentsInSectionsBySlug from './filterComponentsInSectionsBySlug';
 import filterSectionExamples from './filterSectionExamples';
 import findSection from './findSection';
 import getInfoFromHash from './getInfoFromHash';
@@ -37,7 +37,7 @@ export default function getRouteData(sections, hash, pagePerSection) {
 	// Parse URL hash to check if the components list must be filtered
 	const {
 		// Name of the filtered component/section to show isolated (/#!/Button → Button)
-		targetName,
+		targetSlug,
 		// Index of the fenced block example of the filtered component isolate (/#!/Button/1 → 1)
 		targetIndex,
 	} = getInfoFromHash(hash);
@@ -45,13 +45,13 @@ export default function getRouteData(sections, hash, pagePerSection) {
 	let displayMode = DisplayModes.all;
 
 	// Filter the requested component if required
-	if (targetName) {
-		const filteredComponents = filterComponentsInSectionsByExactName(sections, targetName);
+	if (targetSlug) {
+		const filteredComponents = filterComponentsInSectionsBySlug(sections, targetSlug);
 		if (filteredComponents.length) {
 			sections = [{ components: filteredComponents }];
 			displayMode = DisplayModes.component;
 		} else {
-			const section = findSection(sections, targetName);
+			const section = findSection(sections, targetSlug);
 			sections = section ? [section] : [];
 			displayMode = DisplayModes.section;
 		}

--- a/src/utils/getUrl.js
+++ b/src/utils/getUrl.js
@@ -1,7 +1,6 @@
 /**
  * Get component / section URL.
  *
- * @param {string} $.name Name
  * @param {string} $.slug Slug
  * @param {number} $.example Example index
  * @param {boolean} $.anchor Anchor?
@@ -11,8 +10,8 @@
  * @param {object} [location] Location object (will use current page location by default)
  * @return {string}
  */
-export default function getUrl(
-	{ name, slug, example, anchor, isolated, nochrome, absolute } = {},
+export default function(
+	{ slug, example, anchor, isolated, nochrome, absolute } = {},
 	{ origin, pathname } = window.location
 ) {
 	let url = pathname;
@@ -24,7 +23,7 @@ export default function getUrl(
 	if (anchor) {
 		url += `#${slug}`;
 	} else if (isolated || nochrome) {
-		url += `#!/${name}`;
+		url += `#!/${slug}`;
 	}
 
 	if (example !== undefined) {


### PR DESCRIPTION
Hello @sapegin and all of you! 
We're using styleguidist as a part of a big client project, and alost immediately ran in to problems with that the components all live in a global namespace, mentioned in #325, #919 and other places. 

Requiring the specific components that you need is a bit ugly but works to solve naming conflicts in the examples. I'd like to take a stab at fixing this as well at some point, but we had a more critical problem with the routing.
 
When using styleguidist with the `pagePerSection` option set to true the routing use the section or component name instead of it's slug as a path/hash, meaning sections with conflicting names are completely unreachable.

Since the slugs we're already in place to (I assume) handle this very problem when you don't use the `pagePerSection` option using them here as well seemed like a reasonable solution. 

The slug generation could possibly be improved further by prefixing child-section slugs with the parent section, allowing for for more meaningful and stable urls (e.g. `button/button` and `toolbar/button` instead of `button` and `button-1) but this might be a breaking change for some.