### PR TITLE
fix: Incorrect current section highlighting on partial match closes #1237 

### DIFF
--- a/src/client/rsg-components/ComponentsList/ComponentsListRenderer.js
+++ b/src/client/rsg-components/ComponentsList/ComponentsListRenderer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Link from 'rsg-components/Link';
 import Styled from 'rsg-components/Styled';
-import { hasInHash, getHash } from '../../utils/handleHash';
+import { getHash } from '../../utils/handleHash';
 
 const styles = ({ color, fontFamily, fontSize, space, mq }) => ({
 	list: {
@@ -48,7 +48,7 @@ export function ComponentsListRenderer({ classes, items }) {
 	return (
 		<ul className={classes.list}>
 			{items.map(({ heading, visibleName, href, content, external }) => {
-				const isItemSelected = hasInHash(windowHash, href);
+				const isItemSelected = windowHash === href;
 				return (
 					<li
 						className={cx(


### PR DESCRIPTION
### Background
* Usage of the hasInHash function to determine the current section to highlight on the sidebar causes partial matches to be highlighted as well. This is because the hasInHash function uses indexof.

### Changes
* Removed usage of hasInHash and its import in the ComponentsListRenderer.
* Compare string in order to determine the right section to highlight. similar to before I compare the windowHash with the current item href.