### PR TITLE
Fix build if assetsDir is an array

### DIFF
--- a/src/scripts/__tests__/make-webpack-config.spec.js
+++ b/src/scripts/__tests__/make-webpack-config.spec.js
@@ -114,6 +114,11 @@ it('should set from with assetsDir in CopyWebpackPlugin', () => {
 	expect(CopyWebpackPlugin).toHaveBeenCalledWith([{ from: '/assets/' }]); //([
 });
 
+it('should set array of from with assetsDir array in CopyWebpackPlugin', () => {
+	makeWebpackConfig({ ...styleguideConfig, assetsDir: ['/assets1/', '/assets2/'] }, 'production');
+	expect(CopyWebpackPlugin).toHaveBeenCalledWith([{ from: '/assets1/' }, { from: '/assets2/' }]);
+});
+
 it('should add CopyWebpackPlugin to plugins in production', () => {
 	makeWebpackConfig({ ...styleguideConfig }, 'production');
 	expect(CopyWebpackPlugin).toHaveBeenCalledWith([]);

--- a/src/scripts/make-webpack-config.js
+++ b/src/scripts/make-webpack-config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const isArray = require('lodash/isArray');
 const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
@@ -93,11 +94,9 @@ module.exports = function(config, env) {
 				}),
 				new CopyWebpackPlugin(
 					config.assetsDir
-						? [
-								{
-									from: config.assetsDir,
-								},
-						  ]
+						? isArray(config.assetsDir)
+							? config.assetsDir.map(dir => ({ from: dir }))
+							: [{ from: config.assetsDir }]
 						: []
 				),
 			],

--- a/src/scripts/make-webpack-config.js
+++ b/src/scripts/make-webpack-config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const isArray = require('lodash/isArray');
+const castArray = require('lodash/castArray');
 const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
@@ -93,11 +93,7 @@ module.exports = function(config, env) {
 					verbose: config.verbose === true,
 				}),
 				new CopyWebpackPlugin(
-					config.assetsDir
-						? isArray(config.assetsDir)
-							? config.assetsDir.map(dir => ({ from: dir }))
-							: [{ from: config.assetsDir }]
-						: []
+					config.assetsDir ? castArray(config.assetsDir).map(dir => ({ from: dir })) : []
 				),
 			],
 			optimization: {


### PR DESCRIPTION
copy-webpack-plugin is not allowing `from` to be as an array.
If we still want to use `from` and support array format for
assetsDir, then we should pass an array of objects {from: ...} to
copy-webpack-plugin

iss: #1320