### PR TITLE
Fix Sections with numbers in the name don't work

### DIFF
--- a/src/client/utils/__tests__/getInfoFromHash.spec.ts
+++ b/src/client/utils/__tests__/getInfoFromHash.spec.ts
@@ -35,4 +35,24 @@ describe('getInfoFromHash', () => {
 			targetIndex: undefined,
 		});
 	});
+
+	it('should return a proper parsed result even though the hash starts with a number', () => {
+		const result = getInfoFromHash('#/1.Documentation');
+		expect(result).toEqual({
+			isolate: false,
+			hashArray: ['1.Documentation'],
+			targetName: '1.Documentation',
+			targetIndex: undefined,
+		});
+	});
+
+	it('should return a proper parsed result even though the hash contains a space', () => {
+		const result = getInfoFromHash('#/1. Just do it');
+		expect(result).toEqual({
+			isolate: false,
+			hashArray: ['1. Just do it'],
+			targetName: '1. Just do it',
+			targetIndex: undefined,
+		});
+	});
 });

--- a/src/client/utils/__tests__/getInfoFromHash.spec.ts
+++ b/src/client/utils/__tests__/getInfoFromHash.spec.ts
@@ -36,22 +36,22 @@ describe('getInfoFromHash', () => {
 		});
 	});
 
+	it('should extract target index when the URL ends with a number', () => {
+		const result = getInfoFromHash('#/Documentation/Files/Buttons/5');
+		expect(result).toEqual({
+			isolate: false,
+			hashArray: ['Documentation', 'Files', 'Buttons'],
+			targetName: 'Documentation',
+			targetIndex: 5,
+		});
+	});
+
 	it('should return a proper parsed result even though the hash starts with a number', () => {
 		const result = getInfoFromHash('#/1.Documentation');
 		expect(result).toEqual({
 			isolate: false,
 			hashArray: ['1.Documentation'],
 			targetName: '1.Documentation',
-			targetIndex: undefined,
-		});
-	});
-
-	it('should return a proper parsed result even though the hash contains a space', () => {
-		const result = getInfoFromHash('#/1. Just do it');
-		expect(result).toEqual({
-			isolate: false,
-			hashArray: ['1. Just do it'],
-			targetName: '1. Just do it',
 			targetIndex: undefined,
 		});
 	});

--- a/src/client/utils/getInfoFromHash.ts
+++ b/src/client/utils/getInfoFromHash.ts
@@ -1,6 +1,6 @@
 import { hasInHash, getHashAsArray } from './handleHash';
 
-function consistsOnlyNumbers(item: string): boolean {
+function hasDigitsOnly(item: string): boolean {
 	return item.match(/^\d+$/) !== null;
 }
 
@@ -27,9 +27,9 @@ export default function getInfoFromHash(
 		const targetHash = hashArray[hashArray.length - 1];
 		return {
 			isolate: shouldIsolate,
-			hashArray: hashArray.filter(item => !consistsOnlyNumbers(item)),
+			hashArray: hashArray.filter(item => !hasDigitsOnly(item)),
 			targetName: hashArray[0],
-			targetIndex: consistsOnlyNumbers(targetHash) ? parseInt(targetHash, 10) : undefined,
+			targetIndex: hasDigitsOnly(targetHash) ? parseInt(targetHash, 10) : undefined,
 		};
 	}
 	return {};

--- a/src/client/utils/getInfoFromHash.ts
+++ b/src/client/utils/getInfoFromHash.ts
@@ -1,8 +1,7 @@
-import isNaN from 'lodash/isNaN';
 import { hasInHash, getHashAsArray } from './handleHash';
 
-function filterNumbers(item: string): boolean {
-	return isNaN(parseInt(item, 10)) && item !== '';
+function consistsOnlyNumbers(item: string): boolean {
+	return item.match(/^\d+$/) !== null;
 }
 
 /**
@@ -25,12 +24,12 @@ export default function getInfoFromHash(
 	const shouldIsolate = hasInHash(hash, '#!/');
 	if (shouldIsolate || hasInHash(hash, '#/')) {
 		const hashArray = getHashAsArray(hash, shouldIsolate ? '#!/' : '#/');
-		const index = parseInt(hashArray[hashArray.length - 1], 10);
+		const targetHash = hashArray[hashArray.length - 1];
 		return {
 			isolate: shouldIsolate,
-			hashArray: hashArray.filter(filterNumbers),
+			hashArray: hashArray.filter(item => !consistsOnlyNumbers(item)),
 			targetName: hashArray[0],
-			targetIndex: isNaN(index) ? undefined : index,
+			targetIndex: consistsOnlyNumbers(targetHash) ? parseInt(targetHash, 10) : undefined,
 		};
 	}
 	return {};


### PR DESCRIPTION
Resolve:

- Sections with numbers in the name don't work #1594

The main reason is that `parseInt` parses the first number string as a number.
Therefore, when `1.Doc` given, it was computed as `1`.

