### PR TITLE
Chore: Use Preact on component definition instead use React

### DIFF
--- a/examples/preact/.eslintrc
+++ b/examples/preact/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "import/no-unresolved": [
+      2,
+      {
+        "ignore": [ "preact" ]
+      }
+    ]
+  }
+}

--- a/examples/preact/babel.config.js
+++ b/examples/preact/babel.config.js
@@ -5,7 +5,6 @@ module.exports = {
 			{
 				debug: true,
 				modules: false,
-				useBuiltIns: 'usage',
 			},
 		],
 		'@babel/react',

--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -8521,6 +8521,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
       "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -8668,6 +8669,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
       "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -21,9 +21,7 @@
     "lodash": "^4.17.11",
     "preact": "^8.2.7",
     "preact-compat": "^3.18.0",
-    "prop-types": "^15.6.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",
@@ -33,6 +31,8 @@
     "babel-loader": "^8.0.0-beta.4",
     "css-loader": "^0.28.11",
     "file-loader": "^1.1.11",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-styleguidist": "^6.5.3",
     "style-loader": "^0.20.3",
     "url-loader": "^0.6.2",

--- a/examples/preact/src/components/Button/Button.js
+++ b/examples/preact/src/components/Button/Button.js
@@ -1,4 +1,6 @@
-import React from 'react';
+/** @jsx h */
+
+import { h } from 'preact';
 import PropTypes from 'prop-types';
 
 import './Button.css';

--- a/examples/preact/src/components/CounterButton/CounterButton.js
+++ b/examples/preact/src/components/CounterButton/CounterButton.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+/** @jsx h */
+
+import { h, Component } from 'preact';
 
 /**
  * Button that counts how many times it was pressed and exposes a `@public` method to reset itself.

--- a/examples/preact/src/components/Placeholder/Placeholder.js
+++ b/examples/preact/src/components/Placeholder/Placeholder.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+/** @jsx h */
+
+import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
 import './Placeholder.css';

--- a/examples/preact/src/components/PushButton/PushButton.js
+++ b/examples/preact/src/components/PushButton/PushButton.js
@@ -1,4 +1,6 @@
-import React from 'react';
+/** @jsx h */
+
+import { h } from 'preact';
 import PropTypes from 'prop-types';
 
 import './PushButton.css';

--- a/examples/preact/src/components/RandomButton/RandomButton.js
+++ b/examples/preact/src/components/RandomButton/RandomButton.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+/** @jsx h */
+
+import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import sample from 'lodash/sample';
 

--- a/examples/preact/src/components/RandomButton/Readme.md
+++ b/examples/preact/src/components/RandomButton/Readme.md
@@ -1,6 +1,6 @@
 You can `import` external files in your examples:
 
 ```jsx
-import { all } from 'dog-names'
-;<RandomButton variants={all} />
+const { all } = require('dog-names');
+<RandomButton variants={all} />
 ```

--- a/examples/preact/src/components/WrappedButton/WrappedButton.js
+++ b/examples/preact/src/components/WrappedButton/WrappedButton.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+/** @jsx h */
+
+import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
 /**


### PR DESCRIPTION
Currently Preact examples import `react` which is an alias pointing to `preact`

This PR updates it to directly import 'preact' which is the most common usage on production.

```diff
- import React, { Component } from 'react';
+ import { h, Component } from 'preact';
```

This also set the needed pragma for Preact.
