### PR TITLE
Support Promise API for webpack config

### DIFF
--- a/src/loaders/__tests__/styleguide-loader.spec.ts
+++ b/src/loaders/__tests__/styleguide-loader.spec.ts
@@ -23,11 +23,13 @@ it('should return valid, parsable JS', () => {
 	expect(() => new vm.Script(result)).not.toThrow();
 });
 
-it('should return correct component paths: default glob pattern', () => {
+it('should return correct component paths: default glob pattern', async () => {
 	const result = styleguideLoader.pitch.call({
 		request: file,
 		_styleguidist: {
-			...getConfig(path.resolve(__dirname, '../../../test/apps/defaults/styleguide.config.js')),
+			...(await getConfig(
+				path.resolve(__dirname, '../../../test/apps/defaults/styleguide.config.js')
+			)),
 		},
 		addContextDependency: () => {},
 	} as any);

--- a/src/scripts/__tests__/config.spec.ts
+++ b/src/scripts/__tests__/config.spec.ts
@@ -11,38 +11,39 @@ afterAll(() => {
 	process.chdir(cwd);
 });
 
-it('should read a config file', () => {
-	const result = getConfig('../basic/styleguide.config.js');
+it('should read a config file', async () => {
+	const result = await getConfig('../basic/styleguide.config.js');
 	expect(result).toMatchObject({ title: 'React Style Guide Example' });
 });
 
-it('should accept absolute path', () => {
-	const result = getConfig(path.join(__dirname, '../../../test/apps/basic/styleguide.config.js'));
+it('should accept absolute path', async () => {
+	const result = await getConfig(
+		path.join(__dirname, '../../../test/apps/basic/styleguide.config.js')
+	);
 	expect(result).toMatchObject({ title: 'React Style Guide Example' });
 });
 
 it('should throw when passed config file not found', () => {
-	const fn = () => getConfig('pizza');
-	expect(fn).toThrow();
+	expect(getConfig('pizza')).rejects.toThrow();
 });
 
-it('should find config file automatically', () => {
+it('should find config file automatically', async () => {
 	process.chdir('../basic');
-	const result = getConfig();
+	const result = await getConfig();
 	expect(result).toMatchObject({ title: 'React Style Guide Example' });
 });
 
-it('should accept config as an object', () => {
-	const result = getConfig({
+it('should accept config as an object', async () => {
+	const result = await getConfig({
 		title: 'Style guide',
 	});
 	expect(result).toMatchObject({ title: 'Style guide' });
 });
 
-it('should throw if config has errors', () => {
+it('should throw if config has errors', async () => {
 	expect.assertions(1);
 	try {
-		getConfig({
+		await getConfig({
 			components: 42,
 		} as any);
 	} catch (err) {
@@ -50,8 +51,8 @@ it('should throw if config has errors', () => {
 	}
 });
 
-it('should change the config using the update callback', () => {
-	const result = getConfig(
+it('should change the config using the update callback', async () => {
+	const result = await getConfig(
 		{
 			title: 'Style guide',
 		},
@@ -63,83 +64,83 @@ it('should change the config using the update callback', () => {
 	expect(result).toMatchObject({ title: 'Pizza' });
 });
 
-it('should have default getExampleFilename implementation', () => {
-	const result = getConfig();
+it('should have default getExampleFilename implementation', async () => {
+	const result = await getConfig();
 	expect(typeof result.getExampleFilename).toEqual('function');
 });
 
-it('default getExampleFilename should return Readme.md path if it exists', () => {
+it('default getExampleFilename should return Readme.md path if it exists', async () => {
 	process.chdir('../..');
-	const result = getConfig();
+	const result = await getConfig();
 	expect(result.getExampleFilename(path.resolve('components/Button/Button.js'))).toEqual(
 		path.resolve('components/Button/Readme.md')
 	);
 });
 
-it('default getExampleFilename should return Component.md path if it exists', () => {
+it('default getExampleFilename should return Component.md path if it exists', async () => {
 	process.chdir('../..');
-	const result = getConfig();
+	const result = await getConfig();
 	expect(result.getExampleFilename(path.resolve('components/Placeholder/Placeholder.js'))).toEqual(
 		path.resolve('components/Placeholder/Placeholder.md')
 	);
 });
 
-it('default getExampleFilename should return Component.md path if it exists with index.js', () => {
+it('default getExampleFilename should return Component.md path if it exists with index.js', async () => {
 	process.chdir('../..');
-	const result = getConfig();
+	const result = await getConfig();
 	result.components = './components/**/*.js';
 	expect(result.getExampleFilename(path.resolve('components/Label/index.js'))).toEqual(
 		path.resolve('components/Label/Label.md')
 	);
 });
 
-it('default getExampleFilename should return false if no examples file found', () => {
+it('default getExampleFilename should return false if no examples file found', async () => {
 	process.chdir('../..');
-	const result = getConfig();
+	const result = await getConfig();
 	expect(
 		result.getExampleFilename(path.resolve('components/RandomButton/RandomButton.js'))
 	).toBeFalsy();
 });
 
-it('should have default getComponentPathLine implementation', () => {
-	const result = getConfig();
+it('should have default getComponentPathLine implementation', async () => {
+	const result = await getConfig();
 	expect(typeof result.getComponentPathLine).toEqual('function');
 	expect(result.getComponentPathLine('components/Button.js')).toEqual('components/Button.js');
 });
 
-it('should have default title based on package.json name', () => {
-	const result = getConfig();
+it('should have default title based on package.json name', async () => {
+	const result = await getConfig();
 	expect(result.title).toEqual('Pizza Style Guide');
 });
 
-it('configDir option should be a directory of a passed config', () => {
-	const result = getConfig(path.join(configDir, 'styleguide.config.js'));
+it('configDir option should be a directory of a passed config', async () => {
+	const result = await getConfig(path.join(configDir, 'styleguide.config.js'));
 	expect(result).toMatchObject({ configDir });
 });
 
-it('configDir option should be a current directory if the config was passed as an object', () => {
-	const result = getConfig();
+it('configDir option should be a current directory if the config was passed as an object', async () => {
+	const result = await getConfig();
 	expect(result).toMatchObject({ configDir: process.cwd() });
 });
 
-it('should absolutize assetsDir if it exists', () => {
+it('should absolutize assetsDir if it exists', async () => {
 	const assetsDir = 'src/components';
-	const result = getConfig({
+	const result = await getConfig({
 		assetsDir,
 	});
 	expect(result.assetsDir).toEqual(path.join(configDir, assetsDir));
 });
 
 it('should throw if assetsDir does not exist', () => {
-	const fn = () =>
+	expect(
 		getConfig({
 			assetsDir: 'pizza',
-		});
-	expect(fn).toThrow();
+		})
+	).rejects.toThrow();
 });
 
-it('should use embedded default example template if defaultExample=true', done => {
-	const result = getConfig({
+it('should use embedded default example template if defaultExample=true', async done => {
+	const result = await getConfig({
 		defaultExample: true,
 	});
 	expect(typeof result.defaultExample).toEqual('string');
@@ -151,17 +152,17 @@ it('should use embedded default example template if defaultExample=true', done =
 	done();
 });
 
-it('should absolutize defaultExample if it is a string', () => {
-	const result = getConfig({
+it('should absolutize defaultExample if it is a string', async () => {
+	const result = await getConfig({
 		defaultExample: 'src/components/Button.md',
 	});
 	expect(result.defaultExample).toMatch(/^\//);
 });
 
-it('should throw if defaultExample does not exist', () => {
+it('should throw if defaultExample does not exist', async () => {
 	expect.assertions(1);
 	try {
-		getConfig({
+		await getConfig({
 			defaultExample: 'pizza',
 		});
 	} catch (err) {
@@ -169,24 +170,24 @@ it('should throw if defaultExample does not exist', () => {
 	}
 });
 
-it('should use components option as the first sections if there’s no sections option', () => {
+it('should use components option as the first sections if there’s no sections option', async () => {
 	const components = 'components/*/*.js';
-	const result = getConfig({
+	const result = await getConfig({
 		components,
 	});
 	expect(result.sections).toHaveLength(1);
 	expect(result.sections[0].components).toEqual(components);
 });
 
-it('should use default components option both components and sections options weren’t specified', () => {
-	const result = getConfig();
+it('should use default components option both components and sections options weren’t specified', async () => {
+	const result = await getConfig();
 	expect(result.sections).toHaveLength(1);
 	expect(result.sections[0].components).toMatch('**');
 });
 
-it('should ignore components option there’s sections options', () => {
+it('should ignore components option there’s sections options', async () => {
 	const components = 'components/*/*.js';
-	const result = getConfig({
+	const result = await getConfig({
 		components: 'components/Button/*.js',
 		sections: [
 			{
@@ -198,17 +199,17 @@ it('should ignore components option there’s sections options', () => {
 	expect(result.sections[0].components).toEqual(components);
 });
 
-it('should return webpackConfig option as is', () => {
+it('should return webpackConfig option as is', async () => {
 	const webpackConfig = { foo: 42 };
-	const result = getConfig({
+	const result = await getConfig({
 		webpackConfig,
 	});
 	expect(result.webpackConfig).toEqual(webpackConfig);
 });
 
-it('should return webpackConfig with user webpack config', () => {
+it('should return webpackConfig with user webpack config', async () => {
 	process.chdir('../basic');
-	const result = getConfig();
+	const result = await getConfig();
 	expect(result.webpackConfig).toEqual(
 		expect.objectContaining({
 			module: {
@@ -220,14 +221,14 @@ it('should return webpackConfig with user webpack config', () => {
 
 it('should allow no webpack config', () => {
 	process.chdir('../no-webpack');
-	const fn = () => getConfig();
+	const fn = async () => await getConfig();
 	expect(fn).not.toThrow();
 });
 
-it('should throw when old template as a string option passed', () => {
+it('should throw when old template as a string option passed', async () => {
 	expect.assertions(1);
 	try {
-		getConfig({
+		await getConfig({
 			template: 'pizza',
 		});
 	} catch (err) {
@@ -235,10 +236,10 @@ it('should throw when old template as a string option passed', () => {
 	}
 });
 
-it('should throw when editorConfig option passed', () => {
+it('should throw when editorConfig option passed', async () => {
 	expect.assertions(1);
 	try {
-		getConfig({
+		await getConfig({
 			editorConfig: { theme: 'foo' },
 		});
 	} catch (err) {
@@ -246,39 +247,39 @@ it('should throw when editorConfig option passed', () => {
 	}
 });
 
-it('mountPointId should have default value', () => {
-	const result = getConfig();
+it('mountPointId should have default value', async () => {
+	const result = await getConfig();
 	expect(result.mountPointId).toEqual('rsg-root');
 });
 
-it('mountPointId should have default value', () => {
-	const result = getConfig();
+it('mountPointId should have default value', async () => {
+	const result = await getConfig();
 	expect(result.mountPointId).toEqual('rsg-root');
 });
 
-it('should set the exampleMode to expand if the flag showCode is on', () => {
-	const result = getConfig({
+it('should set the exampleMode to expand if the flag showCode is on', async () => {
+	const result = await getConfig({
 		showCode: true,
 	});
 	expect(result.exampleMode).toBe('expand');
 });
 
-it('should set the exampleMode to collapse if the flag showCode is off', () => {
-	const result = getConfig({
+it('should set the exampleMode to collapse if the flag showCode is off', async () => {
+	const result = await getConfig({
 		showCode: false,
 	});
 	expect(result.exampleMode).toBe('collapse');
 });
 
-it('should set the usageMode to expand if the flag showUsage is on', () => {
-	const result = getConfig({
+it('should set the usageMode to expand if the flag showUsage is on', async () => {
+	const result = await getConfig({
 		showUsage: true,
 	});
 	expect(result.usageMode).toBe('expand');
 });
 
-it('should set the usageMode to collapse if the flag showUsage is off', () => {
-	const result = getConfig({
+it('should set the usageMode to collapse if the flag showUsage is off', async () => {
+	const result = await getConfig({
 		showUsage: false,
 	});
 	expect(result.usageMode).toBe('collapse');

--- a/src/scripts/__tests__/create-server.spec.ts
+++ b/src/scripts/__tests__/create-server.spec.ts
@@ -7,17 +7,17 @@ afterEach(() => {
 	process.chdir(cwd);
 });
 
-test('createServer should return an object containing a server instance', () => {
+test('createServer should return an object containing a server instance', async () => {
 	process.chdir('test/apps/basic');
-	const config = getConfig();
+	const config = await getConfig();
 	const result = createServer(config, 'production');
 	expect(result).toBeTruthy();
 	expect(result.app).toBeTruthy();
 });
 
-test('createServer should return an object containing a production Webpack compiler', done => {
+test('createServer should return an object containing a production Webpack compiler', async done => {
 	process.chdir('test/apps/basic');
-	const config = getConfig();
+	const config = await getConfig();
 	const result = createServer(config, 'production');
 	expect(result).toBeTruthy();
 	expect(result.compiler).toBeTruthy();
@@ -33,9 +33,9 @@ test('createServer should return an object containing a production Webpack compi
 	done();
 });
 
-test('createServer should return an object containing a development Webpack compiler', done => {
+test('createServer should return an object containing a development Webpack compiler', async done => {
 	process.chdir('test/apps/basic');
-	const config = getConfig();
+	const config = await getConfig();
 	const result = createServer(config, 'development');
 	expect(result).toBeTruthy();
 	expect(result.compiler).toBeTruthy();

--- a/src/scripts/__tests__/index.esm.spec.ts
+++ b/src/scripts/__tests__/index.esm.spec.ts
@@ -6,15 +6,16 @@ import styleguidist from '../index.esm';
 jest.mock('../build');
 jest.mock('../server');
 
-const getDefaultWebpackConfig = (): any => styleguidist().makeWebpackConfig();
+const getDefaultWebpackConfig = async (): Promise<any> =>
+	(await styleguidist()).makeWebpackConfig();
 
 const cwd = process.cwd();
 afterEach(() => {
 	process.chdir(cwd);
 });
 
-it('should return API methods', () => {
-	const api = styleguidist(require('../../../test/data/styleguide.config.js'));
+it('should return API methods', async () => {
+	const api = await styleguidist(require('../../../test/data/styleguide.config.js'));
 	expect(api).toBeTruthy();
 	expect(typeof api.build).toBe('function');
 	expect(typeof api.server).toBe('function');
@@ -22,25 +23,25 @@ it('should return API methods', () => {
 });
 
 describe('makeWebpackConfig', () => {
-	it('should return development Webpack config', () => {
-		const api = styleguidist();
+	it('should return development Webpack config', async () => {
+		const api = await styleguidist();
 		const result = api.makeWebpackConfig('development');
 		expect(result).toBeTruthy();
 		expect(result.output && result.output.filename).toBe('build/[name].bundle.js');
 		expect(result.output && result.output.chunkFilename).toBe('build/[name].js');
 	});
 
-	it('should return production Webpack config', () => {
-		const api = styleguidist();
+	it('should return production Webpack config', async () => {
+		const api = await styleguidist();
 		const result = api.makeWebpackConfig('production');
 		expect(result).toBeTruthy();
 		expect(result.output && result.output.filename).toBe('build/bundle.[chunkhash:8].js');
 		expect(result.output && result.output.chunkFilename).toBe('build/[name].[chunkhash:8].js');
 	});
 
-	it('should merge webpackConfig config option', () => {
-		const defaultWebpackConfig = getDefaultWebpackConfig();
-		const api = styleguidist({
+	it('should merge webpackConfig config option', async () => {
+		const defaultWebpackConfig = await getDefaultWebpackConfig();
+		const api = await styleguidist({
 			webpackConfig: {
 				resolve: {
 					extensions: ['.scss'],
@@ -56,9 +57,9 @@ describe('makeWebpackConfig', () => {
 		expect(last(result.resolve.extensions)).toEqual('.scss');
 	});
 
-	it('should merge webpackConfig but ignore output section', () => {
-		const defaultWebpackConfig = getDefaultWebpackConfig();
-		const api = styleguidist({
+	it('should merge webpackConfig but ignore output section', async () => {
+		const defaultWebpackConfig = await getDefaultWebpackConfig();
+		const api = await styleguidist({
 			webpackConfig: {
 				resolve: {
 					extensions: ['.scss'],
@@ -75,8 +76,8 @@ describe('makeWebpackConfig', () => {
 		);
 	});
 
-	it('should merge webpackConfig config option as a function', () => {
-		const api = styleguidist({
+	it('should merge webpackConfig config option as a function', async () => {
+		const api = await styleguidist({
 			webpackConfig: (env: string) => ({
 				_env: env,
 			}),
@@ -87,9 +88,9 @@ describe('makeWebpackConfig', () => {
 		expect(result._env).toEqual('production');
 	});
 
-	it('should apply updateWebpackConfig config option', () => {
-		const defaultWebpackConfig = getDefaultWebpackConfig();
-		const api = styleguidist({
+	it('should apply updateWebpackConfig config option', async () => {
+		const defaultWebpackConfig = await getDefaultWebpackConfig();
+		const api = await styleguidist({
 			dangerouslyUpdateWebpackConfig: (webpackConfig: Configuration, env: string) => {
 				if (webpackConfig.resolve && webpackConfig.resolve.extensions) {
 					webpackConfig.resolve.extensions.push(env);
@@ -106,18 +107,18 @@ describe('makeWebpackConfig', () => {
 		expect(last(result.resolve.extensions)).toEqual('production');
 	});
 
-	it('should merge Create React App Webpack config', () => {
+	it('should merge Create React App Webpack config', async () => {
 		process.chdir('test/apps/basic');
-		const api = styleguidist();
+		const api = await styleguidist();
 		const result = api.makeWebpackConfig();
 
 		expect(result).toBeTruthy();
 		expect(result.module).toBeTruthy();
 	});
 
-	it('should add webpack entry for each require config option item', () => {
+	it('should add webpack entry for each require config option item', async () => {
 		const modules = ['babel-polyfill', 'path/to/styles.css'];
-		const api = styleguidist({
+		const api = await styleguidist({
 			require: modules,
 		});
 		const result = api.makeWebpackConfig();
@@ -125,8 +126,8 @@ describe('makeWebpackConfig', () => {
 		expect(result.entry).toEqual(expect.arrayContaining(modules));
 	});
 
-	it('should add webpack alias for each styleguideComponents config option item', () => {
-		const api = styleguidist({
+	it('should add webpack alias for each styleguideComponents config option item', async () => {
+		const api = await styleguidist({
 			styleguideComponents: {
 				Wrapper: 'styleguide/components/Wrapper',
 				StyleGuideRenderer: 'styleguide/components/StyleGuide',
@@ -142,12 +143,12 @@ describe('makeWebpackConfig', () => {
 });
 
 describe('build', () => {
-	it('should pass style guide config and stats to callback', () => {
+	it('should pass style guide config and stats to callback', async () => {
 		const config = {
 			components: '*.js',
 		};
 		const callback = jest.fn();
-		const api = styleguidist(config);
+		const api = await styleguidist(config);
 		api.build(callback);
 
 		expect(callback).toBeCalled();
@@ -157,12 +158,12 @@ describe('build', () => {
 });
 
 describe('server', () => {
-	it('should pass style guide config to callback', () => {
+	it('should pass style guide config to callback', async () => {
 		const config = {
 			components: '*.js',
 		};
 		const callback = jest.fn();
-		const api = styleguidist(config);
+		const api = await styleguidist(config);
 		api.server(callback);
 
 		expect(callback).toBeCalled();

--- a/src/scripts/__tests__/server.spec.ts
+++ b/src/scripts/__tests__/server.spec.ts
@@ -11,8 +11,8 @@ jest.mock('../create-server', () => () => {
 	};
 });
 
-test('server should return an object containing a server instance', () => {
-	const config = getConfig();
+test('server should return an object containing a server instance', async () => {
+	const config = await getConfig();
 	const callback = jest.fn();
 	const serverInfo = server(config, callback);
 

--- a/src/scripts/config.ts
+++ b/src/scripts/config.ts
@@ -33,10 +33,10 @@ function findConfigFile(): string | false {
  * @param {function} [update] Change config object before running validation on it.
  * @returns {object}
  */
-function getConfig(
-	config?: string | Rsg.StyleguidistConfig,
+async function getConfig(
+	config?: string | Rsg.StyleguidistConfig | Promise<Rsg.StyleguidistConfig>,
 	update?: (conf: Rsg.StyleguidistConfig) => Rsg.StyleguidistConfig
-): Rsg.SanitizedStyleguidistConfig {
+): Promise<Rsg.SanitizedStyleguidistConfig> {
 	let configFilepath: string | false = false;
 	if (isString(config)) {
 		// Load config from a given file
@@ -58,6 +58,8 @@ function getConfig(
 	if (!config || isString(config)) {
 		return {} as any;
 	}
+
+	config = await config;
 
 	if (update) {
 		config = update(config);

--- a/src/scripts/index.esm.ts
+++ b/src/scripts/index.esm.ts
@@ -15,8 +15,8 @@ import * as Rsg from '../typings';
  * @param {object} [config] Styleguidist config.
  * @returns {object} API.
  */
-export default function(configArg?: Rsg.StyleguidistConfig | string) {
-	const config = getConfig(configArg, conf => {
+export default async function(configArg?: Rsg.StyleguidistConfig | string) {
+	const config = await getConfig(configArg, conf => {
 		setupLogger(conf.logger as Record<string, (msg: string) => void>, conf.verbose, {});
 		return conf;
 	});


### PR DESCRIPTION
Webpack supports promise in configuration:
https://webpack.js.org/configuration/configuration-types/#exporting-a-promise
Added Promise support to styleguidist. 
PR has breaking changes.