### PR TITLE
Fix: Hide HTML comments in Markdown files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5445,7 +5445,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5463,11 +5464,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5480,15 +5483,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5591,7 +5597,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5601,6 +5608,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5613,17 +5621,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5640,6 +5651,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5712,7 +5724,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5722,6 +5735,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5797,7 +5811,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5827,6 +5842,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5844,6 +5860,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5882,11 +5899,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -11369,6 +11388,11 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-html-comments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-html-comments/-/strip-html-comments-1.0.0.tgz",
+      "integrity": "sha1-Cuff8DAKYHWkwpP7YRG0yx0Mt7c="
     },
     "strip-indent": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "recast": "^0.17.4",
     "remark": "^10.0.1",
     "rewrite-imports": "1.2.0",
+    "strip-html-comments": "^1.0.0",
     "terser-webpack-plugin": "^1.2.3",
     "to-ast": "^1.0.0",
     "type-detect": "^4.0.8",

--- a/src/client/rsg-components/Markdown/Markdown.js
+++ b/src/client/rsg-components/Markdown/Markdown.js
@@ -1,6 +1,7 @@
 import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { compiler } from 'markdown-to-jsx';
+import stripHtmlComments from 'strip-html-comments';
 import Link from 'rsg-components/Link';
 import Text from 'rsg-components/Text';
 import Para from 'rsg-components/Para';
@@ -145,7 +146,7 @@ export const inlineOverrides = {
 
 function Markdown({ text, inline }) {
 	const overrides = inline ? inlineOverrides : baseOverrides;
-	return compiler(text, { overrides, forceBlock: true });
+	return compiler(stripHtmlComments(text), { overrides, forceBlock: true });
 }
 
 Markdown.propTypes = {

--- a/src/client/rsg-components/Markdown/Markdown.spec.js
+++ b/src/client/rsg-components/Markdown/Markdown.spec.js
@@ -123,6 +123,32 @@ and this is _emphasized_
 | more foo	| more bar	|
 `);
 	});
+
+	it('should ignore single line comments', () => {
+		const markdown = `Hello World
+<!-- This is a single line comment -->
+`;
+		const actual = mount(<Markdown text={markdown} />);
+
+		expect(actual.find('p').props().children[0]).not.toContain('This is a single line comment');
+	});
+
+	it('should ignore multiline comments', () => {
+		const markdown = `Hello World
+<!--
+This is a 
+multiline
+comment
+-->
+`;
+		const actual = mount(<Markdown text={markdown} />);
+
+		expect(actual.find('p').props().children[0]).not.toContain(
+			`This is a 
+multiline
+comment`
+		);
+	});
 });
 
 describe('Markdown inline', () => {


### PR DESCRIPTION
* Add tests for single-line, multi-line comments
* Hide HTML comments in Markdown files

Updated this PR, added a fix for hiding HTML comments in Markdown files

~Refers~ Closes #1326 