### PR TITLE
Fix getExampleFilename customization if file is not exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5107,6 +5107,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-extend": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
+      "integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=",
+      "dev": true
+    },
     "fast-glob": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
@@ -5406,6 +5412,12 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-monkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.3.3.tgz",
+      "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==",
+      "dev": true
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -5445,8 +5457,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5464,13 +5475,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5483,18 +5492,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5597,8 +5603,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5608,7 +5613,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5621,20 +5625,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5651,7 +5652,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5724,8 +5724,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5735,7 +5734,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5811,8 +5809,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5842,7 +5839,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5860,7 +5856,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5899,13 +5894,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8466,6 +8459,16 @@
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
           "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
         }
+      }
+    },
+    "memfs": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.15.2.tgz",
+      "integrity": "sha512-jFC2mc3Aa224nJB824vbJzuiksf3+wPjFSKrXS7bA3o3H0Yy4/bh0R1nAsQyL/P80PVyT56ZowQJ+NGniHWhVQ==",
+      "dev": true,
+      "requires": {
+        "fast-extend": "0.0.2",
+        "fs-monkey": "^0.3.3"
       }
     },
     "memory-fs": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "jest-serializer-html": "^6.0.0",
     "keymirror": "^0.1.1",
     "lint-staged": "^8.1.5",
+    "memfs": "^2.15.2",
     "prettier": "1.16.4",
     "raf": "^3.4.1",
     "react": "^16.8.5",

--- a/src/loaders/utils/__tests__/getExamples.spec.js
+++ b/src/loaders/utils/__tests__/getExamples.spec.js
@@ -1,15 +1,31 @@
 import deabsDeep from 'deabsdeep';
+import { vol } from 'memfs';
 import getExamples from '../getExamples';
+
+jest.mock('fs', () => {
+	return require('memfs').fs;
+});
 
 const file = '../pizza.js';
 const displayName = 'Pizza';
 const examplesFile = './Pizza.md';
 const defaultExample = './Default.md';
 
+afterEach(vol.reset.bind(vol));
+
 test('require an example file if component has example file', () => {
+	vol.fromJSON({ [examplesFile]: 'pizza' });
+
 	const result = getExamples(file, displayName, examplesFile);
 	expect(deabsDeep(result).require).toMatchInlineSnapshot(
 		`"!!~/src/loaders/examples-loader.js?displayName=Pizza&file=.%2F..%2Fpizza.js&shouldShowDefaultExample=false!./Pizza.md"`
+	);
+});
+
+test('require default example file if component has no example in the file system', () => {
+	const result = getExamples(file, displayName, examplesFile, defaultExample);
+	expect(deabsDeep(result).require).toMatchInlineSnapshot(
+		`"!!~/src/loaders/examples-loader.js?displayName=Pizza&file=.%2F..%2Fpizza.js&shouldShowDefaultExample=false!./Default.md"`
 	);
 });
 

--- a/src/loaders/utils/getExamples.js
+++ b/src/loaders/utils/getExamples.js
@@ -1,5 +1,6 @@
 // @flow
 import path from 'path';
+import fs from 'fs';
 import { encode } from 'qss';
 import requireIt from './requireIt';
 
@@ -14,7 +15,7 @@ module.exports = function getExamples(
 	examplesFile: string,
 	defaultExample: string
 ): {} | null {
-	const examplesFileToLoad = examplesFile || defaultExample;
+	const examplesFileToLoad = (fs.existsSync(examplesFile) && examplesFile) || defaultExample;
 	if (!examplesFileToLoad) {
 		return null;
 	}


### PR DESCRIPTION
If a file does not exist in fs we have errors during the build.
In this case, we should continue to use the default example file.

iss: #1338