### PR TITLE
Fix: remove style warning when compiling

### DIFF
--- a/src/client/rsg-components/Styled/index.ts
+++ b/src/client/rsg-components/Styled/index.ts
@@ -1,1 +1,2 @@
-export { default, JssInjectedProps, Theme } from 'rsg-components/Styled/Styled';
+export { default } from 'rsg-components/Styled/Styled';
+export * from 'rsg-components/Styled/Styled';


### PR DESCRIPTION
When running the standard basic example, one gets a warning in webpack:

```sh
 WARN  Compiled with warnings

./lib/client/rsg-components/Styled/index.js
Attempted import error: 'JssInjectedProps' is not exported from 'rsg-components/Styled/Styled'.
 @ ./lib/client/rsg-components/StyleGuide/StyleGuideRenderer.js
 @ ./lib/client/rsg-components/StyleGuide/StyleGuide.js
 @ ./lib/client/rsg-components/StyleGuide/index.js
 @ ./lib/client/utils/renderStyleguide.js
 @ ./lib/client/index.js
 @ multi ./lib/client/index ./node_modules/react-dev-utils/webpackHotDevClient.js
```

babel does not understand the difference between exposing an interface and an actual js object.
Hence the warning. 

This change fixes it.