### PR TITLE
Fix usage of CleanWebpackPlugin

### DIFF
--- a/src/scripts/make-webpack-config.ts
+++ b/src/scripts/make-webpack-config.ts
@@ -98,7 +98,7 @@ export default function(
 			},
 			plugins: [
 				new CleanWebpackPlugin({
-					root: config.styleguideDir,
+					cleanOnceBeforeBuildPatterns: [`${config.styleguideDir}/build/**/*`],
 					verbose: config.verbose === true,
 				} as any),
 			],


### PR DESCRIPTION
Was still using an option that no longer exists. Fixed to mimic the original behavior. The option `root` was [removed in v2](https://github.com/johnagan/clean-webpack-plugin/issues/106) but [this commit](https://github.com/styleguidist/react-styleguidist/commit/98042591dc75cad8cdf88cc2a2f0817d69e5e66d) forgot to address it.

It's deleting everything in the `styleguidistDir` folder which isn't the way it was before.
With this PR, it only deletes files in `build/`.