### PR TITLE
Docs: Fix webpack css loader example

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -69,7 +69,7 @@ module.exports = {
         // Other loaders that are needed for your components
         {
           test: /\.css$/,
-          loader: 'style-loader!css-loader?modules'
+          use: ['style-loader', 'css-loader']
         }
       ]
     }


### PR DESCRIPTION
Following the docs I was trying to load a 3rd party css library by requiring it:
`require: [path.resolve(__dirname, "node_modules/react-dates/lib/css/_datepicker.css")],`

and adding the corresponding loader as it is shown [here](https://react-styleguidist.js.org/docs/webpack.html#custom-webpack-config) but didn't work out.
```js
{
  test: /\.css$/,
  loader: 'style-loader!css-loader?modules'
}
```

Changing `loader` for `use` did the trick.
```js
{
  test: /\.css$/,
  use: ['style-loader', 'css-loader'] 
}
```
