### PR TITLE
Feat: Add support for using glob patterns in arrays and functions

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -106,7 +106,7 @@ Each section consists of (all fields are optional):
 
 * `name` — section title.
 * `content` — location of a Markdown file containing the overview content.
-* `components` — a glob pattern string, an array of component paths or a function returning a list of components. The same rules apply as for the root `components` option.
+* `components` — a glob pattern string, an array of component paths or glob pattern strings, or a function returning a list of components or glob pattern strings. The same rules apply as for the root `components` option.
 * `sections` — array of subsections (can be nested).
 * `description` — A small description of this section.
 * `ignore` — string/array of globs that should not be included in the section.

--- a/loaders/utils/__tests__/getComponentFiles.spec.js
+++ b/loaders/utils/__tests__/getComponentFiles.spec.js
@@ -29,7 +29,7 @@ it('getComponentFiles() should accept components as an array of file names', () 
 	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
 });
 
-it('getComponentFiles() should accept components as a function that returns absolute paths', () => {
+it('getComponentFiles() should accept components as an array of absolute paths', () => {
 	const absolutize = files => files.map(file => path.join(configDir, file));
 	const result = getComponentFiles(absolutize(components), configDir);
 	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);

--- a/loaders/utils/__tests__/getComponentFiles.spec.js
+++ b/loaders/utils/__tests__/getComponentFiles.spec.js
@@ -5,6 +5,7 @@ import getComponentFiles from '../getComponentFiles';
 const configDir = path.resolve(__dirname, '../../../test');
 const components = ['one.js', 'two.js'];
 const glob = 'components/**/[A-Z]*.js';
+const globArray = ['components/Annotation/[A-Z]*.js', 'components/Button/[A-Z]*.js'];
 
 const deabs = x => deabsDeep(x, { root: configDir });
 
@@ -24,6 +25,14 @@ it('getComponentFiles() should accept components as a function that returns abso
 	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
 });
 
+it('getComponentFiles() should accept components as a function that returns globs', () => {
+	const result = getComponentFiles(() => globArray, configDir);
+	expect(deabs(result)).toEqual([
+		'~/components/Annotation/Annotation.js',
+		'~/components/Button/Button.js',
+	]);
+});
+
 it('getComponentFiles() should accept components as an array of file names', () => {
 	const result = getComponentFiles(components, configDir);
 	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
@@ -33,6 +42,14 @@ it('getComponentFiles() should accept components as an array of absolute paths',
 	const absolutize = files => files.map(file => path.join(configDir, file));
 	const result = getComponentFiles(absolutize(components), configDir);
 	expect(deabs(result)).toEqual(['~/one.js', '~/two.js']);
+});
+
+it('getComponentFiles() should accept components as an array of globs', () => {
+	const result = getComponentFiles(globArray, configDir);
+	expect(deabs(result)).toEqual([
+		'~/components/Annotation/Annotation.js',
+		'~/components/Button/Button.js',
+	]);
 });
 
 it('getComponentFiles() should accept components as a glob', () => {
@@ -46,13 +63,23 @@ it('getComponentFiles() should accept components as a glob', () => {
 	]);
 });
 
-it('getComponentFiles() should ignore specified patterns', () => {
+it('getComponentFiles() should ignore specified patterns for globs', () => {
 	const result = getComponentFiles(glob, configDir, ['**/*Button*']);
 	expect(deabs(result)).toEqual([
 		'~/components/Annotation/Annotation.js',
 		'~/components/Placeholder/Placeholder.js',
 		'~/components/Price/Price.js',
 	]);
+});
+
+it('getComponentFiles() should ignore specified patterns for globs in arrays', () => {
+	const result = getComponentFiles(globArray, configDir, ['**/*Button*']);
+	expect(deabs(result)).toEqual(['~/components/Annotation/Annotation.js']);
+});
+
+it('getComponentFiles() should ignore specified patterns for globs from functions', () => {
+	const result = getComponentFiles(() => globArray, configDir, ['**/*Button*']);
+	expect(deabs(result)).toEqual(['~/components/Annotation/Annotation.js']);
 });
 
 it('getComponentFiles() should throw if components is not a function, array or a string', () => {

--- a/loaders/utils/getComponentFiles.js
+++ b/loaders/utils/getComponentFiles.js
@@ -3,6 +3,18 @@ const glob = require('glob');
 const isFunction = require('lodash/isFunction');
 const isString = require('lodash/isString');
 
+function getFilesMatchingGlobs(components, rootDir, ignore) {
+	return components
+		.map(listItem => {
+			if (glob.hasMagic(listItem)) {
+				return glob.sync(path.resolve(rootDir, listItem), { ignore });
+			}
+			// Wrap path in an array so reduce always gets an array of arrays
+			return [listItem];
+		})
+		.reduce((accumulator, current) => accumulator.concat(current), []);
+}
+
 /**
  * Return absolute paths of components that should be rendered in the style guide.
  *
@@ -18,9 +30,9 @@ module.exports = function getComponentFiles(components, rootDir, ignore) {
 
 	let componentFiles;
 	if (isFunction(components)) {
-		componentFiles = components();
+		componentFiles = getFilesMatchingGlobs(components(), rootDir, ignore);
 	} else if (Array.isArray(components)) {
-		componentFiles = components;
+		componentFiles = getFilesMatchingGlobs(components, rootDir, ignore);
 	} else if (isString(components)) {
 		componentFiles = glob.sync(path.resolve(rootDir, components), { ignore });
 	} else {

--- a/loaders/utils/getComponentFiles.js
+++ b/loaders/utils/getComponentFiles.js
@@ -6,7 +6,7 @@ const isString = require('lodash/isString');
 /**
  * Return absolute paths of components that should be rendered in the style guide.
  *
- * @param {string|Function} components Function or glob pattern.
+ * @param {string|Function|Array} components Function, Array or glob pattern.
  * @param {string} rootDir
  * @param {Array} [ignore] Glob patterns to ignore.
  * @returns {Array}


### PR DESCRIPTION
This commit introduces support for using glob patterns in arrays
and functions provided to the `components`. This feature lets you
for instance include multiple glob patterns under the same section.
This can be useful if your repository has related components spread
across multiple folders, in which case maintaining a single glob
pattern that would include all folders could get tricky. This feature
may for instance be useful if you work with a monorepo.

I've included some very minor changes that I figured I'd include since
I was in the neighbourhood. One test case had a misleading description,
and the JSDoc lacked Array as a valid input to the loader.

I hope you'll consider this feature. It would be useful for us in 
https://github.com/SpareBank1/designsystem where we now do do a
workaround by using glob ourselves (with the error of not including ignores,
but that's a different story :) )