### PR TITLE
fix:(isolation mode issue) issue #1492

### DIFF
--- a/src/client/utils/__tests__/getUrl.spec.ts
+++ b/src/client/utils/__tests__/getUrl.spec.ts
@@ -6,6 +6,11 @@ describe('getUrl', () => {
 		pathname: '/styleguide/',
 		hash: '#/Components',
 	};
+	const locHashedURL = {
+		origin: 'http://example.com',
+		pathname: '/styleguide/',
+		hash: '#button',
+	}
 	const name = 'FooBar';
 	const slug = 'foobar';
 
@@ -42,6 +47,11 @@ describe('getUrl', () => {
 	it('should return an isolated example URL', () => {
 		const result = getUrl({ name, slug, example: 3, isolated: true }, loc);
 		expect(result).toBe('/styleguide/#!/Components/FooBar/3');
+	});
+
+	it('should return an isolated example for a HashedURL', () => {
+		const result = getUrl({ name, slug, example: 0, isolated: true }, locHashedURL);
+		expect(result).toBe('/styleguide/#!/FooBar/0');
 	});
 
 	it('should return an isolated example=0 URL', () => {

--- a/src/client/utils/getUrl.ts
+++ b/src/client/utils/getUrl.ts
@@ -1,15 +1,15 @@
 /* Returns the HashPath to be included in the isolated page view url */
 function getCurrentHashPath(stripFragment:RegExp,stripTrailingSlash:RegExp,currentHash: string):string {
 
-	/*The below pattern is used to identify the urls like..http://hostname.com/#button etc.,
-	these are generated when we click on a component in the side nav-bar.
-	This will verify whether the first character after the '#' symbol is an alphanumeric which can include "_".
+	/*This pattern matches urls like http://hostname.com/#button etc.,
+	these urls are generated when we click on a component in the side nav-bar.
+	This will verify whether the first character after the '#' symbol is an alphanumeric char or "_".
 	this pattern used to validate the components names.*/
-	const hashUrlPattern = /^#[a-zA-Z0-9_]/;
+	const hashUrlPattern = /^#[a-zA-Z0-9_]/; // Ex. matches "#button","#1button","#_button"
 
-	/* This pattern is used to identify if the url contains the "#!/" string pattern in the 'currentHash' const
+	/* This pattern matches "#!/" string pattern in the 'currentHash' const
 	this url pattern is used to show isolated page view mode in this project. */
-	const isolatedPageViewUrlPattern = /^#!\//;
+	const isolatedPageViewUrlPattern = /^#!\//; // Ex. matches "#!/button"  
 
 	if (hashUrlPattern.test(currentHash)) {
 		return '';

--- a/src/client/utils/getUrl.ts
+++ b/src/client/utils/getUrl.ts
@@ -1,3 +1,24 @@
+/* Returns the HashPath to be included in the isolated page view url */
+function getCurrentHashPath(stripFragment:RegExp,stripTrailingSlash:RegExp,currentHash: string):string {
+
+	/*The below pattern is used to identify the urls like..http://hostname.com/#button etc.,
+	these are generated when we click on a component in the side nav-bar.
+	This will verify whether the first character after the '#' symbol is an alphanumeric which can include "_".
+	this pattern used to validate the components names.*/
+	const hashUrlPattern = /^#[a-zA-Z0-9_]/;
+
+	/* This pattern is used to identify if the url contains the "#!/" string pattern in the 'currentHash' const
+	this url pattern is used to show isolated page view mode in this project. */
+	const isolatedPageViewUrlPattern = /^#!\//;
+
+	if (hashUrlPattern.test(currentHash)) {
+		return '';
+	} else {
+		return (currentHash && !isolatedPageViewUrlPattern.test(currentHash)) ?
+			 currentHash.replace(stripFragment, '').replace(stripTrailingSlash, '') + '/' : '';
+	}
+}
+
 /**
  * Gets the URL fragment for an isolated or nochrome link.
  *
@@ -14,17 +35,8 @@ function buildIsolatedOrNoChromeFragment({
 }): string {
 	const stripFragment = /^#\/?/;
 	const stripTrailingSlash = /\/$/;
-	const hashUrlPattern = /^#[a-zA-Z0-9_]/;
-	let currentHashPath;
-	if (hashUrlPattern.test(currentHash)) {
-		currentHashPath = '';
-	} else {
-		currentHashPath =
-			// skip if we are already using `#!/`
-			currentHash && !currentHash.includes('#!/')
-				? currentHash.replace(stripFragment, '').replace(stripTrailingSlash, '') + '/'
-				: '';
-	}
+
+	const currentHashPath = getCurrentHashPath(stripFragment,stripTrailingSlash,currentHash);
 	return `#!/${currentHashPath}${encodedName}`;
 }
 

--- a/src/client/utils/getUrl.ts
+++ b/src/client/utils/getUrl.ts
@@ -14,11 +14,17 @@ function buildIsolatedOrNoChromeFragment({
 }): string {
 	const stripFragment = /^#\/?/;
 	const stripTrailingSlash = /\/$/;
-	const currentHashPath =
-		// skip if we are already using `#!/`
-		currentHash && !currentHash.includes('#!/')
-			? currentHash.replace(stripFragment, '').replace(stripTrailingSlash, '') + '/'
-			: '';
+	const hashUrlPattern = /^#[a-zA-Z0-9_]/;
+	let currentHashPath;
+	if (hashUrlPattern.test(currentHash)) {
+		currentHashPath = '';
+	} else {
+		currentHashPath =
+			// skip if we are already using `#!/`
+			currentHash && !currentHash.includes('#!/')
+				? currentHash.replace(stripFragment, '').replace(stripTrailingSlash, '') + '/'
+				: '';
+	}
 	return `#!/${currentHashPath}${encodedName}`;
 }
 


### PR DESCRIPTION
issue link: https://github.com/styleguidist/react-styleguidist/issues/1492

This issue occurred because of the fix that have been made in version 10.0.1 for the issue: https://github.com/styleguidist/react-styleguidist/issues/1454

Hashed Url example: the "#button" in the url is an example of Hashed Url...it gets appended after clicking the Button component in the side-Navbar...
<img width="1440" alt="Screenshot 2020-01-03 at 6 14 45 PM" src="https://user-images.githubusercontent.com/21274438/71724136-2967fc80-2e55-11ea-9a6e-39c9d16d21e2.png">

After the issue #1454 was resolved...it was taking the hashed url token in the isolated page(which opens after clicking the fullscreen icon) url as you can see below

after clicking the fullscreen icon we got results like this!
<img width="973" alt="pageNotFound(1)" src="https://user-images.githubusercontent.com/21274438/71724438-54068500-2e56-11ea-80c8-736a9591db60.png">

so this was the issue which is resolved by doing a simple check i.e. we are verifying if the currentHash that we are getting in the 'buildIsolatedOrNoChromeFragment()' function is a hashedUrl("#button") or a Section-Url("#/Components")...

we just checked the first character after the '#' in the currentHash string if it matches the hashedUrlpattern then we are neglecting the extra currentHashPath...

now as you can see below we removed the "/button" from the url...it is working fine..
<img width="1440" alt="pageFound" src="https://user-images.githubusercontent.com/21274438/71725180-050e1f00-2e59-11ea-921c-e471a6be3df0.png">


we have written a test case for that as you can check...!
and also the issue mentioned in #1454 is also working fine...





