### PR TITLE
Fix: Appear page not found when a component is isolated

### DIFF
--- a/src/utils/getRouteData.js
+++ b/src/utils/getRouteData.js
@@ -49,7 +49,7 @@ export default function getRouteData(sections, hash, pagePerSection) {
 			hashArray.forEach((hashName, index) => {
 				// Filter the requested component if required but only on the first depth
 				// so in the next time of iteration, it will be trying to filter only on the second depth and so on
-				filteredSections = filterComponentsInSectionsByExactName(sections, hashName, false);
+				filteredSections = filterComponentsInSectionsByExactName(sections, hashName, isolate);
 
 				// If filteredSections exists, its because is an array of an component
 				// else it is an array of sections and depending his sectionDepth


### PR DESCRIPTION
If isolated is `true`, so it shoud try to search with recursivity until find the component.