### PR TITLE
Add foldername.md pattern to getExampleFilename when component is ind…

### DIFF
--- a/examples/basic/src/components/Label/Label.md
+++ b/examples/basic/src/components/Label/Label.md
@@ -1,0 +1,7 @@
+Basic Label:
+
+    <Label>Hi there !!!</Label>
+
+Pink background label:
+
+    <Label background="deeppink" color="white">Click Me</Label>

--- a/examples/basic/src/components/Label/index.js
+++ b/examples/basic/src/components/Label/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The only true label.
+ */
+export default function Label({ color, background, children }) {
+	const styles = {
+		color,
+		background,
+		padding: '.5em 1em',
+		borderRadius: '0.3em',
+		fontFamily: 'arial',
+	};
+
+	return <label style={styles}>{children}</label>;
+}
+Label.propTypes = {
+	/**
+	 * Label text.
+	 */
+	children: PropTypes.string.isRequired,
+	color: PropTypes.string,
+	background: PropTypes.string,
+};
+Label.defaultProps = {
+	color: '#333',
+	background: 'white',
+};

--- a/loaders/utils/__tests__/__snapshots__/getSections.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/getSections.spec.js.snap
@@ -116,6 +116,19 @@ Array [
         "slug": "button-3",
       },
       Object {
+        "filepath": "components/Label/index.js",
+        "hasExamples": true,
+        "metadata": Object {},
+        "module": Object {
+          "require": "~/test/components/Label/index.js",
+        },
+        "pathLine": "components/Label/index.js",
+        "props": Object {
+          "require": "!!~/loaders/props-loader.js!~/test/components/Label/index.js",
+        },
+        "slug": "label-1",
+      },
+      Object {
         "filepath": "components/Placeholder/Placeholder.js",
         "hasExamples": true,
         "metadata": Object {
@@ -291,6 +304,19 @@ Object {
         "require": "!!~/loaders/props-loader.js!~/test/components/Button/Button.js",
       },
       "slug": "button-1",
+    },
+    Object {
+      "filepath": "components/Label/index.js",
+      "hasExamples": true,
+      "metadata": Object {},
+      "module": Object {
+        "require": "~/test/components/Label/index.js",
+      },
+      "pathLine": "components/Label/index.js",
+      "props": Object {
+        "require": "!!~/loaders/props-loader.js!~/test/components/Label/index.js",
+      },
+      "slug": "label",
     },
     Object {
       "filepath": "components/Placeholder/Placeholder.js",

--- a/scripts/__tests__/config.spec.js
+++ b/scripts/__tests__/config.spec.js
@@ -81,6 +81,15 @@ it('default getExampleFilename should return Component.md path if it exists', ()
 	);
 });
 
+it('default getExampleFilename should return Component.md path if it exists with index.js', () => {
+	process.chdir('../..');
+	const result = getConfig();
+	result.components = './components/**/*.js';
+	expect(result.getExampleFilename(path.resolve('components/Label/index.js'))).toEqual(
+		path.resolve('components/Label/Label.md')
+	);
+});
+
 it('default getExampleFilename should return false if no examples file found', () => {
 	process.chdir('../..');
 	const result = getConfig();

--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -82,16 +82,17 @@ module.exports = {
 		default: componentPath => {
 			const files = [
 				path.join(path.dirname(componentPath), 'Readme.md'),
+				// ComponentName.md
 				componentPath.replace(path.extname(componentPath), '.md'),
+				// FolderName.md when component definition file is index.js
+				path.join(path.dirname(componentPath), path.basename(path.dirname(componentPath)) + '.md'),
 			];
-
 			for (const file of files) {
 				const existingFile = fileExistsCaseInsensitive(file);
 				if (existingFile) {
 					return existingFile;
 				}
 			}
-
 			return false;
 		},
 		example: componentPath => componentPath.replace(/\.jsx?$/, '.examples.md'),

--- a/test/components/Label/Label.md
+++ b/test/components/Label/Label.md
@@ -1,0 +1,7 @@
+Basic Label:
+
+    <Label>Hi there !!!</Label>
+
+Pink background label:
+
+    <Label background="deeppink" color="white">Click Me</Label>

--- a/test/components/Label/index.js
+++ b/test/components/Label/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The only true label.
+ */
+export default function Label({ color, background, children }) {
+	const styles = {
+		color,
+		background,
+		padding: '.5em 1em',
+		borderRadius: '0.3em',
+		fontFamily: 'arial',
+	};
+
+	return <label style={styles}>{children}</label>;
+}
+Label.propTypes = {
+	/**
+	 * Label text.
+	 */
+	children: PropTypes.string.isRequired,
+	color: PropTypes.string,
+	background: PropTypes.string,
+};
+Label.defaultProps = {
+	color: '#333',
+	background: 'white',
+};


### PR DESCRIPTION
Fix issue [#1169](https://github.com/styleguidist/react-styleguidist/issues/1169)
Update to getExampleFilename in order to detect example file when the component definition file is `index.js` and the examples are in FolderName.md.
Test has been added.
Unfortunately all other tests do not pass but it looks like it was like this when I forked.