### PR TITLE
Adding Theme UI to Thirdparties docs

### DIFF
--- a/docs/Thirdparties.md
+++ b/docs/Thirdparties.md
@@ -10,6 +10,7 @@
   - [Relay](#relay)
   - [Styled-components](#styled-components)
   - [Emotion](#emotion)
+  - [Theme UI](#theme-ui)
   - [Fela](#fela)
   - [CSS Modules with react-css-modules](#css-modules-with-react-css-modules)
   - [Styletron](#styletron)
@@ -252,6 +253,10 @@ This will automatically apply your theme to your styled-components. When you ope
 ### Emotion
 
 The usage is similar to [styled-components](#styled-components).
+
+### Theme UI
+
+The usage is similar to [Adding styled-components `ThemeProvider`](#adding-styled-components-themeprovider).
 
 ### Fela
 


### PR DESCRIPTION
Adding Theme UI to the docs addresses these two issues that I had yesterday:
1. Not finding in the first minutes why Styleguidist was not recognizing Theme UI was above all, a SEO issue: Theme UI is not mentioned in the docs, so you never get to Thirdparties through Google.

2. Once you end up in Thirdparties through the Styleguidist website, you are just going to bypass the "Adding styled-components ThemeProvider" section if your head didn't click yet about the facts that a) you are not passing the ThemeProvider to Styleguidist and b) Theme UI was built with Emotion among other technologies.