### PR TITLE
Feat: Made the mounting point id configurable.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -281,7 +281,7 @@ module.exports = {
 
 Type: `string`, defaults: `rsg-root`
 
-The id of the DOM element that React-Styleguidist mounts.
+The ID of the DOM element that React-Styleguidist mounts.
 
 #### `pagePerSection`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -21,6 +21,7 @@ By default, Styleguidist will look for `styleguide.config.js` file in your proje
 - [`handlers`](#handlers)
 - [`ignore`](#ignore)
 - [`logger`](#logger)
+- [`mountPointId`](#mountPointId)
 - [`pagePerSection`](#pagepersection)
 - [`printBuildInstructions`](#printbuildinstructions)
 - [`printServerInstructions`](#printserverinstructions)
@@ -275,6 +276,12 @@ module.exports = {
   }
 }
 ```
+
+#### `mountPointId`
+
+Type: `string`, defaults: `rsg-root`
+
+The id of the DOM element that React-Styleguidist mounts.
 
 #### `pagePerSection`
 

--- a/loaders/styleguide-loader.js
+++ b/loaders/styleguide-loader.js
@@ -24,6 +24,7 @@ const CLIENT_CONFIG_OPTIONS = [
 	'editorConfig',
 	'ribbon',
 	'pagePerSection',
+	'mountPointId',
 ];
 
 module.exports = function() {};

--- a/scripts/__tests__/config.spec.js
+++ b/scripts/__tests__/config.spec.js
@@ -228,3 +228,8 @@ it('should throw when old template as a string option passed', () => {
 		});
 	expect(fn).toThrow('format has been changed');
 });
+
+it('mountPointId should have default value', () => {
+	const result = getConfig();
+	expect(result.mountPointId).toEqual('rsg-root');
+});

--- a/scripts/__tests__/make-webpack-config.spec.js
+++ b/scripts/__tests__/make-webpack-config.spec.js
@@ -192,3 +192,23 @@ it('should not overwrite NODE_ENV', () => {
 	makeWebpackConfig(styleguideConfig, 'production');
 	expect(process.env.NODE_ENV).toBe(process$env$nodeEnv);
 });
+
+it('should pass specified mountPointId to HTML plugin', () => {
+	const result = makeWebpackConfig(
+		{
+			...styleguideConfig,
+			mountPointId: 'foo-bar',
+		},
+		'development'
+	);
+	expect(getClasses(result.plugins, 'MiniHtmlWebpackPlugin')[0].options.context.container).toEqual(
+		'foo-bar'
+	);
+});
+
+it('should pass default mountPointId to HTML plugin', () => {
+	const result = makeWebpackConfig(styleguideConfig, 'development');
+	expect(getClasses(result.plugins, 'MiniHtmlWebpackPlugin')[0].options.context.container).toEqual(
+		'rsg-root'
+	);
+});

--- a/scripts/__tests__/make-webpack-config.spec.js
+++ b/scripts/__tests__/make-webpack-config.spec.js
@@ -205,10 +205,3 @@ it('should pass specified mountPointId to HTML plugin', () => {
 		'foo-bar'
 	);
 });
-
-it('should pass default mountPointId to HTML plugin', () => {
-	const result = makeWebpackConfig(styleguideConfig, 'development');
-	expect(getClasses(result.plugins, 'MiniHtmlWebpackPlugin')[0].options.context.container).toEqual(
-		'rsg-root'
-	);
-});

--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -27,7 +27,7 @@ module.exports = function(config, env) {
 	const htmlPluginOptions = {
 		context: Object.assign({}, templateContext, {
 			title: config.title,
-			container: config.mountPointId || 'rsg-root',
+			container: config.mountPointId,
 			trimWhitespace: true,
 		}),
 		template,

--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -27,7 +27,7 @@ module.exports = function(config, env) {
 	const htmlPluginOptions = {
 		context: Object.assign({}, templateContext, {
 			title: config.title,
-			container: 'rsg-root',
+			container: config.mountPointId || 'rsg-root',
 			trimWhitespace: true,
 		}),
 		template,

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -134,6 +134,10 @@ module.exports = {
 	logger: {
 		type: 'object',
 	},
+	mountPointId: {
+		type: 'string',
+		default: 'rsg-root',
+	},
 	pagePerSection: {
 		type: 'boolean',
 		default: false,

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,6 @@ import ReactDOM from 'react-dom';
 import renderStyleguide from './utils/renderStyleguide';
 import { getParameterByName, hasInHash } from './utils/handleHash';
 
-const CONTAINER_ID = 'rsg-root';
-
 // Examples code revision to rerender only code examples (not the whole page) when code changes
 // eslint-disable-next-line no-unused-vars
 let codeRevision = 0;
@@ -38,7 +36,7 @@ const render = () => {
 	const styleguide = require('!!../loaders/styleguide-loader!./index.js');
 	ReactDOM.render(
 		renderStyleguide(styleguide, codeRevision),
-		document.getElementById(CONTAINER_ID)
+		document.getElementById(styleguide.config.mountPointId)
 	);
 };
 


### PR DESCRIPTION
By default RSG binds to a div with an id of `rsg-root` with no way of overriding this. We needed to import multiple RSG bundle files into our work documentation site and as such needed to be able to specify the id of the element we wanted the bundles to bind to.

In your `styleguide.config.js` you can now specify an optional `mountPointId` to specify the id of the DOM element you want the app to bind to. It will default to the existing `rsg-root` if not specified.

I have tried to add some tests but might need some guidance here to make sure I am on the right track.