### PR TITLE
Allow output.globalObject from webpack-config

### DIFF
--- a/src/scripts/utils/mergeWebpackConfig.js
+++ b/src/scripts/utils/mergeWebpackConfig.js
@@ -45,5 +45,8 @@ const merge = mergeBase({
 module.exports = function mergeWebpackConfig(baseConfig, userConfig, env) {
 	const userConfigObject = isFunction(userConfig) ? userConfig(env) : userConfig;
 	const safeUserConfig = omit(userConfigObject, IGNORE_SECTIONS.concat(IGNORE_SECTIONS_ENV[env]));
+	if (userConfigObject && userConfigObject.output && userConfigObject.output.globalObject) {
+		baseConfig.output.globalObject = userConfigObject.output.globalObject;
+	}
 	return merge(baseConfig, safeUserConfig);
 };


### PR DESCRIPTION
In some cases i.e. https://github.com/webpack/webpack/issues/6642 a user needs to set output.globalConfig in their webpack config. Unfortunately this is thrown away by styleguidist.

This patch allows specifically output.globalObject to be retained from the users webpack config.
