### PR TITLE
When hovering on and isDeprecated maintains the link-through.

### DIFF
--- a/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
+++ b/src/rsg-components/SectionHeading/SectionHeadingRenderer.js
@@ -42,6 +42,9 @@ const styles = ({ color, space }) => ({
 	isDeprecated: {
 		textDecoration: 'line-through',
 		color: color.light,
+		'&:hover': {
+			textDecoration: 'line-through',
+		},
 	},
 });
 


### PR DESCRIPTION
For https://github.com/styleguidist/react-styleguidist/issues/1026 I didn't need to using `inherit` after all...

Unhovered:
<img width="1552" alt="screen shot 2018-06-26 at 10 05 20 am" src="https://user-images.githubusercontent.com/142403/41927928-7a86726a-7928-11e8-9a7e-1ac7b640e365.png">

Hovered:

<img width="1552" alt="screen shot 2018-06-26 at 10 06 11 am" src="https://user-images.githubusercontent.com/142403/41927969-94ef4898-7928-11e8-9914-02f8ad8d017f.png">
