### PR TITLE
Namespace user components and make available to the active example

### DIFF
--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -75,7 +75,7 @@ class Playground extends Component {
 		const { displayMode } = this.context;
 		const isExampleHidden = exampleMode === ExampleModes.hide;
 		const isEditorHidden = settings.noeditor || isExampleHidden;
-		const preview = <Preview code={code} evalInContext={evalInContext} />;
+		const preview = <Preview name={name} code={code} evalInContext={evalInContext} />;
 
 		return isEditorHidden ? (
 			<Para>{preview}</Para>

--- a/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
+++ b/src/rsg-components/Playground/__snapshots__/Playground.spec.js.snap
@@ -50,6 +50,7 @@ exports[`should render component renderer 1`] = `
 </button>
 
       evalInContext={[Function]}
+      name="name"
     />
   }
   previewProps={Object {}}

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -13,6 +13,7 @@ export default class Preview extends Component {
 	static propTypes = {
 		code: PropTypes.string.isRequired,
 		evalInContext: PropTypes.func.isRequired,
+		name: PropTypes.string,
 	};
 	static contextTypes = {
 		config: PropTypes.object.isRequired,
@@ -69,6 +70,7 @@ export default class Preview extends Component {
 				evalInContext={this.props.evalInContext}
 				onError={this.handleError}
 				compilerConfig={this.context.config.compilerConfig}
+				name={this.props.name}
 			/>
 		);
 

--- a/src/utils/__tests__/getComponent.spec.js
+++ b/src/utils/__tests__/getComponent.spec.js
@@ -9,38 +9,18 @@ describe('getComponent', () => {
 		});
 	});
 
-	describe('if it is a CommonJS module and exports a function', () => {
-		it('should return the module', () => {
-			const testCases = [() => {}, function() {}, class Class {}];
-			testCases.forEach(testCase => {
-				const actual = getComponent(testCase);
-				expect(actual).toBe(testCase);
-			});
-		});
-	});
-
-	describe('if there is only one named export in the module', () => {
-		it('should return that', () => {
-			const module = { oneNamedExport: 'isLonely' };
-			const actual = getComponent(module);
-			expect(actual).toBe(module.oneNamedExport);
-		});
-	});
-
-	describe('if there is a named export whose name matches the name argument', () => {
-		it('should return that', () => {
-			const name = 'Component';
-			const module = { [name]: 'isNamed', OtherComponent: 'isAlsoNamed' };
-			const actual = getComponent(module, name);
-			expect(actual).toBe(module[name]);
-		});
-	});
-
-	describe('if there is more than one named export and no matching name', () => {
+	describe('if there is more than one named export but no default', () => {
 		it('should fall back on returning the module as a whole', () => {
-			const name = 'Component';
 			const module = { RandomName: 'isNamed', confusingExport: 123 };
-			const actual = getComponent(module, name);
+			const actual = getComponent(module);
+			expect(actual).toBe(module);
+		});
+	});
+
+	describe('if there is one export but no default', () => {
+		it('should fall back on returning the module as a whole', () => {
+			const module = { confusingExport: 123 };
+			const actual = getComponent(module);
 			expect(actual).toBe(module);
 		});
 	});

--- a/src/utils/__tests__/globalizeComponent.spec.js
+++ b/src/utils/__tests__/globalizeComponent.spec.js
@@ -3,19 +3,23 @@ import globalizeComponent from '../globalizeComponent';
 const component = { module: 'someModule', name: 'SomeName' };
 
 describe('globalizeComponent', () => {
+	beforeEach(() => {
+		global.RsgUserComponents = {};
+	});
+
 	afterEach(() => {
-		delete global[component.name];
+		delete global.RsgUserComponents;
 	});
 
 	it('should not add anything as a global variable if there is no component name', () => {
-		expect(global[component.name]).toBeUndefined();
+		expect(global.RsgUserComponents[component.name]).toBeUndefined();
 		globalizeComponent({});
-		expect(global[component.name]).toBeUndefined();
+		expect(global.RsgUserComponents[component.name]).toBeUndefined();
 	});
 
 	it('should set the return value of getComponent as a global variable', () => {
-		expect(global[component.name]).toBeUndefined();
+		expect(global.RsgUserComponents[component.name]).toBeUndefined();
 		globalizeComponent(component);
-		expect(global[component.name]).toBe(component.module);
+		expect(global.RsgUserComponents[component.name]).toBe(component.module);
 	});
 });

--- a/src/utils/__tests__/globalizeComponents.spec.js
+++ b/src/utils/__tests__/globalizeComponents.spec.js
@@ -1,13 +1,15 @@
 import globalizeComponents from '../globalizeComponents';
 
+beforeEach(() => {
+	global.RsgUserComponents = {};
+});
+
 afterEach(() => {
-	delete global.Foo;
-	delete global.Bar;
+	delete global.RsgUserComponents;
 });
 
 describe('globalizeComponents', () => {
 	it('should set all components’ modules as a global variables', () => {
-		const globalsCount = Object.keys(global).length;
 		globalizeComponents([
 			{
 				components: [
@@ -30,8 +32,8 @@ describe('globalizeComponents', () => {
 				],
 			},
 		]);
-		expect(Object.keys(global).length).toBe(globalsCount + 2);
-		expect(global.Foo).toBe(13);
-		expect(global.Bar).toBe(14);
+		expect(Object.keys(global.RsgUserComponents).length).toBe(2);
+		expect(global.RsgUserComponents.Foo).toBe(13);
+		expect(global.RsgUserComponents.Bar).toBe(14);
 	});
 });

--- a/src/utils/__tests__/renderStyleguide.spec.js
+++ b/src/utils/__tests__/renderStyleguide.spec.js
@@ -38,8 +38,7 @@ const history = {
 };
 
 afterEach(() => {
-	delete global.Button;
-	delete global.Image;
+	delete global.RsgUserComponents;
 });
 
 describe('renderStyleguide', () => {
@@ -50,14 +49,14 @@ describe('renderStyleguide', () => {
 
 	it('should globalize all components', () => {
 		renderStyleguide(styleguide, codeRevision, location, doc, history);
-		expect(global.Button).toBe('ButtonModule');
-		expect(global.Image).toBe('ImageModule');
+		expect(global.RsgUserComponents.Button).toBe('ButtonModule');
+		expect(global.RsgUserComponents.Image).toBe('ImageModule');
 	});
 
 	it('should globalize all components in isolated mode', () => {
 		renderStyleguide(styleguide, codeRevision, { hash: '#!/Button' }, doc, history);
-		expect(global.Button).toBe('ButtonModule');
-		expect(global.Image).toBe('ImageModule');
+		expect(global.RsgUserComponents.Button).toBe('ButtonModule');
+		expect(global.RsgUserComponents.Image).toBe('ImageModule');
 	});
 
 	it('should change document title', () => {

--- a/src/utils/getComponent.js
+++ b/src/utils/getComponent.js
@@ -4,57 +4,17 @@
  * See /docs/Components.md
  *
  * @param  {object} module
- * @param  {string} name
  * @return {function|object}
  */
-export default function getComponent(module, name) {
+export default function getComponent(module) {
+	// Previously, the logic was to
+	// 1: return module.default if existed
+	// 2: return module if __esModule is not set (assuming cjs)
+	// 3: return module[x] where x is the only named export if there is only one name export
+	// 4: return module[component.name] if the component exported a named export that matched the component name, use that
+	// 5: return module
 	//
-	// If the module defines a default export, return that
-	// e.g.
-	//
-	// ```
-	// export default function Component() { ... }
-	// ```
-	//
-	if (module.default) {
-		return module.default;
-	}
+	// This has been changed now that we support name-spacing components better
 
-	// If it is a CommonJS module which exports a function, return that
-	// e.g.
-	//
-	// ```
-	// function Component() { ... }
-	// module.exports = Component;
-	// ```
-	//
-	if (!module.__esModule && typeof module === 'function') {
-		return module;
-	}
-	const moduleKeys = Object.keys(module);
-
-	// If the module exports just one named export, return that
-	// e.g.
-	//
-	// ```
-	// export function Component() { ... }
-	// ```
-	//
-	if (moduleKeys.length === 1) {
-		return module[moduleKeys[0]];
-	}
-
-	// If the module exports a named export with the same name as the
-	// understood Component identifier, return that
-	// e.g.
-	//
-	// ```
-	// // /component.js
-	// export function someUtil() { ... }
-	// export Component() { ... } // if identifier is Component, return this named export
-	// ```
-	//
-	// Else return the module itself
-	//
-	return module[name] || module;
+	return module.default || module;
 }

--- a/src/utils/globalizeComponent.js
+++ b/src/utils/globalizeComponent.js
@@ -10,5 +10,6 @@ export default function globalizeComponent(component) {
 		return;
 	}
 
-	global[component.name] = getComponent(component.module, component.name);
+	const globalComponents = global.RsgUserComponents || (global.RsgUserComponents = {});
+	globalComponents[component.name] = getComponent(component.module);
 }


### PR DESCRIPTION
@sapegin This is my proposal for the issue we were discussing earlier. To me, it is a happy middle ground between explicitly using components from another place, and still being clear where components are coming from. 

This does not yet include doc updates; that seemed premature. 

Thanks!