### PR TITLE
Fix: Single sections OK to contain no component

### DIFF
--- a/src/client/rsg-components/TableOfContents/TableOfContents.js
+++ b/src/client/rsg-components/TableOfContents/TableOfContents.js
@@ -41,7 +41,11 @@ export default class TableOfContents extends Component {
 		const { sections, useRouterLinks } = this.props;
 		// If there is only one section, we treat it as a root section
 		// In this case the name of the section won't be rendered and it won't get left padding
-		const firstLevel = sections.length === 1 ? sections[0].components : sections;
+		// Since a section can contain only other sections,
+		// we need to make sure not to loose the subsections.
+		// We will treat those subsecttions as the new roots.
+		const firstLevel =
+			sections.length === 1 ? sections[0].sections || sections[0].components : sections;
 		const filtered = filterSectionsByName(firstLevel, searchTerm);
 
 		return this.renderLevel(filtered, useRouterLinks);


### PR DESCRIPTION
If a section contains only one subsection,
styleguidist will try to optimize.
It will make the section disapear and show
its components instead.

If this section only contain sections, no components,
it should optimize to sections and not to components.

CF: https://github.com/vue-styleguidist/vue-styleguidist/issues/492