### PR TITLE
Build: Avoid compiling spec files when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "start:sections": "node lib/bin/styleguidist.js server --config examples/sections/styleguide.config.js",
     "start:ui": "node lib/bin/styleguidist.js server",
     "lint": "eslint . --cache --fix --ext .js,.ts,.tsx",
-    "compile": "babel --delete-dir-on-start --ignore **/__mocks__/*,**/__tests__/*,**/*.spec.*,**/*.d.ts --extensions '.js,.ts,.tsx' -d lib/ src/",
+    "compile": "babel --delete-dir-on-start --ignore '**/__mocks__/*,**/__tests__/*,**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/*.d.ts' --extensions '.js,.ts,.tsx' -d lib/ src/",
     "compile:types": "tsc -p ./tsconfig.types.json --emitDeclarationOnly",
     "compile:watch": "npm run compile -- --watch",
     "prepublishOnly": "npm run compile",


### PR DESCRIPTION
When running `npm run compile` all spec.ts and tsx files are compiled into the lib folder which result in publishing tests to npm.

I remove this compilation, to make the command faster and avoid conflicts with other libraries.