### PR TITLE
Add function signature to description

### DIFF
--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -427,6 +427,17 @@ describe('props columns', () => {
 	`);
 	});
 
+	test('should render function signature in description', () => {
+		const { container } = renderFlow(['onSomething: (e) => console.log(e)']);
+
+		expect(getText(container)).toMatchInlineSnapshot(`
+    "Prop name: onSomething
+    Type: func
+    Description:
+     Function signature: onSomething(): void"
+    `);
+	});
+
 	test('should render arguments from JsDoc tags', () => {
 		const props: any = [
 			{

--- a/src/client/rsg-components/Props/renderExtra.tsx
+++ b/src/client/rsg-components/Props/renderExtra.tsx
@@ -59,6 +59,14 @@ function renderShape(props: Record<string, PropDescriptor>) {
 	});
 }
 
+function renderFunction(type: TypeDescriptor): React.ReactNode {
+	return (
+		<span>
+			Function signature: <Code>{type.raw}</Code>
+		</span>
+	);
+}
+
 export default function renderExtra(prop: PropDescriptor): React.ReactNode {
 	const type = getType(prop);
 	if (!type) {
@@ -79,6 +87,11 @@ export default function renderExtra(prop: PropDescriptor): React.ReactNode {
 		case 'objectOf':
 			if (type.value.name === 'shape') {
 				return prop.type && renderShape(prop.type.value.value);
+			}
+			return null;
+		case 'signature':
+			if (type.type === 'function') {
+				return renderFunction(type);
 			}
 			return null;
 		default:


### PR DESCRIPTION
I didn't see any pre-existing format to use for PR's, so please let me know if there is one so I can update this text.

I also need help figuring out how the heck to get the test to work. The test file is quite large, and I had a hard time figuring out where my test should go or what helpers were available for it. Sadly, I ran out of timeboxed time for myself to figure this out on my own.

## Goal state

While using Styleguidist at work, I found that it would be helpful to have the function signature (ie: `funcName(): void` or so) display in the description for the Props & Methods table.

![Screen Shot 2020-04-10 at 12 54 30 PM](https://user-images.githubusercontent.com/992688/79023638-a4683f80-7b35-11ea-8b5c-51e9cb9496ec.png)

#### How do I do this without this PR?

Add this to your config file:

```
  propsParser(filePath, source, resolver, handlers) {
    const docGen = require('react-docgen').parse(source, resolver, handlers);
    Object.keys(docGen[0].props).map((propName) => {
      const props = docGen[0].props[propName];
      if (!props || !props.flowType) { return; }
      if (props.flowType.name === "signature" && props.flowType.type === "function") {
        props.description += "<div>Function signature: `" + props.flowType.raw + "`</div>";
      }
    });
    return docGen;
  },
```

🤷 

## Current state

![Screen Shot 2020-04-10 at 12 41 56 PM](https://user-images.githubusercontent.com/992688/79023643-a92cf380-7b35-11ea-8ab3-1639a9d42cbc.png)
