### PR TITLE
Fixed missed argument in updateDocs config method

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -535,7 +535,7 @@ Function that modifies props, methods, and metadata after parsing a source file.
 
 ```javascript
 module.exports = {
-  updateDocs(docs) {
+  updateDocs(docs, file) {
     if (docs.doclets.version) {
       const versionFilePath = path.resolve(
         path.dirname(file),


### PR DESCRIPTION
Example code from `updateDocs` option is broken because of missing `file` argument