### PR TITLE
Allow trailing comma in named imports in examples

### DIFF
--- a/src/client/utils/__tests__/transpileImports.spec.js
+++ b/src/client/utils/__tests__/transpileImports.spec.js
@@ -57,6 +57,34 @@ const E = snake$0.default || snake$0;
 `);
 	});
 
+	test('transpile multiline named imports without trailing comma', () => {
+		const result = transpileImports(`import {
+  B,
+  C
+} from 'cat'
+`);
+		expect(result).toMatchInlineSnapshot(`
+"const cat$0 = require('cat');
+const B = cat$0.B;
+const C = cat$0.C;
+"
+`);
+	});
+
+	test('transpile multiline named imports with trailing comma', () => {
+		const result = transpileImports(`import {
+  B,
+  C,
+} from 'cat'
+`);
+		expect(result).toMatchInlineSnapshot(`
+"const cat$0 = require('cat');
+const B = cat$0.B;
+const C = cat$0.C;
+"
+`);
+	});
+
 	test('return code if there are no imports', () => {
 		const code = `<Button />`;
 		const result = transpileImports(code);

--- a/src/client/utils/rewriteImports.js
+++ b/src/client/utils/rewriteImports.js
@@ -45,7 +45,7 @@ export default function(str, fn = 'require') {
 	num = 0;
 	return str
 		.replace(NAMED, (_, asterisk, base, req, dep) =>
-			generate(req ? req.split(',') : [], dep, base, fn)
+			generate(req ? req.split(',').filter(dep => dep.trim()) : [], dep, base, fn)
 		)
 		.replace(UNNAMED, (_, dep) => `${fn}('${dep}');`);
 }


### PR DESCRIPTION
Fixes #1295 