### PR TITLE
feat(StyleGuideRenderer): support StyleGuideRenderer composition

### DIFF
--- a/src/rsg-components/StyleGuide/StyleGuideRenderer.js
+++ b/src/rsg-components/StyleGuide/StyleGuideRenderer.js
@@ -55,9 +55,10 @@ const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth
 	},
 });
 
-export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc, hasSidebar }) {
+export function StyleGuideRenderer(props) {
+	const { className, classes, title, homepageUrl, children, toc, hasSidebar, ...rest } = props;
 	return (
-		<div className={cx(classes.root, hasSidebar && classes.hasSidebar)}>
+		<div className={cx(classes.root, hasSidebar && classes.hasSidebar, className)} {...rest}>
 			<main className={classes.content}>
 				{children}
 				<footer className={classes.footer}>
@@ -79,6 +80,7 @@ export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc,
 
 StyleGuideRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
+	className: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	homepageUrl: PropTypes.string.isRequired,
 	children: PropTypes.node.isRequired,


### PR DESCRIPTION
# problem

i desire, but ATM cannot have:

1) free maintenance and updates to RSG components as they are developed, **plus**
2) the ability to tweak RSG components slightly (beyond the theme APIs)

# solution

- improve RSG component composition by proxying unhandled props to the target DOM node
    - use `transform-object-rest-spread` to do this.  woo hoo!
    - ideally it would be nice to extend this pattern to other components, but i thought a small focused change would help the discussion along

# example

i want to apply a class name and/or an id to the `<StyleGuideRenderer />` 
```jsx
import * as React from 'react'
import OrigStyleGuideRenderer from 'react-styleguidist/lib/rsg-components/StyleGuide/StyleGuideRenderer.js'
export default function StyleGuideRenderer (props) {
  return <OrigStyleGuideRenderer {...{ ...props, id: 'bananas', className: 'sans-serif' }} />
}
```

# discussion

- the `contributing.md` steps don't work for me, even on master.  `jest` craps out with:

```
react-styleguidist/test/jestsetup.js:15
    import { configure, shallow, render, mount } from 'enzyme';
           ^

    SyntaxError: Unexpected token {

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:316:17)
```