### PR TITLE
Feat: build progress

### DIFF
--- a/src/bin/styleguidist.js
+++ b/src/bin/styleguidist.js
@@ -131,7 +131,7 @@ function commandServer() {
 	verbose('Webpack config:', compiler.options);
 
 	// Print server message
-	compiler.hooks.done.tap('printServeMessage', () => {
+	compiler.hooks.done.tap('printServerMessage', () => {
 		if (config.printServerInstructions) {
 			config.printServerInstructions(config, { isHttps });
 		} else {

--- a/src/scripts/make-webpack-config.js
+++ b/src/scripts/make-webpack-config.js
@@ -51,6 +51,7 @@ module.exports = function(config, env) {
 				'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 				'process.env.STYLEGUIDIST_ENV': JSON.stringify(env),
 			}),
+			new webpack.ProgressPlugin(),
 		],
 		performance: {
 			hints: false,


### PR DESCRIPTION
Hi

I add a `webpack.ProgressPlugin` to `make-webpack-config.js` for let user know current building progress.

The `printServerInstructions()` and `openBrowser()` behaviors will works after building completed.