### PR TITLE
Fix param of array

### DIFF
--- a/examples/sections/styleguide.config.js
+++ b/examples/sections/styleguide.config.js
@@ -93,8 +93,8 @@ module.exports = {
 			env === 'development'
 				? false
 				: {
-						maxAssetSize: 1100000, // bytes
-						maxEntrypointSize: 1100000, // bytes
+						maxAssetSize: 1150000, // bytes
+						maxEntrypointSize: 1150000, // bytes
 						hints: 'error',
 				  },
 	}),

--- a/src/client/rsg-components/Argument/Argument.spec.tsx
+++ b/src/client/rsg-components/Argument/Argument.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { ArgumentRenderer, styles } from './ArgumentRenderer';
 
 const name = 'Foo';
-const type = { name: 'Array' };
+const type = {type: 'NameExpression', name: 'Array'};
 const description = 'Converts foo to bar';
 const props = {
 	classes: classes(styles),
@@ -28,7 +28,7 @@ it('should render optional argument', () => {
 	const actual = shallow(
 		<ArgumentRenderer
 			{...props}
-			type={{ type: 'OptionalType', expression: { name: 'Array' } }}
+			type={{ type: 'OptionalType', expression: {type: 'NameExpression', name: 'Array'} }}
 			description={description}
 		/>
 	);
@@ -40,7 +40,7 @@ it('should render default value of argument', () => {
 	const actual = shallow(
 		<ArgumentRenderer
 			{...props}
-			type={{ name: 'String' }}
+			type={{type: 'NameExpression', name: 'String'}}
 			default="bar"
 			description={description}
 		/>
@@ -53,7 +53,7 @@ it('should render default value of optional argument', () => {
 	const actual = shallow(
 		<ArgumentRenderer
 			{...props}
-			type={{ type: 'OptionalType', expression: { name: 'Boolean' } }}
+			type={{ type: 'OptionalType', expression: {type: 'NameExpression', name: 'Boolean'} }}
 			default="true"
 			description={description}
 		/>

--- a/src/client/rsg-components/Argument/ArgumentRenderer.tsx
+++ b/src/client/rsg-components/Argument/ArgumentRenderer.tsx
@@ -39,7 +39,7 @@ export const ArgumentRenderer: React.FunctionComponent<ArgumentPropsWithClasses>
 	if (isOptional) {
 		type = type.expression;
 	}
-	const typeName = doctrine.type.stringify(type);
+	const typeName = type ? doctrine.type.stringify(type) : '';
 	const content = (
 		<Group>
 			{returns && 'Returns'}

--- a/src/client/rsg-components/Argument/ArgumentRenderer.tsx
+++ b/src/client/rsg-components/Argument/ArgumentRenderer.tsx
@@ -5,6 +5,7 @@ import Markdown from 'rsg-components/Markdown';
 import Name from 'rsg-components/Name';
 import Type from 'rsg-components/Type';
 import Group from 'react-group';
+import doctrine from 'doctrine';
 import * as Rsg from '../../../typings';
 
 export const styles = ({ space }: Rsg.Theme) => ({
@@ -38,6 +39,7 @@ export const ArgumentRenderer: React.FunctionComponent<ArgumentPropsWithClasses>
 	if (isOptional) {
 		type = type.expression;
 	}
+	const typeName = doctrine.type.stringify(type);
 	const content = (
 		<Group>
 			{returns && 'Returns'}
@@ -49,7 +51,7 @@ export const ArgumentRenderer: React.FunctionComponent<ArgumentPropsWithClasses>
 			)}
 			{type && (
 				<Type>
-					{type.name}
+					{typeName}
 					{isOptional && '?'}
 					{!!defaultValue && `=${defaultValue}`}
 				</Type>

--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -441,7 +441,7 @@ describe('props columns', () => {
 						{
 							name: 'Foo',
 							description: 'Converts foo to bar',
-							type: { name: 'Array' },
+							type: {type: 'NameExpression', name: 'Array' },
 						},
 					],
 					param: [
@@ -479,7 +479,7 @@ describe('props columns', () => {
 						{
 							title: 'Foo',
 							description: 'Returns foo from bar',
-							type: { name: 'Array' },
+							type: {type: 'NameExpression', name: 'Array' },
 						},
 					],
 				},

--- a/src/client/rsg-components/ReactComponent/ReactComponent.spec.tsx
+++ b/src/client/rsg-components/ReactComponent/ReactComponent.spec.tsx
@@ -47,7 +47,7 @@ const componentWithEverything: Rsg.Component = {
 					{
 						name: 'newValue',
 						description: 'New value for the counter.',
-						type: { name: 'Number' },
+						type: {type: 'NameExpression', name: 'Number' },
 					},
 				],
 				returns: null,


### PR DESCRIPTION
Doctrine has a function to stringify the parameter types. If the type is a `string[]`, doctrine will stringify this into `Array.<string>`. I believe this is backwards compatible.