### PR TITLE
Update react-dev-utils to ^9.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1642,8 +1642,8 @@
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
@@ -1651,8 +1651,8 @@
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
@@ -1984,9 +1984,9 @@
       "dev": true
     },
     "address": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-      "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+      "version": "1.1.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/address/-/address-1.1.0.tgz",
+      "integrity": "sha1-744EeEf80sW29QwWll+ST9mf5wk="
     },
     "ajv": {
       "version": "6.5.5",
@@ -2017,7 +2017,8 @@
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -2116,7 +2117,7 @@
     },
     "array-filter": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "array-find-index": {
@@ -2142,12 +2143,12 @@
     },
     "array-map": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-union": {
@@ -2307,6 +2308,58 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "babel-core": {
@@ -2799,13 +2852,13 @@
       }
     },
     "browserslist": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
-      "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+      "version": "4.6.6",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/browserslist/-/browserslist-4.6.6.tgz",
+      "integrity": "sha1-bkv0Z83lILydvfN0fa+gNTHOxFM=",
       "requires": {
-        "caniuse-lite": "^1.0.30000884",
-        "electron-to-chromium": "^1.3.62",
-        "node-releases": "^1.0.0-alpha.11"
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
       }
     },
     "bser": {
@@ -2926,7 +2979,7 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
@@ -2991,9 +3044,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000909",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000909.tgz",
-      "integrity": "sha512-4Ix9ArKpo3s/dLGVn/el9SAk6Vn2kGhg8XeE4eRTsGEsmm9RnTkwnBsVZs7p4wA8gB+nsgP36vZWYbG8a4nYrg=="
+      "version": "1.0.30000989",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+      "integrity": "sha1-uRk+KTzPfkQmxSRRNLjypWwKxLk="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -4000,8 +4053,8 @@
     },
     "detect-port-alt": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-      "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+      "integrity": "sha1-JHB96r6TLUo89iEwICfCsmZWgnU=",
       "requires": {
         "address": "^1.0.1",
         "debug": "^2.6.0"
@@ -4100,7 +4153,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -4148,7 +4201,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -4178,9 +4231,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz",
-      "integrity": "sha512-IYhbzJYOopiTaNWMBp7RjbecUBsbnbDneOP86f3qvS0G0xfzwNSvMJpTrvi5/Y1gU7tg2NAgeg8a8rCYvW9Whw=="
+      "version": "1.3.229",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/electron-to-chromium/-/electron-to-chromium-1.3.229.tgz",
+      "integrity": "sha1-rMyaCN0H0KTWx2k3ghvJTrLknq4="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -4839,11 +4892,11 @@
       "dev": true
     },
     "eventsource": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "version": "1.0.7",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "^1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -4918,6 +4971,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -5091,9 +5145,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-      "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+      "version": "2.2.7",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha1-aVOFfDr6R1//ku5gFdUtpwpM050=",
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
@@ -5174,8 +5228,8 @@
     },
     "filesize": {
       "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -5350,6 +5404,21 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
+    },
+    "fork-ts-checker-webpack-plugin": {
+      "version": "1.5.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.5.0.tgz",
+      "integrity": "sha1-zh13GQtE2Bp2GxC2KEo3N5XkHww=",
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.4.1",
+        "chokidar": "^2.0.4",
+        "micromatch": "^3.1.10",
+        "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
+        "tapable": "^1.0.0",
+        "worker-rpc": "^0.1.0"
+      }
     },
     "form-data": {
       "version": "2.3.3",
@@ -6094,13 +6163,14 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
       "requires": {
         "global-prefix": "^1.0.1",
         "is-windows": "^1.0.1",
@@ -6111,6 +6181,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
         "homedir-polyfill": "^1.0.1",
@@ -6166,12 +6237,19 @@
       "dev": true
     },
     "gzip-size": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
-      "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+      "version": "5.1.1",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
       "requires": {
         "duplexer": "^0.1.1",
-        "pify": "^3.0.0"
+        "pify": "^4.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+        }
       }
     },
     "handle-thing": {
@@ -6220,7 +6298,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -6228,8 +6305,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
@@ -6308,6 +6384,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -6636,9 +6713,9 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
     },
     "immer": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-1.7.2.tgz",
-      "integrity": "sha512-4Urocwu9+XLDJw4Tc6ZCg7APVjjLInCFvO4TwGsAYV5zT6YYSor14dsZR0+0tHlDIN92cFUOq+i7fC00G5vTxA=="
+      "version": "1.10.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/immer/-/immer-1.10.0.tgz",
+      "integrity": "sha1-utZ2BbqcgQJ12R4cKkfUWC6YKG0="
     },
     "import-fresh": {
       "version": "3.0.0",
@@ -6761,23 +6838,66 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "version": "6.5.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha1-IwMxfvyaTqfsLi32+GVptzSsz0I=",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
+        "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
+        "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+        },
+        "rxjs": {
+          "version": "6.5.2",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/rxjs/-/rxjs-6.5.2.tgz",
+          "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "internal-ip": {
@@ -6895,7 +7015,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -7108,9 +7228,9 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
-      "integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg=="
+      "version": "2.1.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/is-root/-/is-root-2.1.0.tgz",
+      "integrity": "sha1-gJ4YEpzxEpZEMCpPhUQDXVGYSpw="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -8123,7 +8243,7 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
@@ -8437,7 +8557,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -8790,14 +8910,19 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+      "version": "1.2.4",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha1-ySaVieaIWmDPgGBdlSLUtnymRuM="
     },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "microevent.ts": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/microevent.ts/-/microevent.ts-0.1.1.tgz",
+      "integrity": "sha1-cLCbg/Q99RctAgWmMCW84Pc1f6A="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -9128,9 +9253,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.4.tgz",
-      "integrity": "sha512-GqRV9GcHw8JCRDaP/JoeNMNzEGzHAknMvIHqMb2VeTOmg1Cf9+ej8bkV12tHfzWHQMCkQ5zUFgwFUkfraynNCw==",
+      "version": "1.1.27",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/node-releases/-/node-releases-1.1.27.tgz",
+      "integrity": "sha1-sZ7IrdKv6agmqZ3OzMUWEEwe2vQ=",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -9374,6 +9499,14 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "open": {
+      "version": "6.4.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/open/-/open-6.4.0.tgz",
+      "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
+      "requires": {
+        "is-wsl": "^1.1.0"
       }
     },
     "opn": {
@@ -9624,7 +9757,8 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "3.0.3",
@@ -9750,7 +9884,7 @@
     },
     "pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
         "find-up": "^2.1.0"
@@ -10175,56 +10309,93 @@
       }
     },
     "react-dev-utils": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.1.1.tgz",
-      "integrity": "sha512-ThbJ86coVd6wV/QiTo8klDTvdAJ1WsFCGQN07+UkN+QN9CtCSsl/+YuDJToKGeG8X4j9HMGXNKbk2QhPAZr43w==",
+      "version": "9.0.3",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/react-dev-utils/-/react-dev-utils-9.0.3.tgz",
+      "integrity": "sha1-dgdFVYeruEWZRRRg6zfO8LaEExo=",
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "address": "1.0.3",
-        "browserslist": "4.1.1",
-        "chalk": "2.4.1",
+        "@babel/code-frame": "7.5.5",
+        "address": "1.1.0",
+        "browserslist": "4.6.6",
+        "chalk": "2.4.2",
         "cross-spawn": "6.0.5",
         "detect-port-alt": "1.1.6",
         "escape-string-regexp": "1.0.5",
         "filesize": "3.6.1",
         "find-up": "3.0.0",
-        "global-modules": "1.0.0",
-        "globby": "8.0.1",
-        "gzip-size": "5.0.0",
-        "immer": "1.7.2",
-        "inquirer": "6.2.0",
-        "is-root": "2.0.0",
-        "loader-utils": "1.1.0",
-        "opn": "5.4.0",
+        "fork-ts-checker-webpack-plugin": "1.5.0",
+        "global-modules": "2.0.0",
+        "globby": "8.0.2",
+        "gzip-size": "5.1.1",
+        "immer": "1.10.0",
+        "inquirer": "6.5.0",
+        "is-root": "2.1.0",
+        "loader-utils": "1.2.3",
+        "open": "^6.3.0",
         "pkg-up": "2.0.0",
-        "react-error-overlay": "^5.1.0",
+        "react-error-overlay": "^6.0.1",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.6.1",
-        "sockjs-client": "1.1.5",
-        "strip-ansi": "4.0.0",
+        "sockjs-client": "1.3.0",
+        "strip-ansi": "5.2.0",
         "text-table": "0.2.0"
       },
       "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "requires": {
             "locate-path": "^3.0.0"
           }
         },
+        "global-modules": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/global-modules/-/global-modules-2.0.0.tgz",
+          "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
+          "requires": {
+            "global-prefix": "^3.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        },
         "globby": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+          "version": "8.0.2",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha1-VpdhnM2VxSdduy1vqkIIfBqUHY0=",
           "requires": {
             "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
+            "dir-glob": "2.0.0",
             "fast-glob": "^2.0.2",
             "glob": "^7.1.2",
             "ignore": "^3.3.5",
@@ -10232,50 +10403,43 @@
             "slash": "^1.0.0"
           }
         },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
-          }
-        },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.2.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "requires": {
             "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "requires": {
             "p-limit": "^2.0.0"
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+          "version": "2.2.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
@@ -10333,9 +10497,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.0.tgz",
-      "integrity": "sha512-akMy/BQT5m1J3iJIHkSb4qycq2wzllWsmmolaaFVnb+LPV9cIJ/nTud40ZsiiT0H3P+/wXIdbjx2fzF61OaeOQ=="
+      "version": "6.0.1",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
+      "integrity": "sha1-uNPPm7mRwCiDIlxIBEyz7iBBPg8="
     },
     "react-group": {
       "version": "3.0.0",
@@ -10502,8 +10666,8 @@
     },
     "recursive-readdir": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha1-mUb7MnThYo3m42svZxSVO0hFCU8=",
       "requires": {
         "minimatch": "3.0.4"
       }
@@ -10776,6 +10940,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
@@ -10870,6 +11035,7 @@
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
       "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -11077,7 +11243,7 @@
     },
     "shell-quote": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
         "array-filter": "~0.0.0",
@@ -11267,16 +11433,31 @@
       }
     },
     "sockjs-client": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
-      "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+      "version": "1.3.0",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/sockjs-client/-/sockjs-client-1.3.0.tgz",
+      "integrity": "sha1-EvydbLZj2lc509xftuhofalcsXc=",
       "requires": {
-        "debug": "^2.6.6",
-        "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
         "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        }
       }
     },
     "source-list-map": {
@@ -11765,8 +11946,7 @@
     "tapable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-      "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==",
-      "dev": true
+      "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
     },
     "terser": {
       "version": "3.17.0",
@@ -13088,6 +13268,14 @@
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-rpc": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.shuttercorp.net/artifactory/api/npm/npm-composite/worker-rpc/-/worker-rpc-0.1.1.tgz",
+      "integrity": "sha1-y1Zb1tcHGo8WZgaGBR6WmtMvVNU=",
+      "requires": {
+        "microevent.ts": "~0.1.1"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prop-types": "^15.7.2",
     "q-i": "^2.0.1",
     "qss": "^2.0.3",
-    "react-dev-utils": "^6.1.1",
+    "react-dev-utils": "^9.0.3",
     "react-docgen": "^4.1.0",
     "react-docgen-annotation-resolver": "^1.0.0",
     "react-docgen-displayname-handler": "^2.1.1",


### PR DESCRIPTION
[Snyk](https://snyk.io/) has reported a security vulnerability through the following dependency chains:

1. `react-styleguidist@9.1.3 › react-dev-utils@6.1.1 › sockjs-client@1.1.5 › eventsource@0.1.6 › original@1.0.0 › url-parse@1.0.5`
1. `react-styleguidist@9.1.3 › react-dev-utils@6.1.1 › sockjs-client@1.1.5 › url-parse@1.2.0`

Details of the Snyk report:

> **Overview**
> url-parse is a Small footprint URL parser that works seamlessly across Node.js and browser environments.
>
> Affected versions of this package are vulnerable to Open Redirect, Server Side Request Forgery (SSRF) and Bypass Authentication Protocol due to returning wrong hostname.

> **Remediation**
> Upgrade url-parse to version 1.4.3 or higher.

Details of dependency updates:

- `react-dev-utils@9.0.3` updates `sockjs-client@1.1.5 -> sockjs-client@1.3.0`
- `sockjs-client@1.3.0` updates: 
  - [`url-parse@^1.4.3`](https://github.com/sockjs/sockjs-client/blob/master/package.json#L33) fixing dependency chain 2 ✅
  - `eventsource@1.0.7`
- `eventsource@1.0.7` updates `original@^1.0.0`
- `original@^1.0.0` updates [`url-parse@^1.4.3`](https://github.com/unshiftio/original/blob/master/package.json#L25) fixing dependency chain 1 ✅ 