### PR TITLE
Allow chunkify to accept other extensions than js, jsx and html

### DIFF
--- a/loaders/examples-loader.js
+++ b/loaders/examples-loader.js
@@ -30,7 +30,7 @@ function examplesLoader(source) {
 		: undefined;
 
 	// Load examples
-	const examples = chunkify(source, updateExample);
+	const examples = chunkify(source, updateExample, query.customLangs);
 
 	// We're analysing the examples' source code to figure out the require statements. We do it manually with regexes,
 	// because webpack unfortunately doesn't expose its smart logic for rewriting requires

--- a/loaders/utils/__tests__/__snapshots__/chunkify.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/chunkify.spec.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should even parse examples with customized extensions 1`] = `
+exports[`should even parse examples with custom extensions 1`] = `
 Array [
   Object {
-    "content": "Pass props to CodeRenderer",
+    "content": "Custom extensions",
     "type": "markdown",
   },
   Object {
     "content": 
 <AppButton>
-  Example in frame and Without editor
+  Example in vue
 </AppButton>
 ,
     "settings": Object {},
@@ -66,6 +66,30 @@ Array [
   Object {
     "content": "\`\`\`jsx
 &lt;h2&gt;This is Highlighted!<span class=\\"xml\\"><span class=\\"hljs-tag\\">&lt;/<span class=\\"hljs-name\\">h2</span>&gt;</span></span>
+\`\`\`",
+    "type": "markdown",
+  },
+]
+`;
+
+exports[`should parse undefined custom extensions without throwing 1`] = `
+Array [
+  Object {
+    "content": "Undefined extensions (default)",
+    "type": "markdown",
+  },
+  Object {
+    "content": 
+<AppButton>
+  Example in jsx with undefined extensions
+</AppButton>
+,
+    "settings": Object {},
+    "type": "code",
+  },
+  Object {
+    "content": "\`\`\`pizza
+Unknown language: \\"pizza\\"
 \`\`\`",
     "type": "markdown",
   },

--- a/loaders/utils/__tests__/__snapshots__/chunkify.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/chunkify.spec.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should even parse examples with customized extensions 1`] = `
+Array [
+  Object {
+    "content": "Pass props to CodeRenderer",
+    "type": "markdown",
+  },
+  Object {
+    "content": 
+<AppButton>
+  Example in frame and Without editor
+</AppButton>
+,
+    "settings": Object {},
+    "type": "code",
+  },
+]
+`;
+
 exports[`should parse examples settings correctly 1`] = `
 Array [
   Object {

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -128,14 +128,30 @@ it('should call updateExample function for example', () => {
 	expect(actual).toEqual(expected);
 });
 
-it('should even parse examples with customized extensions', () => {
+it('should even parse examples with custom extensions', () => {
 	const markdown = `
-Pass props to CodeRenderer
+Custom extensions
 
 \`\`\`vue
-<AppButton>Example in frame and Without editor</AppButton>
+<AppButton>Example in vue</AppButton>
 \`\`\`
 `;
 	const actual = chunkify(markdown, undefined, ['vue']);
+	expect(actual).toMatchSnapshot();
+});
+
+it('should parse undefined custom extensions without throwing', () => {
+	const markdown = `
+Undefined extensions (default)
+
+\`\`\`jsx
+<AppButton>Example in jsx with undefined extensions</AppButton>
+\`\`\`
+
+\`\`\`pizza
+<AppButton>Example in pizza with undefined extensions</AppButton>
+\`\`\`
+`;
+	const actual = chunkify(markdown, undefined, undefined);
 	expect(actual).toMatchSnapshot();
 });

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -127,3 +127,15 @@ it('should call updateExample function for example', () => {
 	const actual = chunkify(markdown, updateExample);
 	expect(actual).toEqual(expected);
 });
+
+it('should even parse examples with customized extensions', () => {
+	const markdown = `
+Pass props to CodeRenderer
+
+\`\`\`vue
+<AppButton>Example in frame and Without editor</AppButton>
+\`\`\`
+`;
+	const actual = chunkify(markdown, undefined, ['vue']);
+	expect(actual).toMatchSnapshot();
+});

--- a/loaders/utils/__tests__/chunkify.spec.js
+++ b/loaders/utils/__tests__/chunkify.spec.js
@@ -149,7 +149,7 @@ Undefined extensions (default)
 \`\`\`
 
 \`\`\`pizza
-<AppButton>Example in pizza with undefined extensions</AppButton>
+<AppButton>Example in pizza with undefined extensions (test double)</AppButton>
 \`\`\`
 `;
 	const actual = chunkify(markdown, undefined, undefined);

--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -11,9 +11,10 @@ const CODE_PLACEHOLDER = '<%{#code#}%>';
  *
  * @param {string} markdown
  * @param {Function} updateExample
+ * @param {Array<string>} playgroundLangs
  * @returns {Array}
  */
-module.exports = function chunkify(markdown, updateExample) {
+module.exports = function chunkify(markdown, updateExample, playgroundLangs = PLAYGROUND_LANGS) {
 	const codeChunks = [];
 
 	/*
@@ -34,7 +35,7 @@ module.exports = function chunkify(markdown, updateExample) {
 
 				const lang = example.lang;
 				node.lang = lang;
-				if (!lang || (PLAYGROUND_LANGS.indexOf(lang) !== -1 && !example.settings.static)) {
+				if (!lang || (playgroundLangs.indexOf(lang) !== -1 && !example.settings.static)) {
 					codeChunks.push({
 						type: 'code',
 						content: example.content,

--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -14,7 +14,8 @@ const CODE_PLACEHOLDER = '<%{#code#}%>';
  * @param {Array<string>} playgroundLangs
  * @returns {Array}
  */
-module.exports = function chunkify(markdown, updateExample, playgroundLangs = PLAYGROUND_LANGS) {
+module.exports = function chunkify(markdown, updateExample, playgroundLangs) {
+	playgroundLangs = playgroundLangs || PLAYGROUND_LANGS;
 	const codeChunks = [];
 
 	/*

--- a/loaders/utils/chunkify.js
+++ b/loaders/utils/chunkify.js
@@ -14,8 +14,7 @@ const CODE_PLACEHOLDER = '<%{#code#}%>';
  * @param {Array<string>} playgroundLangs
  * @returns {Array}
  */
-module.exports = function chunkify(markdown, updateExample, playgroundLangs) {
-	playgroundLangs = playgroundLangs || PLAYGROUND_LANGS;
+module.exports = function chunkify(markdown, updateExample, playgroundLangs = PLAYGROUND_LANGS) {
 	const codeChunks = [];
 
 	/*


### PR DESCRIPTION
I am in the process of trying to simplify vue-styleguidist and I need to extract every react specific detail of styleguidist.
In this spirit, we want to be able to use example-loader.
Bad luck, we allow the use of "vue" as a language for our examples. 

This brought https://github.com/vue-styleguidist/vue-styleguidist#200

I thought the best way to clean up vsg's code while making rsg a little more powerful was to add an option to the example-loader customLangs.

Wether it's additional langs or replace entirely can be changed.

Thank you for your remarks.
Bart