### PR TITLE
Feat: minimize options to be able to disable the js compression

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -20,6 +20,7 @@ By default, Styleguidist will look for `styleguide.config.js` file in your proje
 - [`handlers`](#handlers)
 - [`ignore`](#ignore)
 - [`logger`](#logger)
+- [`minimize`](#minimize)
 - [`moduleAliases`](#modulealiases)
 - [`mountPointId`](#mountpointid)
 - [`pagePerSection`](#pagepersection)
@@ -288,6 +289,12 @@ module.exports = {
   }
 }
 ```
+
+#### `minimize`
+
+Type: `Boolean`, default: `true`
+
+If `false`, the production build will not be minimized.
 
 #### `moduleAliases`
 

--- a/src/scripts/make-webpack-config.js
+++ b/src/scripts/make-webpack-config.js
@@ -96,6 +96,7 @@ module.exports = function(config, env) {
 				),
 			],
 			optimization: {
+				minimize: config.minimize === true,
 				minimizer: [minimizer],
 			},
 		});

--- a/src/scripts/schemas/config.js
+++ b/src/scripts/schemas/config.js
@@ -135,6 +135,10 @@ module.exports = {
 	logger: {
 		type: 'object',
 	},
+	minify: {
+		type: 'boolean',
+		default: true,
+	},
 	moduleAliases: {
 		type: 'object',
 	},


### PR DESCRIPTION
Sometimes `terser` can cause errors or be unwanted for debugging purpose.

I just had all my documentations broken and this will help me behave quickly when minify step is unwanted. 

Related to https://github.com/terser/terser/issues/490 