### PR TITLE
Possible fix for #1321 

### DIFF
--- a/examples/styled-components/src/StyleGuideWrapper.tsx
+++ b/examples/styled-components/src/StyleGuideWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, Fragment } from 'react';
 import ThemeProvider from './ThemeProvider';
 import GlobalStyle from './styles';
 
@@ -9,10 +9,10 @@ interface Props {
 const StyleGuideWrapper = function({ children }: Props) {
     return (
         <ThemeProvider>
-            <>
+            <Fragment>
                 <GlobalStyle />
                 {children}
-            </>
+            </Fragment>
         </ThemeProvider>
     )
 };

--- a/src/client/rsg-components/Preview/Preview.js
+++ b/src/client/rsg-components/Preview/Preview.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import PlaygroundError from 'rsg-components/PlaygroundError';
@@ -96,10 +96,10 @@ export default class Preview extends Component {
 	render() {
 		const { error } = this.state;
 		return (
-			<>
+			<Fragment>
 				<div ref={ref => (this.mountNode = ref)} />
 				{error && <PlaygroundError message={error} />}
-			</>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
Replaces React.fragment short notation `<>` with long notation `<React.Fragment>`

Apparently not all the tooling supports the short notation. 
