### PR TITLE
Feat: added ignoreNodeModules option

### DIFF
--- a/scripts/create-server.js
+++ b/scripts/create-server.js
@@ -13,7 +13,7 @@ module.exports = function createServer(config, env) {
 			hot: true,
 			quiet: true,
 			watchOptions: {
-				ignored: /node_modules/,
+				ignored: config.ignoreNodeModules || /node_modules/,
 			},
 			watchContentBase: config.assetsDir !== undefined,
 			stats: webpackConfig.stats || {},

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -97,6 +97,10 @@ module.exports = {
 			'**/*.d.ts',
 		],
 	},
+	ignoreNodeModules: {
+		type: ['string', 'regexp'],
+		default: /node_modules/,
+	},
 	highlightTheme: {
 		type: 'string',
 		default: 'base16-light',

--- a/scripts/utils/sanitizeConfig.js
+++ b/scripts/utils/sanitizeConfig.js
@@ -4,6 +4,7 @@ const isDirectory = require('is-directory');
 const castArray = require('lodash/castArray');
 const isBoolean = require('lodash/isBoolean');
 const isFunction = require('lodash/isFunction');
+const isRegexp = require('lodash/isRegExp');
 const isPlainObject = require('lodash/isPlainObject');
 const isString = require('lodash/isString');
 const isFinite = require('lodash/isFinite');
@@ -19,6 +20,7 @@ const StyleguidistError = require('./error');
 const typeCheckers = {
 	number: isFinite,
 	string: isString,
+	regexp: isRegexp,
 	boolean: isBoolean,
 	array: Array.isArray,
 	function: isFunction,


### PR DESCRIPTION
Right now there is no option in styleguidists config which will allow hot-reload work on specific node_modules.
Projects directory tree may look like this:
```
project
│
└─── node_modules
│   │
│   └─── ...
│   
└─── src
│   │
│   └─── node_modules
│   │   │
│   │   └─── @subproject1
│   │   │   │
│   │   │   └─── ...
│   │   │
│   │   └─── @subproject2
│   │   │   │
│   │   │   └─── ...
...
```
`@subproject`'s directories hold components which I want styleguidist to keep track of.

With `ignoreNodeModules` now we can specify which exact directory styleguidists hmr should ignore.