### PR TITLE
Fix: Update acorn to 6.4.0 to fix several issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,9 +2084,9 @@
       }
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@vxna/mini-html-webpack-template": "^1.0.0",
-    "acorn": "~6.3.0",
+    "acorn": "~6.4.0",
     "acorn-jsx": "^5.1.0",
     "ast-types": "~0.13.2",
     "buble": "0.19.8",


### PR DESCRIPTION
This `acorn` update to `6.4.0` version should fix issues like:

- https://github.com/styleguidist/react-styleguidist/issues/1321;
- https://github.com/styleguidist/react-styleguidist/issues/1312;
- https://github.com/styleguidist/react-styleguidist/issues/1278;
- https://github.com/styleguidist/react-styleguidist/issues/1310.

More about `acorn@6.4.0` — https://github.com/acornjs/acorn/releases/tag/6.4.0.