### PR TITLE
update config file for typescript projects

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -91,15 +91,16 @@ module.exports = {
 
 If you’re using [Create React App](https://github.com/facebook/create-react-app) and TypeScript:
 
-1. Install [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript).
-2. Create a `styleguide.config.js`, see [configuration](Configuration.md) reference.
-3. Update your `styleguide.config.js`:
+  1. Install [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript).
+  2. Create a `styleguide.config.js`, see [configuration](Configuration.md) reference.
+  3. Update your `styleguide.config.js`:
 
-   ```javascript
-   module.exports = {
-     propsParser: require('react-docgen-typescript').parse
-   }
-   ```
+```javascript
+module.exports = {
+  propsParser: require('react-docgen-typescript').parse,
+  webpackConfig: require('react-scripts/config/webpack.config.js')
+};
+```
 
 ## Non-webpack projects
 


### PR DESCRIPTION
I had some problems with the previous config and after some research, I found out this config which works across different computers.

This works with projects created with Create React App version ^2.1.3 using `--typescript` option.