### PR TITLE
Fix doc issues related to updateExample method

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -647,8 +647,12 @@ module.exports = {
   updateExample(props, exampleFilePath) {
     const { settings, lang } = props
     if (typeof settings.file === 'string') {
-      const filepath = path.resolve(exampleFilePath, settings.file)
+      const exampleFileDir = path.dirname(exampleFilePath);
+      const filepath = path.resolve(exampleFileDir, settings.file)
       delete settings.file
+      if (lang === 'javascript' || lang === 'js' || lang === 'jsx') {
+        settings.static = true
+      }
       return {
         content: fs.readFileSync(filepath, 'utf8'),
         settings,
@@ -659,25 +663,12 @@ module.exports = {
   }
 }
 ```
+Please, note: ```settings.static = true```([read more](Documenting.md#usage-examples-and-readme-files)) is used to stop React components to be interpreted. Otherwise, if React component uses ```import``` an error will be thrown, because ```import``` in markdown is not supported yet.
 
 Use it like this in your Markdown files:
 
     ```js { "file": "./some/file.js" }
     ```
-
-You can also use this function to dynamically update some of your fenced code blocks that you do not want to be interpreted as React components by using the [static modifier](Documenting.md#usage-examples-and-readme-files).
-
-```javascript
-module.exports = {
-  updateExample(props) {
-    const { settings, lang } = props
-    if (lang === 'javascript' || lang === 'js' || lang === 'jsx') {
-      settings.static = true
-    }
-    return props
-  }
-}
-```
 
 #### `usageMode`
 


### PR DESCRIPTION
1.  Wrong path bug:
styleguide.config.js
 ```
const filepath = path.resolve(exampleFilePath, settings.file) 
``` 
Readme.md
``` 
{ "file": "./Basic.jsx" }
```
So,  `absolute/path/to/file/Readme.md/Example.jsx` will be resolved, which is wrong.
To fix it as developer I have to change ./Basic.jsx to ../Basic.jsx, which is wrong :)

Proposition is in doc.

2. ```import``` is not supported in *.md. So, when we wants to add to *.md any  js|jsx example that  use ```import``` `CompileError: import is not supported` will be thrown. 
 
So, for now ```updateExample()``` method should always with be used with ```settings.static = true``` in case of all js|jsx with ```import```. For us as developers it has more sense, otherwise it push us to use 'require' in our components.

I have removed second example, because keep it separately haven't no any sense in my opinion.