### PR TITLE
[WIP] Template inline js comments

### DIFF
--- a/src/scripts/make-webpack-config.js
+++ b/src/scripts/make-webpack-config.js
@@ -27,7 +27,6 @@ module.exports = function(config, env) {
 		context: Object.assign({}, templateContext, {
 			title: config.title,
 			container: config.mountPointId,
-			trimWhitespace: true,
 		}),
 		template,
 	};


### PR DESCRIPTION
#1189 
PR to fix a bug with inline JavaScript comments in template script tags. The comments were causing the rest of the script to be commented out when whitespace got removed.

My fix follows an example from [mini-html-webpack-plugin](https://github.com/styleguidist/mini-html-webpack-plugin) that uses [html-minifier](https://github.com/kangax/html-minifier). I'm using this to set options on how the HTML is minified.

I see two possible issues with what I have so far.

1. Needing to add **html-minifier** to package.json.
2. Whether or not I should set the **minifyJS** option to true. It produces cleaner minified HTML but removes comments from the JavaScript within script tags.

Here's an example where I minify the JS.

![image](https://user-images.githubusercontent.com/12503822/61549987-44a99180-aa06-11e9-85aa-3a1cf3bd3927.png)

And here's an example where I don't.

![image](https://user-images.githubusercontent.com/12503822/61549956-3491b200-aa06-11e9-81ae-e730dc3f0be8.png)


