### PR TITLE
WIP: Allow display of shape prop recursively

### DIFF
--- a/examples/basic/src/components/Button/Button.js
+++ b/examples/basic/src/components/Button/Button.js
@@ -29,6 +29,31 @@ Button.propTypes = {
 	disabled: PropTypes.bool,
 	/** Gets called when the user clicks on the button */
 	onClick: PropTypes.func,
+
+	/** TO_BE_REMOVED: Nothing to do with button only for testing purpose */
+	tree: PropTypes.shape({
+		rootId: PropTypes.string.isRequired,
+		items: PropTypes.objectOf(
+			PropTypes.shape({
+				id: PropTypes.string.isRequired,
+				parentId: PropTypes.string,
+				children: PropTypes.arrayOf(PropTypes.string).isRequired,
+				hasChildren: PropTypes.bool.isRequired,
+				hasParent: PropTypes.bool.isRequired,
+				isChecked: PropTypes.bool.isRequired,
+				isExpanded: PropTypes.bool.isRequired,
+				isChildrenLoading: PropTypes.bool.isRequired,
+				type: PropTypes.string.isRequired,
+				data: PropTypes.shape({
+					title: PropTypes.string.isRequired,
+				}).isRequired,
+				defaults: PropTypes.shape({
+					isChecked: PropTypes.bool,
+					isExpanded: PropTypes.bool,
+				}),
+			})
+		).isRequired,
+	}),
 };
 Button.defaultProps = {
 	color: '#333',

--- a/src/client/rsg-components/Props/PropsRenderer.js
+++ b/src/client/rsg-components/Props/PropsRenderer.js
@@ -78,14 +78,19 @@ function renderEnum(prop) {
 	);
 }
 
-function renderShape(props) {
-	const rows = [];
+function renderShape(props, level = 0) {
+	let rows = [];
 	for (const name in props) {
 		const prop = props[name];
 		const defaultValue = renderDefault(prop);
 		const description = prop.description;
 		rows.push(
-			<div key={name}>
+			<div
+				key={name}
+				style={{
+					paddingLeft: 30 * level + 'px',
+				}}
+			>
 				<Name>{name}</Name>
 				{': '}
 				<Type>{renderType(prop)}</Type>
@@ -95,6 +100,7 @@ function renderShape(props) {
 				{description && <Markdown text={description} inline />}
 			</div>
 		);
+		rows = [...rows, renderExtra({ type: prop }, level + 1)];
 	}
 	return rows;
 }
@@ -174,7 +180,7 @@ function renderDescription(prop) {
 	);
 }
 
-function renderExtra(prop) {
+function renderExtra(prop, level = 0) {
 	const type = getType(prop);
 	if (!type) {
 		return null;
@@ -185,15 +191,15 @@ function renderExtra(prop) {
 		case 'union':
 			return renderUnion(prop);
 		case 'shape':
-			return renderShape(prop.type.value);
+			return renderShape(prop.type.value, level);
 		case 'arrayOf':
 			if (type.value.name === 'shape') {
-				return renderShape(prop.type.value.value);
+				return renderShape(prop.type.value.value, level);
 			}
 			return null;
 		case 'objectOf':
 			if (type.value.name === 'shape') {
-				return renderShape(prop.type.value.value);
+				return renderShape(prop.type.value.value, level);
 			}
 			return null;
 		default:


### PR DESCRIPTION
This PR displays  documentation of shapes recursively like this:

![recursive_shape_display](https://user-images.githubusercontent.com/621420/52845855-6c6b9500-3108-11e9-9784-b8bee6e04651.png)


 I will be happy to hear if there is a better way to achieve this.