### PR TITLE
Fix webpack config file name for react-scripts > 2.1.1

### DIFF
--- a/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
+++ b/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
@@ -3,15 +3,16 @@ import findUserWebpackConfig from '../findUserWebpackConfig';
 const cwd = process.cwd();
 afterEach(() => process.chdir(cwd));
 
-it('should return path to Create React App Webpack dev config', () => {
+it('should return path to Create React App Webpack old config (react-scripts <= 2.1.1)', () => {
 	const result = findUserWebpackConfig(a => a);
 	expect(result).toMatch(/^react-scripts\/config\/webpack\.config\.dev/);
 });
 
-it('should return path to Create React App Webpack config', () => {
+it('should return path to Create React App Webpack config (react-scripts > 2.1.1)', () => {
 	const result = findUserWebpackConfig(a => {
 		if (/webpack\.config\.dev/.test(a)) {
-			throw window.Exception();
+			// Simulate an error. For example, if the file doesn't exist.
+			throw new Error();
 		}
 		return a;
 	});

--- a/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
+++ b/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
@@ -5,7 +5,7 @@ afterEach(() => process.chdir(cwd));
 
 it('should return path to Create React App Webpack old config (react-scripts <= 2.1.1)', () => {
 	const result = findUserWebpackConfig(a => a);
-	expect(result).toMatch(/^react-scripts\/config\/webpack\.config\.dev/);
+	expect(result).toMatchInlineSnapshot(`"react-scripts/config/webpack.config.dev"`);
 });
 
 it('should return path to Create React App Webpack config (react-scripts > 2.1.1)', () => {
@@ -16,7 +16,7 @@ it('should return path to Create React App Webpack config (react-scripts > 2.1.1
 		}
 		return a;
 	});
-	expect(result).toMatch(/^react-scripts\/config\/webpack\.config\.js/);
+	expect(result).toMatchInlineSnapshot(`"react-scripts/config/webpack.config"`);
 });
 
 it('should return an absolute path to user Webpack config located in project root folder', () => {

--- a/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
+++ b/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
@@ -16,7 +16,7 @@ it('should return path to Create React App Webpack config (react-scripts > 2.1.1
 		}
 		return a;
 	});
-	expect(result).toMatch(/^react-scripts\/config\/webpack\.config/);
+	expect(result).toMatch(/^react-scripts\/config\/webpack\.config\.js/);
 });
 
 it('should return an absolute path to user Webpack config located in project root folder', () => {

--- a/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
+++ b/src/scripts/utils/__tests__/findUserWebpackConfig.spec.js
@@ -3,9 +3,19 @@ import findUserWebpackConfig from '../findUserWebpackConfig';
 const cwd = process.cwd();
 afterEach(() => process.chdir(cwd));
 
-it('should return path to Create React App Webpack config', () => {
+it('should return path to Create React App Webpack dev config', () => {
 	const result = findUserWebpackConfig(a => a);
-	expect(result).toMatch(/^react-scripts\//);
+	expect(result).toMatch(/^react-scripts\/config\/webpack\.config\.dev/);
+});
+
+it('should return path to Create React App Webpack config', () => {
+	const result = findUserWebpackConfig(a => {
+		if (/webpack\.config\.dev/.test(a)) {
+			throw window.Exception();
+		}
+		return a;
+	});
+	expect(result).toMatch(/^react-scripts\/config\/webpack\.config/);
 });
 
 it('should return an absolute path to user Webpack config located in project root folder', () => {

--- a/src/scripts/utils/findUserWebpackConfig.js
+++ b/src/scripts/utils/findUserWebpackConfig.js
@@ -23,18 +23,18 @@ module.exports = function findUserWebpackConfig(resolve) {
 		// Create React App <= 2.1.1
 		return resolve(CREATE_REACT_APP_WEBPACK_CONFIG_DEV);
 	} catch (err) {
-    try {
-      // Create React App > 2.1.1
-      return resolve(CREATE_REACT_APP_WEBPACK_CONFIG);
-    } catch (err) {
-      // Check in the root folder
-      for (const configFile of USER_WEBPACK_CONFIG_NAMES) {
-        const absoluteConfigFile = absolutize(configFile);
-        if (fs.existsSync(absoluteConfigFile)) {
-          return absoluteConfigFile;
-        }
-      }
-    }
+		try {
+			// Create React App > 2.1.1
+			return resolve(CREATE_REACT_APP_WEBPACK_CONFIG);
+		} catch (err) {
+			// Check in the root folder
+			for (const configFile of USER_WEBPACK_CONFIG_NAMES) {
+				const absoluteConfigFile = absolutize(configFile);
+				if (fs.existsSync(absoluteConfigFile)) {
+					return absoluteConfigFile;
+				}
+			}
+	    	}
 	}
 
 	return false;

--- a/src/scripts/utils/findUserWebpackConfig.js
+++ b/src/scripts/utils/findUserWebpackConfig.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 // react-scripts <= 2.1.1
-const CREATE_REACT_APP_WEBPACK_CONFIG_DEV = 'react-scripts/config/webpack.config.dev';
+const CREATE_REACT_APP_WEBPACK_CONFIG_OLD = 'react-scripts/config/webpack.config.dev';
 // react-scripts > 2.1.1
 const CREATE_REACT_APP_WEBPACK_CONFIG = 'react-scripts/config/webpack.config';
 const USER_WEBPACK_CONFIG_NAMES = ['webpack.config.js', 'webpackfile.js'];
@@ -21,7 +21,7 @@ module.exports = function findUserWebpackConfig(resolve) {
 	resolve = resolve || require.resolve;
 	try {
 		// Create React App <= 2.1.1
-		return resolve(CREATE_REACT_APP_WEBPACK_CONFIG_DEV);
+		return resolve(CREATE_REACT_APP_WEBPACK_CONFIG_OLD);
 	} catch (err) {
 		try {
 			// Create React App > 2.1.1

--- a/src/scripts/utils/findUserWebpackConfig.js
+++ b/src/scripts/utils/findUserWebpackConfig.js
@@ -34,7 +34,7 @@ module.exports = function findUserWebpackConfig(resolve) {
 					return absoluteConfigFile;
 				}
 			}
-	    	}
+		}
 	}
 
 	return false;

--- a/src/scripts/utils/findUserWebpackConfig.js
+++ b/src/scripts/utils/findUserWebpackConfig.js
@@ -1,7 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const CREATE_REACT_APP_WEBPACK_CONFIG = 'react-scripts/config/webpack.config.dev';
+// react-scripts <= 2.1.1
+const CREATE_REACT_APP_WEBPACK_CONFIG_DEV = 'react-scripts/config/webpack.config.dev';
+// react-scripts > 2.1.1
+const CREATE_REACT_APP_WEBPACK_CONFIG = 'react-scripts/config/webpack.config';
 const USER_WEBPACK_CONFIG_NAMES = ['webpack.config.js', 'webpackfile.js'];
 
 const absolutize = filePath => path.resolve(process.cwd(), filePath);
@@ -17,16 +20,21 @@ const absolutize = filePath => path.resolve(process.cwd(), filePath);
 module.exports = function findUserWebpackConfig(resolve) {
 	resolve = resolve || require.resolve;
 	try {
-		// Create React App
-		return resolve(CREATE_REACT_APP_WEBPACK_CONFIG);
+		// Create React App <= 2.1.1
+		return resolve(CREATE_REACT_APP_WEBPACK_CONFIG_DEV);
 	} catch (err) {
-		// Check in the root folder
-		for (const configFile of USER_WEBPACK_CONFIG_NAMES) {
-			const absoluteConfigFile = absolutize(configFile);
-			if (fs.existsSync(absoluteConfigFile)) {
-				return absoluteConfigFile;
-			}
-		}
+    try {
+      // Create React App > 2.1.1
+      return resolve(CREATE_REACT_APP_WEBPACK_CONFIG);
+    } catch (err) {
+      // Check in the root folder
+      for (const configFile of USER_WEBPACK_CONFIG_NAMES) {
+        const absoluteConfigFile = absolutize(configFile);
+        if (fs.existsSync(absoluteConfigFile)) {
+          return absoluteConfigFile;
+        }
+      }
+    }
 	}
 
 	return false;


### PR DESCRIPTION
Since react-scripts 2.1.1, the config file is named webpack.config.js instead of webpack.config.dev.js.
