### PR TITLE
Highlight currently selected page on sidebar

### DIFF
--- a/src/rsg-components/ComponentsList/ComponentsListRenderer.js
+++ b/src/rsg-components/ComponentsList/ComponentsListRenderer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Link from 'rsg-components/Link';
 import Styled from 'rsg-components/Styled';
+import { hasInHash, getHash } from '../../utils/handleHash';
 
 const styles = ({ color, fontFamily, fontSize, space, mq }) => ({
 	list: {
@@ -13,6 +14,7 @@ const styles = ({ color, fontFamily, fontSize, space, mq }) => ({
 		color: color.base,
 		display: 'block',
 		margin: [[space[1], 0, space[1], 0]],
+		padding: [[space[0], 0, space[0], space[0]]],
 		fontFamily: fontFamily.base,
 		fontSize: fontSize.base,
 		listStyle: 'none',
@@ -31,6 +33,9 @@ const styles = ({ color, fontFamily, fontSize, space, mq }) => ({
 		fontFamily: fontFamily.base,
 		fontWeight: 'bold',
 	},
+	isSelected: {
+		backgroundColor: color.lightest,
+	},
 });
 
 export function ComponentsListRenderer({ classes, items }) {
@@ -42,21 +47,30 @@ export function ComponentsListRenderer({ classes, items }) {
 
 	return (
 		<ul className={classes.list}>
-			{items.map(({ heading, visibleName, href, content, external }) => (
-				<li
-					className={cx(classes.item, (!content || !content.props.items.length) && classes.isChild)}
-					key={href}
-				>
-					<Link
-						className={cx(heading && classes.heading)}
-						href={href}
-						target={external ? '_blank' : undefined}
+			{items.map(({ heading, visibleName, href, content, external }) => {
+				const windowHash = window.location.pathname + getHash(window.location.hash);
+				const isItemSelected = hasInHash(windowHash, href);
+
+				return (
+					<li
+						className={cx(
+							classes.item,
+							(!content || !content.props.items.length) && classes.isChild,
+							isItemSelected && classes.isSelected
+						)}
+						key={href}
 					>
-						{visibleName}
-					</Link>
-					{content}
-				</li>
-			))}
+						<Link
+							className={cx(heading && classes.heading)}
+							href={href}
+							target={external ? '_blank' : undefined}
+						>
+							{visibleName}
+						</Link>
+						{content}
+					</li>
+				);
+			})}
 		</ul>
 	);
 }

--- a/src/rsg-components/ComponentsList/ComponentsListRenderer.js
+++ b/src/rsg-components/ComponentsList/ComponentsListRenderer.js
@@ -14,7 +14,6 @@ const styles = ({ color, fontFamily, fontSize, space, mq }) => ({
 		color: color.base,
 		display: 'block',
 		margin: [[space[1], 0, space[1], 0]],
-		padding: [[space[0], 0, space[0], space[0]]],
 		fontFamily: fontFamily.base,
 		fontSize: fontSize.base,
 		listStyle: 'none',
@@ -34,7 +33,7 @@ const styles = ({ color, fontFamily, fontSize, space, mq }) => ({
 		fontWeight: 'bold',
 	},
 	isSelected: {
-		backgroundColor: color.lightest,
+		fontWeight: 'bold',
 	},
 });
 
@@ -45,12 +44,11 @@ export function ComponentsListRenderer({ classes, items }) {
 		return null;
 	}
 
+	const windowHash = window.location.pathname + getHash(window.location.hash);
 	return (
 		<ul className={classes.list}>
 			{items.map(({ heading, visibleName, href, content, external }) => {
-				const windowHash = window.location.pathname + getHash(window.location.hash);
 				const isItemSelected = hasInHash(windowHash, href);
-
 				return (
 					<li
 						className={cx(


### PR DESCRIPTION
https://github.com/styleguidist/react-styleguidist/issues/1186

Implemented check on `ComponentsListRenderer` for the current `window.location.hash` in order to verify which one of the items is currently selected. Added a  `background-color` change to the selected item, and also added some padding to the item to make the highlight selection better due to the previous lack of padding.


![kapture 2018-11-10](https://user-images.githubusercontent.com/3718438/48304053-391ad800-e513-11e8-91e0-3321c6d17a98.gif)
