### PR TITLE
Fix overflow in code examples with long strings

### DIFF
--- a/src/client/rsg-components/Markdown/Pre/PreRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Pre/PreRenderer.tsx
@@ -20,6 +20,7 @@ const styles = ({ space, color, fontSize, fontFamily, borderRadius }: Rsg.Theme)
 		borderRadius,
 		marginTop: 0,
 		marginBottom: space[2],
+		overflow: 'auto',
 		...prismTheme({ color }),
 	},
 });


### PR DESCRIPTION
iss: https://github.com/styleguidist/react-styleguidist/issues/1450

Add `overflow: auto` to the `pre` tags

Example: 
![overflow-auto-on-code-example](https://user-images.githubusercontent.com/5443359/69884969-ff6a6a00-12eb-11ea-948a-5e661fe52224.gif)


