### PR TITLE
Fix(ci): Only run release and documentation on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ stages:
   - test
   - integration
   - coverage
-  - release
+  - name: release
+    if: type != pull_request AND branch = master
   - name: documentation
-    if: branch = master
+    if: type != pull_request AND branch = master
 jobs:
   include:
     - stage: lint
@@ -63,10 +64,10 @@ jobs:
       script:
         - npm install --no-save semantic-release-tamia
         - >-
-          npx semantic-release
-          --analyze-commits semantic-release-tamia/analyzeCommits
-          --verify-release semantic-release-tamia/verifyRelease
-          --generate-notes semantic-release-tamia/generateNotes
+          npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
+          
+          
+          
 
     - stage: documentation
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,21 @@ node_js:
   - 9
   - 8
   - 6
-env:
-  - WEBPACK_VERSION= # Current, from package.json
-install:
+
+before_install:
   # Use npm 5.7.x since it has introduced `npm ci`
   - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
-  - npm ci
-before_script:
-  # Install Webpack version
-  - if [[ -n "$WEBPACK_VERSION" ]]; then npm install --no-save webpack@$WEBPACK_VERSION; fi
+
 script:
   # Run tests without coverage since it's 2x faster
   - npm run test:jest -- --runInBand
+
+# Trigger a push build on master branches only + PRs build on every branches
+# Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
 branches:
   only:
     - master
+
 stages:
   - lint
   - test
@@ -65,6 +65,11 @@ jobs:
         - npm install --no-save semantic-release-tamia
         - >-
           npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
+          
+          
+          
+          
+          
           
           
           

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
   # Run tests without coverage since it's 2x faster
   - npm run test:jest -- --runInBand
 branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/
+  only:
+    - master
 stages:
   - lint
   - test
@@ -65,6 +65,7 @@ jobs:
         - npm install --no-save semantic-release-tamia
         - >-
           npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
+          
           
           
           


### PR DESCRIPTION
I noticed that every pull request was trying to run the release and documentation stages.
I thought it was a waste of time.

This filters the stages in PR builds.