### PR TITLE
Fix Property types don't show up

### DIFF
--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -618,12 +618,27 @@ describe('unquote', () => {
 });
 
 describe('getType', () => {
-	test('should return .type or .flowType property', () => {
+	test('should return not .type but .flowType property', () => {
 		const result = getType({
 			type: 'foo',
 			flowType: 'bar',
 		} as any);
 		expect(result).toBe('bar');
+	});
+
+	test('should return not .type but .tsType property', () => {
+		const result = getType({
+			type: 'foo',
+			tsType: 'bar',
+		} as any);
+		expect(result).toBe('bar');
+	});
+
+	test('should return .type property', () => {
+		const result = getType({
+			type: 'foo',
+		} as any);
+		expect(result).toBe('foo');
 	});
 });
 

--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { parse } from 'react-docgen';
 import PropsRenderer, { columns, getRowKey } from './PropsRenderer';
-import { unquote, getType, showSpaces, PropDescriptorWithFlow } from './util';
+import { unquote, getType, showSpaces, PropDescriptor } from './util';
 
 const propsToArray = (props: any) => Object.keys(props).map(name => ({ ...props[name], name }));
 
@@ -16,7 +16,7 @@ const getText = (node: { innerHTML: string }): string =>
 		.trim();
 
 // Test renderers with clean readable snapshot diffs
-export default function ColumnsRenderer({ props }: { props: PropDescriptorWithFlow[] }) {
+export default function ColumnsRenderer({ props }: { props: PropDescriptor[] }) {
 	return (
 		<>
 			{props.map((row, rowIdx) => (

--- a/src/client/rsg-components/Props/PropsRenderer.tsx
+++ b/src/client/rsg-components/Props/PropsRenderer.tsx
@@ -10,9 +10,9 @@ import Table from 'rsg-components/Table';
 import renderTypeColumn from './renderType';
 import renderExtra from './renderExtra';
 import renderDefault from './renderDefault';
-import { PropDescriptorWithFlow } from './util';
+import { PropDescriptor } from './util';
 
-function renderDescription(prop: PropDescriptorWithFlow) {
+function renderDescription(prop: PropDescriptor) {
 	const { description, tags = {} } = prop;
 	const extra = renderExtra(prop);
 	const args = [...(tags.arg || []), ...(tags.argument || []), ...(tags.param || [])];
@@ -29,7 +29,7 @@ function renderDescription(prop: PropDescriptorWithFlow) {
 	);
 }
 
-function renderName(prop: PropDescriptorWithFlow) {
+function renderName(prop: PropDescriptor) {
 	const { name, tags = {} } = prop;
 	return <Name deprecated={!!tags.deprecated}>{name}</Name>;
 }
@@ -58,7 +58,7 @@ export const columns = [
 ];
 
 interface PropsProps {
-	props: PropDescriptorWithFlow[];
+	props: PropDescriptor[];
 }
 
 const PropsRenderer: React.FunctionComponent<PropsProps> = ({ props }) => {

--- a/src/client/rsg-components/Props/renderDefault.tsx
+++ b/src/client/rsg-components/Props/renderDefault.tsx
@@ -10,8 +10,12 @@ export default function renderDefault(prop: PropDescriptor): React.ReactNode {
 	// If prop has defaultValue it can not be required
 	if (prop.defaultValue) {
 		const defaultValueString = showSpaces(unquote(String(prop.defaultValue.value)));
-		if (prop.type || prop.flowType) {
-			const propName = prop.type ? prop.type.name : prop.flowType && prop.flowType.type;
+		if (prop.type || prop.flowType || prop.tsType) {
+			const propName = prop.type
+				? prop.type.name
+				: prop.flowType
+				? prop.flowType.type
+				: prop.tsType && prop.tsType.type;
 
 			if (defaultValueBlacklist.indexOf(prop.defaultValue.value) > -1) {
 				return <Code>{defaultValueString}</Code>;

--- a/src/client/rsg-components/Props/renderDefault.tsx
+++ b/src/client/rsg-components/Props/renderDefault.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Text from 'rsg-components/Text';
 import Code from 'rsg-components/Code';
-import { showSpaces, unquote, PropDescriptorWithFlow } from './util';
+import { showSpaces, unquote, PropDescriptor } from './util';
 
 const defaultValueBlacklist = ['null', 'undefined'];
 
-export default function renderDefault(prop: PropDescriptorWithFlow): React.ReactNode {
+export default function renderDefault(prop: PropDescriptor): React.ReactNode {
 	// Workaround for issue https://github.com/reactjs/react-docgen/issues/221
 	// If prop has defaultValue it can not be required
 	if (prop.defaultValue) {

--- a/src/client/rsg-components/Props/renderExtra.tsx
+++ b/src/client/rsg-components/Props/renderExtra.tsx
@@ -5,11 +5,11 @@ import Code from 'rsg-components/Code';
 import Name from 'rsg-components/Name';
 import Markdown from 'rsg-components/Markdown';
 
-import { unquote, getType, showSpaces, PropDescriptorWithFlow } from './util';
+import { unquote, getType, showSpaces, PropDescriptor } from './util';
 import renderDefault from './renderDefault';
 import { renderType } from './renderType';
 
-function renderEnum(prop: PropDescriptorWithFlow): React.ReactNode {
+function renderEnum(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
 	if (!type) {
 		return undefined;
@@ -28,7 +28,7 @@ function renderEnum(prop: PropDescriptorWithFlow): React.ReactNode {
 	);
 }
 
-function renderUnion(prop: PropDescriptorWithFlow): React.ReactNode {
+function renderUnion(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
 	if (!type) {
 		return undefined;
@@ -47,7 +47,7 @@ function renderUnion(prop: PropDescriptorWithFlow): React.ReactNode {
 	);
 }
 
-function renderShape(props: Record<string, PropDescriptorWithFlow>) {
+function renderShape(props: Record<string, PropDescriptor>) {
 	return Object.keys(props).map(name => {
 		const prop = props[name];
 		const defaultValue = renderDefault(prop);
@@ -66,7 +66,7 @@ function renderShape(props: Record<string, PropDescriptorWithFlow>) {
 	});
 }
 
-export default function renderExtra(prop: PropDescriptorWithFlow): React.ReactNode {
+export default function renderExtra(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
 	if (!prop.type || !type) {
 		return null;

--- a/src/client/rsg-components/Props/renderType.tsx
+++ b/src/client/rsg-components/Props/renderType.tsx
@@ -3,7 +3,7 @@ import { PropTypeDescriptor } from 'react-docgen';
 import Type from 'rsg-components/Type';
 import Text from 'rsg-components/Text';
 
-import { getType, PropDescriptorWithFlow, FlowTypeDescriptor } from './util';
+import { getType, PropDescriptor, TypeDescriptor } from './util';
 
 interface ExtendedPropTypeDescriptor extends Omit<PropTypeDescriptor, 'name'> {
 	name: string;
@@ -36,7 +36,7 @@ function renderComplexType(name: string, title: string): React.ReactNode {
 	);
 }
 
-function renderFlowType(type: FlowTypeDescriptor): React.ReactNode {
+function renderFlowType(type: TypeDescriptor): React.ReactNode {
 	if (!type) {
 		return 'unknown';
 	}

--- a/src/client/rsg-components/Props/renderType.tsx
+++ b/src/client/rsg-components/Props/renderType.tsx
@@ -56,13 +56,30 @@ function renderFlowType(type: TypeDescriptor): React.ReactNode {
 	}
 }
 
-export default function renderTypeColumn(prop: PropDescriptorWithFlow): React.ReactNode {
+function renderTSType(type: TypeDescriptor): React.ReactNode {
+	if (!type) {
+		return 'unknown';
+	}
+
+	switch (type.name) {
+		case 'literal':
+			return type.value;
+
+		default:
+			return (type as any).raw || (type as any).name;
+	}
+}
+
+export default function renderTypeColumn(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
 	if (!type) {
 		return null;
 	}
 	if (prop.flowType) {
 		return <Type>{renderFlowType(type as any)}</Type>;
+	}
+	if (prop.tsType) {
+		return <Type>{renderTSType(type as any)}</Type>;
 	}
 	return <Type>{renderType(type)}</Type>;
 }

--- a/src/client/rsg-components/Props/renderType.tsx
+++ b/src/client/rsg-components/Props/renderType.tsx
@@ -36,7 +36,7 @@ function renderComplexType(name: string, title: string): React.ReactNode {
 	);
 }
 
-function renderFlowType(type: TypeDescriptor): React.ReactNode {
+function renderAdvancedType(type: TypeDescriptor): React.ReactNode {
 	if (!type) {
 		return 'unknown';
 	}
@@ -56,30 +56,13 @@ function renderFlowType(type: TypeDescriptor): React.ReactNode {
 	}
 }
 
-function renderTSType(type: TypeDescriptor): React.ReactNode {
-	if (!type) {
-		return 'unknown';
-	}
-
-	switch (type.name) {
-		case 'literal':
-			return type.value;
-
-		default:
-			return (type as any).raw || (type as any).name;
-	}
-}
-
 export default function renderTypeColumn(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
 	if (!type) {
 		return null;
 	}
-	if (prop.flowType) {
-		return <Type>{renderFlowType(type as any)}</Type>;
-	}
-	if (prop.tsType) {
-		return <Type>{renderTSType(type as any)}</Type>;
+	if (prop.flowType || prop.tsType) {
+		return <Type>{renderAdvancedType(type as any)}</Type>;
 	}
 	return <Type>{renderType(type)}</Type>;
 }

--- a/src/client/rsg-components/Props/util.ts
+++ b/src/client/rsg-components/Props/util.ts
@@ -1,4 +1,4 @@
-import { PropDescriptor, PropTypeDescriptor } from 'react-docgen';
+import { PropDescriptor as BasePropDescriptor, PropTypeDescriptor } from 'react-docgen';
 
 /**
  * Remove quotes around given string.
@@ -7,8 +7,9 @@ export function unquote(string?: string): string | undefined {
 	return string && string.replace(/^['"]|['"]$/g, '');
 }
 
-export interface PropDescriptorWithFlow extends PropDescriptor {
-	flowType?: FlowTypeDescriptor;
+export interface PropDescriptor extends BasePropDescriptor {
+	flowType?: TypeDescriptor;
+	tsType?: TypeDescriptor;
 }
 
 /**
@@ -17,9 +18,7 @@ export interface PropDescriptorWithFlow extends PropDescriptor {
  * @param {object} prop
  * @returns {object}
  */
-export function getType(
-	prop: PropDescriptorWithFlow
-): PropTypeDescriptor | FlowTypeDescriptor | undefined {
+export function getType(prop: PropDescriptor): PropTypeDescriptor | TypeDescriptor | undefined {
 	if (prop.flowType) {
 		if (
 			prop.flowType.name === 'union' &&
@@ -43,35 +42,35 @@ export function showSpaces(string?: string): string | undefined {
 	return string && string.replace(/^\s|\s$/g, '␣');
 }
 
-export interface FlowTypeEnumDescriptor {
+export interface TypeEnumDescriptor {
 	name: 'enum';
 	type: string;
-	value: FlowTypeDescriptor[];
+	value: TypeDescriptor[];
 }
 
-interface FlowTypeLiteralDescriptor {
+interface TypeLiteralDescriptor {
 	name: 'literal';
 	type: string;
 	value: string;
 }
 
-interface FlowTypeSignatureDescriptor {
+interface TypeSignatureDescriptor {
 	name: 'signature';
 	type: string;
 	raw: string;
 	value: string;
 }
 
-interface FlowTypeUnionDescriptor {
+interface TypeUnionDescriptor {
 	name: 'union' | 'tuple';
-	elements: FlowTypeDescriptor[];
+	elements: TypeDescriptor[];
 	type: string;
 	raw: string;
 	value?: string;
 }
 
-export type FlowTypeDescriptor =
-	| FlowTypeEnumDescriptor
-	| FlowTypeLiteralDescriptor
-	| FlowTypeSignatureDescriptor
-	| FlowTypeUnionDescriptor;
+export type TypeDescriptor =
+	| TypeEnumDescriptor
+	| TypeLiteralDescriptor
+	| TypeSignatureDescriptor
+	| TypeUnionDescriptor;

--- a/src/client/rsg-components/Props/util.ts
+++ b/src/client/rsg-components/Props/util.ts
@@ -32,6 +32,9 @@ export function getType(prop: PropDescriptor): PropTypeDescriptor | TypeDescript
 		}
 		return prop.flowType;
 	}
+	if (prop.tsType) {
+		return prop.tsType;
+	}
 	return prop.type;
 }
 

--- a/src/client/rsg-components/Usage/Usage.tsx
+++ b/src/client/rsg-components/Usage/Usage.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MethodDescriptor } from 'react-docgen';
-import { PropDescriptorWithFlow } from 'rsg-components/Props/util';
+import { PropDescriptor } from 'rsg-components/Props/util';
 import Props from 'rsg-components/Props';
 import Methods from 'rsg-components/Methods';
 import isEmpty from 'lodash/isEmpty';
 
 const Usage: React.FunctionComponent<{
-	props: { methods?: MethodDescriptor[]; props?: PropDescriptorWithFlow[] };
+	props: { methods?: MethodDescriptor[]; props?: PropDescriptor[] };
 }> = ({ props: { props, methods } }) => {
 	const propsNode = props && !isEmpty(props) && <Props props={props} />;
 	const methodsNode = methods && !isEmpty(methods) && <Methods methods={methods} />;


### PR DESCRIPTION
Resolve

- Property types don't show up #1551

I organize react-docgen prop type(Named `PropDescriptor`) to have `flowType` and `tsType` both and I remove "WithFlow" word from the types.

review me please.