### PR TITLE
Feat: Allow code base color to be customized with theme config

### DIFF
--- a/src/client/styles/prismTheme.js
+++ b/src/client/styles/prismTheme.js
@@ -1,4 +1,7 @@
 const prismTheme = ({ color }) => ({
+	'&': {
+		color: color.codeBase,
+	},
 	[`& .token.comment,
 & .token.prolog,
 & .token.doctype,

--- a/src/client/styles/theme.js
+++ b/src/client/styles/theme.js
@@ -26,6 +26,7 @@ export const color = {
 	ribbonBackground: '#e90',
 	ribbonText: '#fff',
 	// Based on default Prism theme
+	codeBase: '#333',
 	codeComment: '#6d6d6d',
 	codePunctuation: '#999',
 	codeProperty: '#905',


### PR DESCRIPTION
#### Change Summary

- Add `theme.color.codeBase` property to config
- Allow syntax highlight default color to set without affecting base color
- The `codeBase` and `codeBackground` can be set to allow finer control of code text contrast ratios. e.g. Create dark themes for code samples.

#### Why is this required?

The `them.color.code*` properties can be used to customized the syntax highlight theme. However, setting a dark color as the codeBackground makes the code almost unreadable (due to low contrast ratios). 

##### Issue Screenshots
Static Code Block
<img width="954" alt="Issue 1 a - Static Code Block" src="https://user-images.githubusercontent.com/227926/56101481-1e012980-5ef2-11e9-83b2-f6d9474808ca.png">
 Editable Code Block
<img width="952" alt="Issue 1 b - Editable Code Block" src="https://user-images.githubusercontent.com/227926/56101483-25283780-5ef2-11e9-90da-25e610fe8d02.png">

##### Screenshots with proposed solution
Static Code Block
<img width="953" alt="Sol 1 a - Static Code Block" src="https://user-images.githubusercontent.com/227926/56101504-5acd2080-5ef2-11e9-9765-42fb264cd325.png">
Editable Code Block
<img width="952" alt="Sol 1 b - Editable Code Block" src="https://user-images.githubusercontent.com/227926/56101505-5acd2080-5ef2-11e9-9145-0eb4df404143.png">


#### Is there a workaround?
Yes. 

- Using custom style wrappers for `rsg-components/Editor` and `rsg-components/Markdown/Pre` components 

There could be other approaches, but it seems most approaches require much more code change than should be required to customize colors with themes.

