### PR TITLE
Build: Publish typings on travis publish

### DIFF
--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -554,15 +554,14 @@ module.exports = {
 
 ## How to re-use the types in Styleguidist?
 
-From version 10, styleguidist is written using typescript language.
+From version 10, Styleguidist is written using TypeScript language.
 
 It allows the maintainers to catch type mismatch before execution and a better developer experience.
 
 It also allows users to write their customized styleguide components using typescript TSX and plugins to build it.
 
-There is a trick though. Since all files in `src/client/rsg-components` are aliased to `rsg-components` using webpack, you will have to add this alias to your `tsconfig.json` file
+There is a trick though. Since all files in `src/client/rsg-components` are aliased to `rsg-components` using webpack, you will have to add this alias to your `tsconfig.json` file:
 
-Here is an example of what this file could contain:
 
 ```json
 {

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -27,6 +27,7 @@
 - [How to reuse project’s webpack config?](#how-to-reuse-projects-webpack-config)
 - [How to use React Styleguidist with Redux, Relay or Styled Components?](#how-to-use-react-styleguidist-with-redux-relay-or-styled-components)
 - [How to change the names of components displayed in Styleguidist UI?](#how-to-change-the-names-of-components-displayed-in-styleguidist-ui)
+- [How to re-use the types in Styleguidist?](#how-to-re-use-the-types-in-styleguidist)
 - [What’s the difference between Styleguidist and Storybook?](#whats-the-difference-between-styleguidist-and-storybook)
 - [Are there any other projects like this?](#are-there-any-other-projects-like-this)
 
@@ -548,6 +549,55 @@ module.exports = {
     }
     return docs
   }
+}
+```
+
+## How to re-use the types in Styleguidist?
+
+From version 10, styleguidist is written using typescript language.
+
+It allows the maintainers to catch type mismatch before execution and a better developer experience.
+
+It also allows users to wtite their customized styleguide components using typescript TSX and plugins to build it.
+
+There is a trick though. Since all files in `src/client/rsg-components` are aliased to `rsg-components` using webpack, you will have to add this alias to your `tsconfig.json` file
+
+Here is an example of what this file could contain:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      // remap rsg-components/anything to its version in react-styleguidist
+      "rsg-components/*": [
+        "node_modules/react-styleguidist/lib/client/rsg-components/*"
+      ]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}
+```
+
+This way when you write the following component, TypeScript will resolve typings for client components and help you type them properly.
+
+```ts
+import Styled from 'rsg-components/Styled'
+import Heading from 'rsg-components/Heading'
+
+export default function SectionsRenderer({ children }) {
+  return (
+    <div>
+      {children.length > 0 && (
+        <div>
+          <Heading level={1}>Example Components</Heading>
+          <p>These are the greatest components</p>
+        </div>
+      )}
+      <DefaultSectionsRenderer>{children}</DefaultSectionsRenderer>
+    </div>
+  )
 }
 ```
 

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -556,12 +556,11 @@ module.exports = {
 
 From version 10, Styleguidist is written using TypeScript language.
 
-It allows the maintainers to catch type mismatch before execution and a better developer experience.
+It allows the maintainers to catch type mismatch before execution and gives them a better developer experience.
 
-It also allows users to write their customized styleguide components using typescript TSX and plugins to build it.
+It also allows you to write customized style guide components using TypeScript TSX instead of JavaScript JSX.
 
-There is a trick though. Since all files in `src/client/rsg-components` are aliased to `rsg-components` using webpack, you will have to add this alias to your `tsconfig.json` file:
-
+**NOTE:** Since all files in `src/client/rsg-components` are aliased to `rsg-components` using webpack, you will have to add this alias to your `tsconfig.json` file:
 
 ```json
 {

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -558,7 +558,7 @@ From version 10, styleguidist is written using typescript language.
 
 It allows the maintainers to catch type mismatch before execution and a better developer experience.
 
-It also allows users to wtite their customized styleguide components using typescript TSX and plugins to build it.
+It also allows users to write their customized styleguide components using typescript TSX and plugins to build it.
 
 There is a trick though. Since all files in `src/client/rsg-components` are aliased to `rsg-components` using webpack, you will have to add this alias to your `tsconfig.json` file
 

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "compile": "babel --delete-dir-on-start --ignore **/__mocks__/*,**/__tests__/*,**/*.spec.*,**/*.d.ts --extensions '.js,.ts,.tsx' -d lib/ src/",
     "compile:types": "tsc -p ./tsconfig.types.json --emitDeclarationOnly",
     "compile:watch": "npm run compile -- --watch",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && npm run compile:types",
     "build:basic": "node lib/bin/styleguidist.js build --config examples/basic/styleguide.config.js",
     "build:customised": "node lib/bin/styleguidist.js build --config examples/customised/styleguide.config.js",
     "build:sections": "node lib/bin/styleguidist.js build --config examples/sections/styleguide.config.js",


### PR DESCRIPTION
As previously mentioned, I want to be able to use the types generated by rsg in vue-styleguidist.
This publishes the types with the compiled library.

There is a known limitation: `rsg-component` aliased path have to be kept in the `tsconfig.json` of any project using the types. It should redirect to `node_modules/react-styleguidist/lib/client/rsg-component`. 