### PR TITLE
Fix Sections with href are always opening in new tabs

### DIFF
--- a/src/client/rsg-components/TableOfContents/TableOfContents.spec.tsx
+++ b/src/client/rsg-components/TableOfContents/TableOfContents.spec.tsx
@@ -219,6 +219,49 @@ it('should render components of a single top section as root', () => {
 	`);
 });
 
+it('should render as the link will open in a new window only if external presents as true', () => {
+	const actual = shallow(
+		<TableOfContents
+			sections={[
+				{
+					sections: [
+						{ content: 'intro.md', href: 'http://example.com' },
+						{ content: 'chapter.md', href: 'http://example.com', external: true },
+					],
+				},
+			]}
+		/>
+	);
+
+	expect(actual.find('ComponentsList').prop('items')).toMatchInlineSnapshot(`
+		Array [
+		  Object {
+		    "components": Array [],
+		    "content": undefined,
+		    "forcedOpen": false,
+		    "heading": false,
+		    "href": "http://example.com",
+		    "initialOpen": true,
+		    "sections": Array [],
+		    "selected": false,
+		    "shouldOpenInNewTab": false,
+		  },
+		  Object {
+		    "components": Array [],
+		    "content": undefined,
+		    "external": true,
+		    "forcedOpen": false,
+		    "heading": false,
+		    "href": "http://example.com",
+		    "initialOpen": true,
+		    "sections": Array [],
+		    "selected": false,
+		    "shouldOpenInNewTab": true,
+		  },
+		]
+	`);
+});
+
 /**
  * testing this layer with no mocking makes no sense...
  */

--- a/src/client/rsg-components/TableOfContents/TableOfContents.tsx
+++ b/src/client/rsg-components/TableOfContents/TableOfContents.tsx
@@ -76,7 +76,7 @@ export default class TableOfContents extends Component<TableOfContentsProps> {
 				heading: !!section.name && children.length > 0,
 				content,
 				selected,
-				shouldOpenInNewTab: !!section.href,
+				shouldOpenInNewTab: !!section.external && !!section.href,
 				initialOpen: this.props.tocMode !== 'collapse' || containsSelected,
 				forcedOpen: !!this.state.searchTerm.length,
 			};


### PR DESCRIPTION
Resolved.

- Sections with href are always opening in new tabs #1559

The section does not open in the new tab unless `href` and `external` has set both.

please review me.