### PR TITLE
Fix: Add custom display code to Examples/Playground components to make hot-reloading JSX inlined in Markdown easier.

### DIFF
--- a/src/client/rsg-components/Examples/Examples.js
+++ b/src/client/rsg-components/Examples/Examples.js
@@ -13,6 +13,7 @@ export default function Examples({ examples, name, exampleMode }, { codeRevision
 						return (
 							<Playground
 								code={example.content}
+								displayCode={example.settings.displaycontent}
 								evalInContext={example.evalInContext}
 								key={`${codeRevision}/${index}`}
 								name={name}

--- a/src/client/rsg-components/Playground/Playground.js
+++ b/src/client/rsg-components/Playground/Playground.js
@@ -12,6 +12,7 @@ import { DisplayModes, ExampleModes } from '../../consts';
 class Playground extends Component {
 	static propTypes = {
 		code: PropTypes.string.isRequired,
+		displayCode: PropTypes.string,
 		evalInContext: PropTypes.func.isRequired,
 		index: PropTypes.number.isRequired,
 		name: PropTypes.string.isRequired,
@@ -26,7 +27,7 @@ class Playground extends Component {
 
 	constructor(props, context) {
 		super(props, context);
-		const { code, settings, exampleMode } = props;
+		const { code, displayCode, settings, exampleMode } = props;
 		const { config } = context;
 		const expandCode = exampleMode === ExampleModes.expand;
 		const activeTab = settings.showcode !== undefined ? settings.showcode : expandCode;
@@ -34,6 +35,7 @@ class Playground extends Component {
 		this.state = {
 			code,
 			prevCode: code,
+			displayCode,
 			activeTab: activeTab ? EXAMPLE_TAB_CODE_EDITOR : undefined,
 		};
 
@@ -42,11 +44,12 @@ class Playground extends Component {
 	}
 
 	static getDerivedStateFromProps(nextProps, prevState) {
-		const { code } = nextProps;
+		const { code, displayCode } = nextProps;
 		if (prevState.prevCode !== code) {
 			return {
 				prevCode: code,
 				code,
+				displayCode,
 			};
 		}
 		return null;
@@ -70,7 +73,7 @@ class Playground extends Component {
 	}
 
 	render() {
-		const { code, activeTab } = this.state;
+		const { code, displayCode, activeTab } = this.state;
 		const { evalInContext, index, name, settings, exampleMode } = this.props;
 		const { displayMode } = this.context;
 		const isExampleHidden = exampleMode === ExampleModes.hide;
@@ -98,7 +101,11 @@ class Playground extends Component {
 						active={activeTab}
 						onlyActive
 						// evalInContext passed through to support custom slots that eval code
-						props={{ code, onChange: this.handleChange, evalInContext }}
+						props={{
+							code: displayCode ? displayCode : code,
+							onChange: this.handleChange,
+							evalInContext,
+						}}
 					/>
 				}
 				toolbar={


### PR DESCRIPTION
This is more of a suggestion to developers than a fully-featured pull request. As you know, at the moment JSX code can either be inlined into Markdown or loaded from an external file using [this technique](https://react-styleguidist.js.org/docs/cookbook.html#how-to-display-the-source-code-of-any-file). The relevant code looks like this:

    ```js
    import MyComponent from './MyComponent';
    ;<MyComponent/>;
    ```
    
    ```js { "file": "./MyComponent.js" }
    ```

Both of these suck because:
1. They are transpiled by Buble instead of Babel (or whatever Webpack config is using), meaning you don't get ES7 features like class properties and other relevant advantages.
2. They don't get hot reloaded, because Webpack doesn't even watch them.

A temporary solution during development is to use this snippet in `styleguide.config.js` (ignore `props.settings.displaycontent` for now):

```js
module.exports = {
    updateExample(props, exampleFilePath) {
        const {settings, lang} = props;
        if (typeof settings.componentPath === 'string') {
            const filePath = path.resolve(path.dirname(exampleFilePath), settings.componentPath);
            const props = {
                content: `import ExampleComp from '${filePath}';\n;<ExampleComp/>;`,
                settings,
                lang,
            };
            // Use lower case, since settings are converted to lowercase for some reason...
            props.settings.displaycontent = fs.readFileSync(filePath, 'utf8');
            return props;

        }
        return props;
    },
};
```

You can now define a component as your normally would with React:

```jsx
// FullDemo.js
export default class FullDemo extends React.Component {
    // ...
}
```

And then put following 2 lines in your markdown:

    ```js { "componentPath": "./FullDemo.js" }
    ```

When this markdown file will be compiled by Styleguidist, the resultant code generated by `updateExample(...)` will look as follows:

```jsx
import ExampleComp from '/abs/path/to/FullDemo.js;
;<ExampleComp/>;
```

This last part, in turn, will make your example render as intended, **while also transpiling the code using Wepback's config AND enabling hot-reloading**.

The only issue at this point is that the code editor in the `Playground` component will show the meaningless `ExampleComp` code. To give developers some sense of what code is actually being rendered, I propose adding a `props.settings.displaycontent` property as seen in `updateExample(...)` code above. This will let developers override what code is shown in the code editor below the example preview. Even though `displaycontent` code will not be editable nor hot-reloadable, it's much better to have inline JSX hot-reloading during development time than no hot-reloading at all. During build time, perhaps, Styleguidist could somehow fallback to default behaviour and render the code from the component again.

**PR commit message:**

Add a new property called `displayCode` to the `Playground` component.
When this property is set, the code displayed in the editor below the
example preview will come from `displayCode` instead of the usual `code`
property.

This can be used to enable hot-reloading and transpiling during
development, see the relevant pull request description.