### PR TITLE
Honor default exports over named exports

### DIFF
--- a/src/loaders/__tests__/examples-loader.spec.ts
+++ b/src/loaders/__tests__/examples-loader.spec.ts
@@ -180,7 +180,7 @@ it('should prepend example code with React require()', () => {
 	expect(result).toBeTruthy();
 	expect(() => new Function(result)).not.toThrowError(SyntaxError);
 	expect(result).toMatch(
-		`const React$0 = require('react');\\nconst React = React$0['React'] || (React$0.default || React$0);`
+		`const React$0 = require('react');\\nconst React = React$0.default || (React$0['React'] || React$0);`
 	);
 });
 
@@ -197,7 +197,7 @@ it('should prepend example code with component require()', () => {
 	expect(result).toBeTruthy();
 	expect(() => new Function(result)).not.toThrowError(SyntaxError);
 	expect(result).toMatch(
-		`const FooComponent$0 = require('../foo.js');\\nconst FooComponent = FooComponent$0['FooComponent'] || (FooComponent$0.default || FooComponent$0);`
+		`const FooComponent$0 = require('../foo.js');\\nconst FooComponent = FooComponent$0.default || (FooComponent$0['FooComponent'] || FooComponent$0);`
 	);
 });
 
@@ -217,10 +217,10 @@ it('should allow explicit import of React and component module', () => {
 	expect(result).toBeTruthy();
 	expect(() => new Function(result)).not.toThrowError(SyntaxError);
 	expect(result).toMatch(
-		`const React$0 = require('react');\\nconst React = React$0['React'] || (React$0.default || React$0);`
+		`const React$0 = require('react');\\nconst React = React$0.default || (React$0['React'] || React$0);`
 	);
 	expect(result).toMatch(
-		`const FooComponent$0 = require('../foo.js');\\nconst FooComponent = FooComponent$0['FooComponent'] || (FooComponent$0.default || FooComponent$0);`
+		`const FooComponent$0 = require('../foo.js');\\nconst FooComponent = FooComponent$0.default || (FooComponent$0['FooComponent'] || FooComponent$0);`
 	);
 });
 
@@ -240,7 +240,7 @@ it('should works for any Markdown file, without a current component', () => {
 	expect(result).toBeTruthy();
 	expect(() => new Function(result)).not.toThrowError(SyntaxError);
 	expect(result).toMatch(
-		`const React$0 = require('react');\\nconst React = React$0['React'] || (React$0.default || React$0);`
+		`const React$0 = require('react');\\nconst React = React$0.default || (React$0['React'] || React$0);`
 	);
 	expect(result).not.toMatch('undefined');
 });

--- a/src/loaders/examples-loader.ts
+++ b/src/loaders/examples-loader.ts
@@ -81,16 +81,16 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 				b.variableDeclaration('const', [
 					b.variableDeclarator(b.identifier(`${name}$0`), requireIt(requireRequest).toAST() as any),
 				]),
-				// const name = name$0[name] || name$0.default || name$0;
+				// const name = name$0.default || name$0[name] || name$0;
 				b.variableDeclaration('const', [
 					b.variableDeclarator(
 						b.identifier(name),
 						b.logicalExpression(
 							'||',
-							b.identifier(`${name}$0['${name}']`),
+							b.identifier(`${name}$0.default`),
 							b.logicalExpression(
 								'||',
-								b.identifier(`${name}$0.default`),
+								b.identifier(`${name}$0['${name}']`),
 								b.identifier(`${name}$0`)
 							)
 						)


### PR DESCRIPTION
When you have a component like 

```tsx
import React from 'react';
import styled from 'styled-components';

export const C: React.FC = () => {
  ...
}

const StyledC = styled(C)``;

export default StyledC;
```
so that you can use non-styled (name-exported) components for testing, styleguidist picks up the named export instead of the default export and breaks the styling in examples. 

If I understand [this part of the doc](https://react-styleguidist.js.org/docs/components.html#default-vs-named-exports) correctly, isn't this supposed to be the case? As in it will try to find
1. default exports 
2. if not found => single named export
3. if not found => named export with the same name

I'm aware there are a few workarounds to get my example above working, but just in case the current behavior isn't intended. 