### PR TITLE
fix: allows pathline to wrap

### DIFF
--- a/src/rsg-components/Pathline/PathlineRenderer.js
+++ b/src/rsg-components/Pathline/PathlineRenderer.js
@@ -10,6 +10,7 @@ export const styles = ({ space, fontFamily, fontSize, color }) => ({
 		fontFamily: fontFamily.monospace,
 		fontSize: fontSize.small,
 		color: color.light,
+		wordBreak: 'break-all'
 	},
 	copyButton: {
 		marginLeft: space[0],


### PR DESCRIPTION
- the "Pathline" breaks the responsive view if it gets too long as there will be a horizontal scrollbar/or the whole document will be scaled down (depending on the browser)