### PR TITLE
docs(webpack): improve typescript usage

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -97,7 +97,7 @@ If you’re using [Create React App](https://github.com/facebook/create-react-ap
 
    ```javascript
    module.exports = {
-     propsParser: require('react-docgen-typescript').parse
+     propsParser: require('react-docgen-typescript').withCustomConfig('./tsconfig.json').parse
    }
    ```
 


### PR DESCRIPTION
# problem

as discussed in https://github.com/styleguidist/react-docgen-typescript/issues/71#issuecomment-362370750, some compiler options break component discovery.  the safest strategy is to always include the tsconfig from user space, which improves component detection.

# solution

add `.withCustomConfig` call, as it's quite commonplace to for consumers to tweak their compiler settings