### PR TITLE
Use latest ecmaVersion parsable by acorn

### DIFF
--- a/src/utils/splitExampleCode.js
+++ b/src/utils/splitExampleCode.js
@@ -21,7 +21,7 @@ const unsemicolon = s => s.replace(/;\s*$/, '');
 export default function splitExampleCode(code) {
 	let ast;
 	try {
-		ast = acorn.parse(code, { ecmaVersion: 10 });
+		ast = acorn.parse(code, { ecmaVersion: 2019 });
 	} catch (err) {
 		return { head: '', example: code };
 	}

--- a/src/utils/splitExampleCode.js
+++ b/src/utils/splitExampleCode.js
@@ -21,7 +21,7 @@ const unsemicolon = s => s.replace(/;\s*$/, '');
 export default function splitExampleCode(code) {
 	let ast;
 	try {
-		ast = acorn.parse(code);
+		ast = acorn.parse(code, { ecmaVersion: 10 });
 	} catch (err) {
 		return { head: '', example: code };
 	}


### PR DESCRIPTION
I ran into an issue trying to run `async`/`await` code in an example. I'm only targeting new Chrome and FF for the styleguide so i've mostly disabled the buble transforms. The problem tho is that this file here, also tries to parse the code, which fails silently.

I think this should be a safe change, and backwards compatible 