### PR TITLE
Feat: Add generated id to markdown headings (#833)

### DIFF
--- a/src/client/rsg-components/Markdown/Markdown.spec.js
+++ b/src/client/rsg-components/Markdown/Markdown.spec.js
@@ -23,7 +23,7 @@ describe('Markdown', () => {
 		expectSnapshotToMatch('a [link](http://test.com)');
 	});
 
-	it('should render headings', () => {
+	it('should render headings with generated ids', () => {
 		expectSnapshotToMatch(`
 # one
 ## two

--- a/src/client/rsg-components/Markdown/MarkdownHeading/MarkdownHeading.spec.js
+++ b/src/client/rsg-components/Markdown/MarkdownHeading/MarkdownHeading.spec.js
@@ -3,8 +3,12 @@ import { html } from 'cheerio';
 import MarkdownHeading from './index';
 
 describe('Markdown Heading', () => {
-	it('should render a heading with a wrapper that provides margin', () => {
-		const actual = render(<MarkdownHeading level={2}>The markdown heading</MarkdownHeading>);
+	it('should render a heading with a wrapper that provides margin and an id', () => {
+		const actual = render(
+			<MarkdownHeading id="the-markdown-heading" level={2}>
+				The markdown heading
+			</MarkdownHeading>
+		);
 
 		expect(html(actual)).toMatchSnapshot();
 	});

--- a/src/client/rsg-components/Markdown/MarkdownHeading/MarkdownHeadingRenderer.js
+++ b/src/client/rsg-components/Markdown/MarkdownHeading/MarkdownHeadingRenderer.js
@@ -9,10 +9,12 @@ const styles = ({ space }) => ({
 	},
 });
 
-function MarkdownHeadingRenderer({ classes, level, children }) {
+function MarkdownHeadingRenderer({ classes, level, children, id }) {
 	return (
 		<div className={classes.spacing}>
-			<Heading level={level}>{children}</Heading>
+			<Heading level={level} id={id}>
+				{children}
+			</Heading>
 		</div>
 	);
 }
@@ -21,6 +23,7 @@ MarkdownHeadingRenderer.propTypes = {
 	classes: PropTypes.object.isRequired,
 	level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]).isRequired,
 	children: PropTypes.node,
+	id: PropTypes.string,
 };
 
 export default Styled(styles)(MarkdownHeadingRenderer);

--- a/src/client/rsg-components/Markdown/MarkdownHeading/__snapshots__/MarkdownHeading.spec.js.snap
+++ b/src/client/rsg-components/Markdown/MarkdownHeading/__snapshots__/MarkdownHeading.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Markdown Heading should render a heading with a wrapper that provides margin 1`] = `
+exports[`Markdown Heading should render a heading with a wrapper that provides margin and an id 1`] = `
 
 <div class="rsg--spacing-0">
-  <h2 class="rsg--heading-2 rsg--heading2-4">
+  <h2 id="the-markdown-heading"
+      class="rsg--heading-2 rsg--heading2-4"
+  >
     The markdown heading
   </h2>
 </div>

--- a/src/client/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/client/rsg-components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -119,36 +119,48 @@ exports[`Markdown should render emphasis and strong text 1`] = `
 
 `;
 
-exports[`Markdown should render headings 1`] = `
+exports[`Markdown should render headings with generated ids 1`] = `
 
 <div>
   <div class="rsg--spacing-3">
-    <h1 class="rsg--heading-4 rsg--heading1-5">
+    <h1 id="one"
+        class="rsg--heading-4 rsg--heading1-5"
+    >
       one
     </h1>
   </div>
   <div class="rsg--spacing-3">
-    <h2 class="rsg--heading-4 rsg--heading2-6">
+    <h2 id="two"
+        class="rsg--heading-4 rsg--heading2-6"
+    >
       two
     </h2>
   </div>
   <div class="rsg--spacing-3">
-    <h3 class="rsg--heading-4 rsg--heading3-7">
+    <h3 id="three"
+        class="rsg--heading-4 rsg--heading3-7"
+    >
       three
     </h3>
   </div>
   <div class="rsg--spacing-3">
-    <h4 class="rsg--heading-4 rsg--heading4-8">
+    <h4 id="four"
+        class="rsg--heading-4 rsg--heading4-8"
+    >
       four
     </h4>
   </div>
   <div class="rsg--spacing-3">
-    <h5 class="rsg--heading-4 rsg--heading5-9">
+    <h5 id="five"
+        class="rsg--heading-4 rsg--heading5-9"
+    >
       five
     </h5>
   </div>
   <div class="rsg--spacing-3">
-    <h6 class="rsg--heading-4 rsg--heading6-10">
+    <h6 id="six"
+        class="rsg--heading-4 rsg--heading6-10"
+    >
       six
     </h6>
   </div>


### PR DESCRIPTION
This PR introduces preliminary support for linking to headings
within an example text using markdown headings.

Since linking in this way requires using the # character it means you
can't link to a section in isolated mode (for instance to
http://localhost:6060/#!/WrappedButton#example-section) on account of
the #! being reserved for routing.

It may still be useful to the reporter of #833 for linking to a section in the list
view, and may act as a base for further improvements 🙂 