### PR TITLE
Feat: Add a user-configurable optional "version" indicator to the sidebar

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,6 +45,7 @@ By default, Styleguidist will look for `styleguide.config.js` file in your proje
 - [`updateExample`](#updateexample)
 - [`usageMode`](#usagemode)
 - [`verbose`](#verbose)
+- [`version`](#version)
 - [`webpackConfig`](#webpackconfig)
 
 <!-- tocstop -->
@@ -679,6 +680,12 @@ Defines the initial state of the props and methods tab:
 Type: `Boolean`, default: `false`
 
 Print debug information. Same as `--verbose` command line switch.
+
+#### `version`
+
+Type: `String`, optional
+
+Style guide version, displayed under the title in the sidebar.
 
 #### `webpackConfig`
 

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -311,6 +311,7 @@ module.exports = {
 import React from 'react'
 const StyleGuideRenderer = ({
   title,
+  version,
   homepageUrl,
   components,
   toc,
@@ -318,6 +319,7 @@ const StyleGuideRenderer = ({
 }) => (
   <div className="root">
     <h1>{title}</h1>
+    {version && <h2>{version}</h2>}
     <main className="wrapper">
       <div className="content">
         {components}

--- a/examples/basic/styleguide.config.js
+++ b/examples/basic/styleguide.config.js
@@ -1,9 +1,12 @@
+const { version } = require('./package');
+
 module.exports = {
 	components: 'src/components/**/[A-Z]*.js',
 	defaultExample: true,
 	ribbon: {
 		url: 'https://github.com/styleguidist/react-styleguidist',
 	},
+	version,
 	webpackConfig: {
 		module: {
 			rules: [

--- a/loaders/styleguide-loader.js
+++ b/loaders/styleguide-loader.js
@@ -14,6 +14,7 @@ const slugger = require('./utils/slugger');
 // Config options that should be passed to the client
 const CLIENT_CONFIG_OPTIONS = [
 	'title',
+	'version',
 	'showCode',
 	'showUsage',
 	'showSidebar',

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -312,6 +312,9 @@ module.exports = {
 		type: 'boolean',
 		default: false,
 	},
+	version: {
+		type: 'string',
+	},
 	webpackConfig: {
 		type: ['object', 'function'],
 		process: val => {

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -96,6 +96,7 @@ export default class StyleGuide extends Component {
 		return (
 			<StyleGuideRenderer
 				title={config.title}
+				version={config.version}
 				homepageUrl={HOMEPAGE}
 				toc={<TableOfContents sections={allSections} useRouterLinks={pagePerSection} />}
 				hasSidebar={hasSidebar(displayMode, config.showSidebar)}

--- a/src/rsg-components/StyleGuide/StyleGuide.spec.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.spec.js
@@ -28,6 +28,7 @@ const sections = [
 ];
 const config = {
 	title: 'Hello',
+	version: '1.0.0',
 	showSidebar: true,
 };
 
@@ -136,11 +137,12 @@ describe('sidebar rendering', () => {
 	});
 });
 
-it('renderer should render logo, table of contents, ribbon and passed children', () => {
+it('renderer should render logo, version, table of contents, ribbon and passed children', () => {
 	const actual = shallow(
 		<StyleGuideRenderer
 			classes={{}}
 			title={config.title}
+			version={config.version}
 			toc={<TableOfContents sections={sections} />}
 			homepageUrl="http://react-styleguidist.js.org/"
 			hasSidebar

--- a/src/rsg-components/StyleGuide/StyleGuideRenderer.js
+++ b/src/rsg-components/StyleGuide/StyleGuideRenderer.js
@@ -5,6 +5,7 @@ import Markdown from 'rsg-components/Markdown';
 import Styled from 'rsg-components/Styled';
 import cx from 'classnames';
 import Ribbon from 'rsg-components/Ribbon';
+import Version from 'rsg-components/Version';
 
 const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth }) => ({
 	root: {
@@ -55,7 +56,15 @@ const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth
 	},
 });
 
-export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc, hasSidebar }) {
+export function StyleGuideRenderer({
+	classes,
+	title,
+	version,
+	homepageUrl,
+	children,
+	toc,
+	hasSidebar,
+}) {
 	return (
 		<div className={cx(classes.root, hasSidebar && classes.hasSidebar)}>
 			<main className={classes.content}>
@@ -68,6 +77,7 @@ export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc,
 				<div className={classes.sidebar}>
 					<div className={classes.logo}>
 						<Logo>{title}</Logo>
+						{version && <Version>{version}</Version>}
 					</div>
 					{toc}
 				</div>
@@ -80,6 +90,7 @@ export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc,
 StyleGuideRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
 	title: PropTypes.string.isRequired,
+	version: PropTypes.string,
 	homepageUrl: PropTypes.string.isRequired,
 	children: PropTypes.node.isRequired,
 	toc: PropTypes.node.isRequired,

--- a/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
+++ b/src/rsg-components/StyleGuide/__snapshots__/StyleGuide.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderer should render logo, table of contents, ribbon and passed children 1`] = `
+exports[`renderer should render logo, version, table of contents, ribbon and passed children 1`] = `
 <div
   className=""
 >
@@ -19,6 +19,9 @@ exports[`renderer should render logo, table of contents, ribbon and passed child
       <Styled(Logo)>
         Hello
       </Styled(Logo)>
+      <Styled(Version)>
+        1.0.0
+      </Styled(Version)>
     </div>
     <TableOfContents
       sections={
@@ -102,6 +105,7 @@ exports[`should render components list 1`] = `
       useRouterLinks={false}
     />
   }
+  version="1.0.0"
 >
   <Sections
     depth={1}

--- a/src/rsg-components/Version/Version.spec.js
+++ b/src/rsg-components/Version/Version.spec.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import VersionRenderer from './VersionRenderer';
+
+it('renderer should render version', () => {
+	const actual = render(<VersionRenderer>1.2.3-a</VersionRenderer>);
+
+	expect(actual).toMatchSnapshot();
+});

--- a/src/rsg-components/Version/VersionRenderer.js
+++ b/src/rsg-components/Version/VersionRenderer.js
@@ -4,7 +4,7 @@ import Styled from 'rsg-components/Styled';
 
 const styles = ({ color, fontFamily, fontSize }) => ({
 	version: {
-		color: color.lightest,
+		color: color.light,
 		margin: [[5, 0, 0, 0]],
 		fontFamily: fontFamily.base,
 		fontSize: fontSize.base,
@@ -13,7 +13,11 @@ const styles = ({ color, fontFamily, fontSize }) => ({
 });
 
 export function VersionRenderer({ classes, children }) {
-	return <h2 className={classes.version}>{children}</h2>;
+	return (
+		<p aria-label="version" className={classes.version}>
+			{children}
+		</p>
+	);
 }
 
 VersionRenderer.propTypes = {

--- a/src/rsg-components/Version/VersionRenderer.js
+++ b/src/rsg-components/Version/VersionRenderer.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Styled from 'rsg-components/Styled';
+
+const styles = ({ color, fontFamily, fontSize }) => ({
+	version: {
+		color: color.lightest,
+		margin: [[5, 0, 0, 0]],
+		fontFamily: fontFamily.base,
+		fontSize: fontSize.base,
+		fontWeight: 'normal',
+	},
+});
+
+export function VersionRenderer({ classes, children }) {
+	return <h2 className={classes.version}>{children}</h2>;
+}
+
+VersionRenderer.propTypes = {
+	classes: PropTypes.object.isRequired,
+	children: PropTypes.node,
+};
+
+export default Styled(styles)(VersionRenderer);

--- a/src/rsg-components/Version/__snapshots__/Version.spec.js.snap
+++ b/src/rsg-components/Version/__snapshots__/Version.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderer should render version 1`] = `
+<h2
+  class="rsg--version-0"
+>
+  1.2.3-a
+</h2>
+`;

--- a/src/rsg-components/Version/__snapshots__/Version.spec.js.snap
+++ b/src/rsg-components/Version/__snapshots__/Version.spec.js.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renderer should render version 1`] = `
-<h2
+<p
+  aria-label="version"
   class="rsg--version-0"
 >
   1.2.3-a
-</h2>
+</p>
 `;

--- a/src/rsg-components/Version/index.js
+++ b/src/rsg-components/Version/index.js
@@ -1,0 +1,1 @@
+export { default } from 'rsg-components/Version/VersionRenderer';


### PR DESCRIPTION
When documenting libraries (of components or otherwise), I at least find it useful to see which version of said library the documentation pertains to. This PR adds a "version" string field to the config that's passed on to the renderer and if not empty, is included in the sidebar just under the title, with some discreet styling that fits the base theme.

I've also added the version to the basic example, where it's read from the example's `package.json` file.

<img width="436" alt="screen shot 2018-07-09 at 15 02 59" src="https://user-images.githubusercontent.com/617000/42449417-480ad464-8389-11e8-9dd0-c7fdf42442ec.png">
