### PR TITLE
Docs: Fixed typos/grammar mistakes in the docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -55,7 +55,7 @@ By default, Styleguidist will look for `styleguide.config.js` file in your proje
 
 Type: `String` or `Array`, optional
 
-Your application static assets folder, will be accessible as `/` in the style guide dev server.
+Your application static assets folder will be accessible as`/`in the style guide dev server.
 
 #### `compilerConfig`
 
@@ -432,13 +432,13 @@ module.exports = {
 
 Type: `Number`, default: 500
 
-Debounce time in milliseconds used before render the changes from the editor. While typing code the preview will not be updated.
+Debounce time in milliseconds used before rendering the changes from the editor. While typing code the preview will not be updated.
 
 #### `propsParser`
 
 Type: `Function`, optional
 
-Function that allows you to override the mechanism used to parse props from a source file. Default mechanism is using [react-docgen](https://github.com/reactjs/react-docgen) to parse props.
+Function that allows you to override the mechanism used to parse props from a source file. The default mechanism is using [react-docgen](https://github.com/reactjs/react-docgen) to parse props.
 
 ```javascript
 module.exports = {
@@ -514,7 +514,7 @@ module.exports = {
 }
 ```
 
-Use [theme](#theme) config option to change ribbon style.
+Use the [theme](#theme) config option to change ribbon style.
 
 #### `sections`
 
@@ -540,7 +540,7 @@ Dev server port.
 
 Type: `Boolean`, default: `true`
 
-Toggle sidebar visibility. Sidebar will be hidden when opening components or examples in isolation mode even if this value is set to `true`. When set to `false`, sidebar will always be hidden.
+Toggle sidebar visibility. The sidebar will be hidden when opening components or examples in isolation mode even if this value is set to `true`. When set to `false`, the sidebar will always be hidden.
 
 #### `skipComponentsWithoutExample`
 
@@ -681,7 +681,7 @@ export default
 
 Type: `Function`, optional
 
-Function that modifies code example (Markdown fenced code block). For example you can use it to load examples from files:
+Function that modifies code example (Markdown fenced code block). For example, you can use it to load examples from files:
 
 ```javascript
 module.exports = {

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -55,7 +55,7 @@ By default, Styleguidist will look for `styleguide.config.js` file in your proje
 
 Type: `String` or `Array`, optional
 
-Your application static assets folder will be accessible as`/`in the style guide dev server.
+Your application static assets folder will be accessible as `/` in the style guide dev server.
 
 #### `compilerConfig`
 

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -19,7 +19,7 @@
 - [How to change style guide dev server logs output?](#how-to-change-style-guide-dev-server-logs-output)
 - [How to debug my components and examples?](#how-to-debug-my-components-and-examples)
 - [How to debug the exceptions thrown from my components?](#how-to-debug-the-exceptions-thrown-from-my-components)
-- [How to use production or development build of React?](#how-to-use-production-or-development-build-of-react)
+- [How to use the production or development build of React?](#how-to-use-the-production-or-development-build-of-react)
 - [Why object references don’t work in example component state?](#why-object-references-dont-work-in-example-component-state)
 - [How to use Vagrant with Styleguidist?](#how-to-use-vagrant-with-styleguidist)
 - [How to add a favicon?](#how-to-add-a-favicon)
@@ -68,7 +68,7 @@ module.exports = {
 
 ## How to hide some components in style guide but make them available in examples?
 
-Enable [skipComponentsWithoutExample](Configuration.md#skipcomponentswithoutexample) option and do not add example file (`Readme.md` by default) to components you want to ignore.
+Enable [skipComponentsWithoutExample](Configuration.md#skipcomponentswithoutexample) option and do not add an example file (`Readme.md` by default) to components you want to ignore.
 
 Import these components in your examples:
 
@@ -270,9 +270,9 @@ module.exports = {
 
 You can replace any Styleguidist React component. But in most of the cases you’ll want to replace `*Renderer` components — all HTML is rendered by these components. For example `ReactComponentRenderer`, `ComponentsListRenderer`, `PropsRenderer`, etc. — [check the source](https://github.com/styleguidist/react-styleguidist/tree/master/src/client/rsg-components) to see what components are available.
 
-There’s also a special wrapper component — `Wrapper` — that wraps every example component. By default it just renders `children` as is but you can use it to provide a custom logic.
+There’s also a special wrapper component — `Wrapper` — that wraps every example component. By default, it just renders `children` as is but you can use it to provide custom logic.
 
-For example you can replace the `Wrapper` component to wrap any example in the [React Intl’s](https://github.com/yahoo/react-intl) provider component. You can’t wrap the whole style guide because every example is compiled separately in a browser.
+For example, you can replace the `Wrapper` component to wrap any example in the [React Intl’s](https://github.com/yahoo/react-intl) provider component. You can’t wrap the whole style guide because every example is compiled separately in a browser.
 
 ```javascript
 // styleguide.config.js
@@ -401,9 +401,9 @@ module.exports = {
 2.  Press the ![Debugger](https://d3vv6lp55qjaqc.cloudfront.net/items/2h2q3N123N3G3R252o41/debugger.png) button in your browser’s developer tools.
 3.  Press the ![Continue](https://d3vv6lp55qjaqc.cloudfront.net/items/3b3c1P3g3O1h3q111I2l/continue.png) button and the debugger will stop execution at the next exception.
 
-## How to use production or development build of React?
+## How to use the production or development build of React?
 
-In some cases, you might need to use development build of React instead of the default [production one](https://reactjs.org/docs/optimizing-performance.html#use-the-production-build). For example, this might be needed if you use React Native and make references to a React Native component’s PropTypes in your code. As React removes all PropTypes in its production build, your code will fail. By default, Styleguidist uses the development build for the dev server, and the production one for static builds.
+In some cases, you might need to use the development build of React instead of the default [production one](https://reactjs.org/docs/optimizing-performance.html#use-the-production-build). For example, this might be needed if you use React Native and make references to a React Native component’s PropTypes in your code. As React removes all PropTypes in its production build, your code will fail. By default, Styleguidist uses the development build for the dev server and the production one for static builds.
 
 ```js
 import React from 'react'
@@ -452,7 +452,7 @@ initialState = {
 
 ## How to use Vagrant with Styleguidist?
 
-First read [Vagrant guide](https://webpack.js.org/guides/development-vagrant/) from the webpack documentation. Then enable polling in your webpack config:
+First, read [Vagrant guide](https://webpack.js.org/guides/development-vagrant/) from the webpack documentation. Then enable polling in your webpack config:
 
 ```js
 devServer: {
@@ -503,7 +503,7 @@ module.exports = {
 }
 ```
 
-In comparison to [require](Configuration.md#require) option, these scripts and links are run in the browser, not during webpack build process. It can be useful for side effect-causing scripts which your components, or in this case Babel output, need to function properly.
+In comparison to [require](Configuration.md#require) option, these scripts and links are run in the browser, not during webpack build process. It can be useful for side effect-causing scripts in which your components, or in this case Babel output, need to function properly.
 
 ## How to add fonts from Google Fonts?
 
@@ -539,7 +539,7 @@ See [working with third-party libraries](Thirdparties.md).
 
 ## How to change the names of components displayed in Styleguidist UI?
 
-You might want to change your components’ names to be displayed differently, for example, for stylistic purposes or to give them a more descriptive names in your style guide.
+You might want to change your components’ names to be displayed differently, for example, for stylistic purposes or to give them more descriptive names in your style guide.
 
 This can be done by adding [@visibleName](Documenting.md#defining-custom-component-names) tag to your component documentation.
 
@@ -558,7 +558,7 @@ module.exports = {
 
 ## What’s the difference between Styleguidist and Storybook?
 
-Both tools are good and mature, they have many similarities but also some distinctions that may make you choose one or the other. For me the biggest distinction is how you describe component variations.
+Both tools are good and mature, they have many similarities but also some distinctions that may make you choose one or the other. For me, the biggest distinction is how you describe component variations.
 
 With [Storybook](https://storybook.js.org/) you write _stories_ in JavaScript files:
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -14,7 +14,7 @@
 
 _For basics see [How to contribute](https://github.com/styleguidist/react-styleguidist/blob/master/.github/Contributing.md)._
 
-Styleguidist isn’t an ordinary single page app and some design decisions may look confusing to an outsider. In this guide we’ll explain these decisions to un-confuse potential contributors.
+Styleguidist isn’t an ordinary single-page app and some design decisions may look confusing to an outsider. In this guide, we’ll explain these decisions to un-confuse potential contributors.
 
 The main thing is that we’re running two apps at the same time: user’s components and Styleguidist UI. They share a webpack configuration and have styles in the same scope (there’s only one scope in CSS). And we can control only one of these two apps: Styleguidist UI. That puts us under some restrictions:
 
@@ -38,9 +38,9 @@ We use webpack loaders to hot reload the style guide on changes in user componen
 - `props-loaders`: loads props documentation using react-docgen;
 - `examples-loader`: loads examples from Markdown files;
 
-Styleguidist tries to load and reuse user’s webpack config (`webpack.config.js` in project root folder). It works most of the time but has some restrictions: Styleguidist [ignores](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/utils/mergeWebpackConfig.js) some fields and plugins because they are already included (like `webpack.HotModuleReplacementPlugin`), don’t make sense for a style guide (like `output`) or may break Styleguidist (like `entry`).
+Styleguidist tries to load and reuse the user’s webpack config (`webpack.config.js` in project root folder). It works most of the time but has some restrictions: Styleguidist [ignores](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/utils/mergeWebpackConfig.js) some fields and plugins because they are already included (like `webpack.HotModuleReplacementPlugin`), don’t make sense for a style guide (like `output`) or may break Styleguidist (like `entry`).
 
-We’re trying to keep Styleguidist’s own [webpack config](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/make-webpack-config.js) minimal to reduce clashes with user’s configuration.
+We’re trying to keep Styleguidist’s [webpack config](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/make-webpack-config.js) minimal to reduce clashes with the user’s configuration.
 
 ## React components
 
@@ -74,7 +74,7 @@ Each component folder usually has several files:
 
 ## Styles
 
-For styles we use [JSS](http://cssinjs.org/), it allows users to customize their style guide and allows us to ensure styles isolations (thanks to [jss-isolate](http://cssinjs.org/jss-isolate/)). No user styles should affect Styleguidist UI and no Styleguidist styles should affect user components.
+For styles we use [JSS](http://cssinjs.org/), it allows users to customize their style guide and allows us to ensure style isolation (thanks to [jss-isolate](http://cssinjs.org/jss-isolate/)). No user styles should affect Styleguidist UI and no Styleguidist styles should affect user components.
 
 Use [clsx](https://github.com/lukeed/clsx) to merge several class names or for conditional class names, import it as `cx` (`import cx from 'clsx'`).
 

--- a/docs/Documenting.md
+++ b/docs/Documenting.md
@@ -1,6 +1,6 @@
 # Documenting components
 
-Styleguidist generates documentation for your components based on the comments in your source code, propTypes declarations and Readme files.
+Styleguidist generates documentation for your components based on the comments in your source code, propTypes declarations, and Readme files.
 
 > **Note:** [See examples](https://github.com/styleguidist/react-styleguidist/tree/master/examples/basic/src/components) of documented components in our demo style guide.
 
@@ -56,7 +56,7 @@ export default class Button extends React.Component {
 
 ## Usage examples and Readme files
 
-Styleguidist will look for any `Readme.md` or `ComponentName.md` files in the component’s folder and display them. Any code block with a language tag of `js`, `jsx` or `javascript` will be rendered as a React component with an interactive playground. For backwards compatibility, code blocks without a language tag are also rendered in this way. It is recommended to always use the proper language tag for new documentation.
+Styleguidist will look for any `Readme.md` or `ComponentName.md` files in the component’s folder and display them. Any code block with a language tag of `js`, `jsx`, or `javascript` will be rendered as a React component with an interactive playground. For backwards compatibility, code blocks without a language tag are also rendered in this way. It is recommended to always use the proper language tag for new documentation.
 
     React component example:
 
@@ -92,7 +92,7 @@ Styleguidist will look for any `Readme.md` or `ComponentName.md` files in the co
 
 > **Note:** You can configure examples file name with the [getExampleFilename](Configuration.md#getexamplefilename) option.
 
-> **Note:** If you need to display some JavaScript code in your documentation that you don’t want rendered as an interactive playground you can use the `static` modifier with a language tag (e.g. `js static`).
+> **Note:** If you need to display some JavaScript code in your documentation that you don’t want to be rendered as an interactive playground you can use the `static` modifier with a language tag (e.g. `js static`).
 
 ## External examples using doclet tags
 
@@ -131,7 +131,7 @@ insertAtCursor(text) {
 
 ## Ignoring props
 
-By default, all props your components have are considered to be public and are published. In some rare cases you might want to remove a prop from the documentation while keeping it in the code. To do so, mark the prop with JSDoc [`@ignore`](http://usejsdoc.org/tags-ignore.html) tag to remove it from the docs:
+By default, all props your components have are considered to be public and are published. In some rare cases, you might want to remove a prop from the documentation while keeping it in the code. To do so, mark the prop with JSDoc [`@ignore`](http://usejsdoc.org/tags-ignore.html) tag to remove it from the docs:
 
 ```javascript
 MyComponent.propTypes = {
@@ -157,7 +157,7 @@ Use `@visibleName` JSDoc tag to define component names that are used in the Styl
 class Button extends React.Component {
 ```
 
-The component will be displayed with a custom “The Best Button Ever 🐙” name and this will not change the name of the component used in code of your app or Styleguidist examples.
+The component will be displayed with a custom “The Best Button Ever 🐙” name and this will not change the name of the component used in the code of your app or Styleguidist examples.
 
 ## Using JSDoc tags
 

--- a/docs/Maintenance.md
+++ b/docs/Maintenance.md
@@ -50,11 +50,11 @@ Patch releases are fully automated — any commit of a `Fix` type is published a
 
 ### Minor and major releases
 
-We’re using [milestones](https://github.com/styleguidist/react-styleguidist/milestones) to group approved pull requests that should be released together. Minor and major releases require a change log (see below). Any commit of a `Feat` type will not trigger a release until you commit a change log. Semantic-release will publish a major release, if there are any commits with [breaking changes](https://github.com/tamiadev/semantic-release-tamia/blob/master/Convention.md#breaking-changes).
+We’re using [milestones](https://github.com/styleguidist/react-styleguidist/milestones) to group approved pull requests that should be released together. Minor and major releases require a change log (see below). Any commit of a `Feat` type will not trigger a release until you commit a change log. Semantic-release will publish a major release if there are any commits with [breaking changes](https://github.com/tamiadev/semantic-release-tamia/blob/master/Convention.md#breaking-changes).
 
 1.  Merge all pull request from a milestone
 2.  Resolve possible merge conflicts.
-3.  Manually check that Styleguidist is still works.
+3.  Manually check that Styleguidist still works.
 4.  Prepare and commit a change log.
 5.  Wait until semantic-release publishes the release.
 6.  Tweet the release!
@@ -66,7 +66,7 @@ We’re using [milestones](https://github.com/styleguidist/react-styleguidist/mi
 - Change logs are written for users, not developers.
 - Change log should show new features with code examples or GIFs.
 - Change log should make all breaking changes clear.
-- Change log should explain how to migrate to a new versions if there are breaking changes.
+- Change log should explain how to migrate to a new version if there are breaking changes.
 - Commit log **is not** a change log.
 
 Here’s a [good example of a change log](https://github.com/styleguidist/react-styleguidist/releases/tag/v7.1.0). Check out [Keep a Changelog](https://keepachangelog.com/) for more details on good change logs.

--- a/docs/Maintenance.md
+++ b/docs/Maintenance.md
@@ -10,10 +10,10 @@
 - [Releases](#releases)
   - [Patch releases](#patch-releases)
   - [Minor and major releases](#minor-and-major-releases)
-- [Change logs](#change-logs)
-  - [What is a good change log](#what-is-a-good-change-log)
-  - [What should be in a change log](#what-should-be-in-a-change-log)
-  - [Preparing a change log](#preparing-a-change-log)
+- [Changelogs](#changelogs)
+  - [What is a good changelog](#what-is-a-good-changelog)
+  - [What should be in a changelog](#what-should-be-in-a-changelog)
+  - [Preparing a changelog](#preparing-a-changelog)
 
 <!-- tocstop -->
 
@@ -50,34 +50,34 @@ Patch releases are fully automated — any commit of a `Fix` type is published a
 
 ### Minor and major releases
 
-We’re using [milestones](https://github.com/styleguidist/react-styleguidist/milestones) to group approved pull requests that should be released together. Minor and major releases require a change log (see below). Any commit of a `Feat` type will not trigger a release until you commit a change log. Semantic-release will publish a major release if there are any commits with [breaking changes](https://github.com/tamiadev/semantic-release-tamia/blob/master/Convention.md#breaking-changes).
+We’re using [milestones](https://github.com/styleguidist/react-styleguidist/milestones) to group approved pull requests that should be released together. Minor and major releases require a changelog (see below). Any commit of a `Feat` type will not trigger a release until you commit a changelog. Semantic-release will publish a major release if there are any commits with [breaking changes](https://github.com/tamiadev/semantic-release-tamia/blob/master/Convention.md#breaking-changes).
 
 1.  Merge all pull request from a milestone
 2.  Resolve possible merge conflicts.
 3.  Manually check that Styleguidist still works.
-4.  Prepare and commit a change log.
+4.  Prepare and commit a changelog.
 5.  Wait until semantic-release publishes the release.
 6.  Tweet the release!
 
-## Change logs
+## Changelogs
 
-### What is a good change log
+### What is a good changelog
 
-- Change logs are written for users, not developers.
-- Change log should show new features with code examples or GIFs.
-- Change log should make all breaking changes clear.
-- Change log should explain how to migrate to a new version if there are breaking changes.
-- Commit log **is not** a change log.
+- Changelogs are written for users, not developers.
+- Changelog should show new features with code examples or GIFs.
+- Changelog should make all breaking changes clear.
+- Changelog should explain how to migrate to a new version if there are breaking changes.
+- Commit log **is not** a changelog.
 
-Here’s a [good example of a change log](https://github.com/styleguidist/react-styleguidist/releases/tag/v7.1.0). Check out [Keep a Changelog](https://keepachangelog.com/) for more details on good change logs.
+Here’s a [good example of a changelog](https://github.com/styleguidist/react-styleguidist/releases/tag/v7.1.0). Check out [Keep a Changelog](https://keepachangelog.com/) for more details on good changelogs.
 
-### What should be in a change log
+### What should be in a changelog
 
 - Information about pull request authors:<br> `(#1040 by @rafaesc)`
 - Open Collective link at the very top:<br> `👋 **[Support Styleguidist](https://opencollective.com/styleguidist) on Open Collective** 👋`
 
-### Preparing a change log
+### Preparing a changelog
 
-1.  Generate a change log draft using [tamia-changelog](https://github.com/tamiadev/tamia-changelog): `npx tamia-changelog`
+1.  Generate a changelog draft using [tamia-changelog](https://github.com/tamiadev/tamia-changelog): `npx tamia-changelog`
 2.  Edit `Changelog.md` file.
-3.  Commit the change log: `npx tamia-changelog commit`.
+3.  Commit the changelog: `npx tamia-changelog commit`.

--- a/docs/Thirdparties.md
+++ b/docs/Thirdparties.md
@@ -20,7 +20,7 @@
 
 Styleguidist _loads_ your components (see [Loading and exposing components](Components.md#loading-and-exposing-components) for more) but it uses [react-docgen](https://github.com/reactjs/react-docgen) to _generate documentation_ which may require changes in your code to work properly.
 
-React-docgen reads your components as static text files and looks for patterns like class or function declarations that looks like React components. It does not run any JavaScript code, so, if your component is dynamically generated, is wrapped in a higher-order component, or is split into several files, then react-docgen may not understand it.
+React-docgen reads your components as static text files and looks for patterns like class or function declarations that look like React components. It does not run any JavaScript code, so, if your component is dynamically generated, is wrapped in a higher-order component, or is split into several files, then react-docgen may not understand it.
 
 It supports components defined via `React.createClass`, ES6 classes and stateless functional components, with optional Flow and TypeScript (via [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript)) type annotations.
 
@@ -194,7 +194,7 @@ export default SalmonButton
 
 If your styled-components require a theme to render properly, add a `ThemeProvider` to your style guide.
 
-First, create your `Wrapper` component. For this example we’ll put it in the `styleguide/` directory, but you can add it anywhere you want.
+First, create your `Wrapper` component. For this example, we’ll put it in the `styleguide/` directory, but you can add it anywhere you want.
 
 ```jsx
 // styleguide/ThemeWrapper.js

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -21,7 +21,7 @@ _Webpack is required to run Styleguidist but your project doesn’t have to use 
 
 ## Reusing your project’s webpack config
 
-By default Styleguidist will try to find `webpack.config.js` in your project’s root directory and use it.
+By default, Styleguidist will try to find `webpack.config.js` in your project’s root directory and use it.
 
 If your webpack config is located somewhere else, you need to load it manually:
 
@@ -60,7 +60,7 @@ module.exports = {
   webpackConfig: {
     module: {
       rules: [
-        // Babel loader, will use your project’s babel.config.js
+        // Babel loader will use your project’s babel.config.js
         {
           test: /\.jsx?$/,
           exclude: /node_modules/,
@@ -117,7 +117,7 @@ First, install the Babel webpack loader:
 npm install --save-dev babel-loader
 ```
 
-> **Note:** If your project doesn’t use webpack you still need add webpack loaders for your files, otherwise Styleguidist won’t be able to load your code.
+> **Note:** If your project doesn’t use webpack you still need to add webpack loaders for your files, otherwise Styleguidist won’t be able to load your code.
 
 Then, add a `webpackConfig` section to your `styleguide.config.js`
 
@@ -189,6 +189,6 @@ This will tell Babel (and some other tools) which browsers you support, so it wo
 
 ## When nothing else works
 
-In very rare cases, like using legacy or third-party libraries, you may need to change webpack options that Styleguidist doesn’t allow you to change via `webpackConfig` options. In this case you can use [dangerouslyUpdateWebpackConfig](Configuration.md#dangerouslyupdatewebpackconfig) option.
+In very rare cases, like using legacy or third-party libraries, you may need to change webpack options that Styleguidist doesn’t allow you to change via `webpackConfig` options. In this case, you can use [dangerouslyUpdateWebpackConfig](Configuration.md#dangerouslyupdatewebpackconfig) option.
 
 > **Warning:** You may easily break Styleguidist using this option, use it at your own risk.


### PR DESCRIPTION
I went through and fixed a handful of typos/grammar issues in the docs. Some of the changes are pretty obvious typos/grammar problems. Others are a bit more debatable, so let me know if you disagree with any of the changes.

Also, it looks like Maintenance.md uses "change log" instead of "changelog" throughout the doc. From what I've seen online, "changelog" is the preferred term so let me know if I'm okay to go through and change it there.