### PR TITLE
Fix missing FlowType enum values in prop description

### DIFF
--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -605,13 +605,22 @@ describe('props columns', () => {
 
 		test('should render enum type', () => {
 			const { container } = renderFn(['foo: MyEnum'], [], [options.enum.declaration]);
-
-			expect(getText(container)).toMatchInlineSnapshot(`
-			"Prop name: foo 
-			Type: ${options.enum.expect.type} 
-			Default: Required 
-			Description:"
-		`);
+			if (options.enum.expect.type === 'enum') {
+				expect(getText(container)).toMatchInlineSnapshot(`
+					"Prop name: foo 
+					Type: ${options.enum.expect.type} 
+					Default: Required 
+					Description: 
+					 One of: One , Two"
+				`);
+			} else {
+				expect(getText(container)).toMatchInlineSnapshot(`
+					"Prop name: foo 
+					Type: ${options.enum.expect.type} 
+					Default: Required 
+					Description:"
+				`);
+			}
 		});
 
 		test('should render tuple type with body in tooltip', () => {

--- a/src/client/rsg-components/Props/renderExtra.tsx
+++ b/src/client/rsg-components/Props/renderExtra.tsx
@@ -4,16 +4,13 @@ import Type from 'rsg-components/Type';
 import Code from 'rsg-components/Code';
 import Name from 'rsg-components/Name';
 import Markdown from 'rsg-components/Markdown';
+import { PropTypeDescriptor } from 'react-docgen';
 
-import { unquote, getType, showSpaces, PropDescriptor } from './util';
+import { unquote, getType, showSpaces, PropDescriptor, TypeDescriptor } from './util';
 import renderDefault from './renderDefault';
 import { renderType } from './renderType';
 
-function renderEnum(prop: PropDescriptor): React.ReactNode {
-	const type = getType(prop);
-	if (!type) {
-		return undefined;
-	}
+function renderEnum(type: PropTypeDescriptor | TypeDescriptor): React.ReactNode {
 	if (!Array.isArray(type.value)) {
 		return <span>{type.value}</span>;
 	}
@@ -28,11 +25,7 @@ function renderEnum(prop: PropDescriptor): React.ReactNode {
 	);
 }
 
-function renderUnion(prop: PropDescriptor): React.ReactNode {
-	const type = getType(prop);
-	if (!type) {
-		return undefined;
-	}
+function renderUnion(type: PropTypeDescriptor | TypeDescriptor): React.ReactNode {
 	if (!Array.isArray(type.value)) {
 		return <span>{type.value}</span>;
 	}
@@ -68,24 +61,24 @@ function renderShape(props: Record<string, PropDescriptor>) {
 
 export default function renderExtra(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
-	if (!prop.type || !type) {
+	if (!type) {
 		return null;
 	}
 	switch (type.name) {
 		case 'enum':
-			return renderEnum(prop);
+			return renderEnum(type);
 		case 'union':
-			return renderUnion(prop);
+			return renderUnion(type);
 		case 'shape':
-			return renderShape(prop.type.value);
+			return prop.type && renderShape(prop.type.value);
 		case 'arrayOf':
 			if (type.value.name === 'shape') {
-				return renderShape(prop.type.value.value);
+				return prop.type && renderShape(prop.type.value.value);
 			}
 			return null;
 		case 'objectOf':
 			if (type.value.name === 'shape') {
-				return renderShape(prop.type.value.value);
+				return prop.type && renderShape(prop.type.value.value);
 			}
 			return null;
 		default:


### PR DESCRIPTION
In `ef4c109b`, the file `PropsRenderer.js` (located at
`src/client/rsg-components/Props/PropsRenderer.js`) was removed. In
`PropsRenderer.js`, the `renderExtra` method checked whether `getType`
for the argument to `renderExtra` was present:

```es6
function renderExtra(prop) {
  const type = getType(prop);
  if (!type) {
    return null;
  }
  ...
}
```

However, in `ef4c109b`, this method was replaced with `renderExtra.tsx`
and the condition was changed to:

```typescript
export default function renderExtra(prop: PropDescriptorWithFlow): React.ReactNode {
  const type = getType(prop);
  if (!prop.type || !type) {
    return null;
  }
```

Unfortunately, this extra condition has resulted in this method always
returning `null` for a Flow typed prop as `prop.type` is always `null`
as `prop.type` is never set.

This commit reverts the condition to what it was before the migration to
TypeScript.