### PR TITLE
Fix component name capitalization issue

### DIFF
--- a/src/loaders/utils/__tests__/getNameFromFilePath.spec.js
+++ b/src/loaders/utils/__tests__/getNameFromFilePath.spec.js
@@ -21,4 +21,16 @@ it('should capitalize the display name', () => {
 	expect(
 		getNameFromFilePath(path.join('an', 'absolute', 'path', 'to', 'your-component', 'index.js'))
 	).toEqual('YourComponent');
+
+	expect(
+		getNameFromFilePath(path.join('an', 'absolute', 'path', 'to', 'yourButtonTS.tsx'))
+	).toEqual('YourButtonTS');
+
+	expect(
+		getNameFromFilePath(path.join('an', 'absolute', 'path', 'to', 'your-buttonTS', 'index.tsx'))
+	).toEqual('YourButtonTS');
+
+	expect(
+		getNameFromFilePath(path.join('an', 'absolute', 'path', 'to', 'ButtonTS', 'index.tsx'))
+	).toEqual('ButtonTS');
 });

--- a/src/loaders/utils/__tests__/getNameFromFilePath.spec.js
+++ b/src/loaders/utils/__tests__/getNameFromFilePath.spec.js
@@ -31,6 +31,10 @@ it('should capitalize the display name', () => {
 	).toEqual('YourButtonTS');
 
 	expect(
+		getNameFromFilePath(path.join('an', 'absolute', 'path', 'to', 'your_button--TS', 'index.tsx'))
+	).toEqual('YourButtonTS');
+
+	expect(
 		getNameFromFilePath(path.join('an', 'absolute', 'path', 'to', 'ButtonTS', 'index.tsx'))
 	).toEqual('ButtonTS');
 });

--- a/src/loaders/utils/getNameFromFilePath.js
+++ b/src/loaders/utils/getNameFromFilePath.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const _ = require('lodash');
 
 module.exports = function getNameFromFilePath(filePath) {
 	let displayName = path.basename(filePath, path.extname(filePath));
@@ -7,5 +6,9 @@ module.exports = function getNameFromFilePath(filePath) {
 		displayName = path.basename(path.dirname(filePath));
 	}
 
-	return _.upperFirst(_.camelCase(displayName));
+	return displayName
+		.charAt(0)
+		.toUpperCase()
+		.concat(displayName.slice(1))
+		.replace(/-([a-z])/, (_, match) => match.toUpperCase());
 };

--- a/src/loaders/utils/getNameFromFilePath.js
+++ b/src/loaders/utils/getNameFromFilePath.js
@@ -1,4 +1,11 @@
 const path = require('path');
+const { startCase } = require('lodash');
+
+function transformDisplayName(displayName) {
+	// ex: your-buttonTS => Your Button TS => YourButtonTS
+	// ex: your_button--TS => Your Button TS => YourButtonTS
+	return startCase(displayName).replace(/\s/g, '');
+}
 
 module.exports = function getNameFromFilePath(filePath) {
 	let displayName = path.basename(filePath, path.extname(filePath));
@@ -6,9 +13,5 @@ module.exports = function getNameFromFilePath(filePath) {
 		displayName = path.basename(path.dirname(filePath));
 	}
 
-	return displayName
-		.charAt(0)
-		.toUpperCase()
-		.concat(displayName.slice(1))
-		.replace(/-([a-z])/, (_, match) => match.toUpperCase());
+	return transformDisplayName(displayName);
 };

--- a/src/loaders/utils/getNameFromFilePath.js
+++ b/src/loaders/utils/getNameFromFilePath.js
@@ -1,17 +1,17 @@
 const path = require('path');
 const { startCase } = require('lodash');
 
-function transformDisplayName(displayName) {
-	// ex: your-buttonTS => Your Button TS => YourButtonTS
-	// ex: your_button--TS => Your Button TS => YourButtonTS
+function transformFileNameToDisplayName(displayName) {
+	// ex: your-buttonTS -> Your Button TS -> YourButtonTS
+	// ex: your_button--TS -> Your Button TS -> YourButtonTS
 	return startCase(displayName).replace(/\s/g, '');
 }
 
 module.exports = function getNameFromFilePath(filePath) {
-	let displayName = path.basename(filePath, path.extname(filePath));
-	if (displayName === 'index') {
-		displayName = path.basename(path.dirname(filePath));
+	let fileName = path.basename(filePath, path.extname(filePath));
+	if (fileName === 'index') {
+		fileName = path.basename(path.dirname(filePath));
 	}
 
-	return transformDisplayName(displayName);
+	return transformFileNameToDisplayName(fileName);
 };


### PR DESCRIPTION
iss: https://github.com/styleguidist/react-styleguidist/issues/1381

It is happening in a case when `react-docgen` (any propsParser) is failed
and we are trying to guess displayName based on the file path.

We capitalized every case in the string instead of just words separated
by `-` or started with a small letter.

So, by mistake `ButtonTS` in file name becomes `ButtonTs` display name for
component when we expect `ButtonTS`