### PR TITLE
Remove error default value for serverPort

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -497,7 +497,7 @@ Dev server hostname.
 
 #### `serverPort`
 
-Type: `Number`, default: `process.env.NODE_ENV` or `6060`
+Type: `Number`, default: `6060`
 
 Dev server port.
 


### PR DESCRIPTION
I checked the source but I don't think this config reads in any env variables?