### PR TITLE
Fix Wrong union description with TypeScript #1621

### DIFF
--- a/examples/sections/styleguide.config.js
+++ b/examples/sections/styleguide.config.js
@@ -93,8 +93,8 @@ module.exports = {
 			env === 'development'
 				? false
 				: {
-						maxAssetSize: 1150000, // bytes
-						maxEntrypointSize: 1150000, // bytes
+						maxAssetSize: 1200000, // bytes
+						maxEntrypointSize: 1200000, // bytes
 						hints: 'error',
 				  },
 	}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2334,6 +2334,11 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
+      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -2502,6 +2507,14 @@
           "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
           "dev": true
         }
+      }
+    },
+    "@tippyjs/react": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.1.0.tgz",
+      "integrity": "sha512-g6Dpm46edr9T9z+BYxd/eJZa6QMFc4T4z5xrztxVlkti7AhNYf7OaE6b3Nh+boUZZ9wn8xkNq9VrQM5K4huwnQ==",
+      "requires": {
+        "tippy.js": "^6.2.0"
       }
     },
     "@types/anymatch": {
@@ -3594,7 +3607,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -3707,7 +3720,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -3828,7 +3841,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -3845,7 +3858,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4428,7 +4441,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -4465,7 +4478,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -4624,7 +4637,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -4874,7 +4887,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -4891,7 +4904,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5005,7 +5018,7 @@
     },
     "colors": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
     },
     "combined-stream": {
@@ -5019,7 +5032,7 @@
     },
     "commander": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
       "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
     },
     "common-dir": {
@@ -5595,7 +5608,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -5608,7 +5621,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -5715,7 +5728,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -5981,7 +5994,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -5993,7 +6006,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
@@ -6080,7 +6093,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -6208,7 +6221,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -7004,7 +7017,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -9712,7 +9725,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-observable": {
@@ -11898,7 +11911,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-parse-better-errors": {
@@ -12487,7 +12500,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12525,7 +12538,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -13759,7 +13772,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
@@ -13925,7 +13938,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -14890,7 +14903,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -15442,7 +15455,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -15649,7 +15662,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -16568,7 +16581,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
@@ -17046,7 +17059,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -17094,6 +17107,14 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "tippy.js": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.2.6.tgz",
+      "integrity": "sha512-0tTL3WQNT0nWmpslhDryRahoBm6PT9fh1xXyDfOsvZpDzq52by2rF2nvsW0WX2j9nUZP/jSGDqfKJGjCtoGFKg==",
+      "requires": {
+        "@popperjs/core": "^2.4.4"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -17125,7 +17146,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk="
         },
         "esprima": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">=10"
   },
   "dependencies": {
+    "@tippyjs/react": "4.1.0",
     "@vxna/mini-html-webpack-template": "^1.0.0",
     "acorn": "^6.4.1",
     "acorn-jsx": "^5.1.0",

--- a/src/client/rsg-components/ComplexType/ComplexType.spec.tsx
+++ b/src/client/rsg-components/ComplexType/ComplexType.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ComplexType from './ComplexTypeRenderder';
+
+function renderComponent(name = 'color', raw = 'red | blue') {
+	return render(<ComplexType name={name} raw={raw} />);
+}
+
+describe('ComplexType', () => {
+	test('should render name', () => {
+		const { getByRole } = renderComponent();
+		expect(getByRole('button')).toHaveTextContent('color');
+	});
+
+	test('should render raw text in the tooltip', () => {
+		const { container, getByRole } = renderComponent();
+		fireEvent.focus(getByRole('button'));
+		expect(container.querySelector('[data-tippy-root]')).toHaveTextContent('red | blue');
+	});
+});

--- a/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
+++ b/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Styled, { JssInjectedProps } from 'rsg-components/Styled';
+import { MdInfoOutline } from 'react-icons/md';
+import Text from 'rsg-components/Text';
+import Tooltip from 'rsg-components/Tooltip';
+import * as Rsg from '../../../typings';
+
+export const styles = ({ space }: Rsg.Theme) => ({
+	complexType: {
+		alignItems: 'center',
+		cursor: 'pointer',
+		display: 'inline-flex',
+		'& span': {
+			marginRight: space[0],
+			cursor: 'pointer',
+		},
+	},
+});
+
+export interface ComplexTypeProps extends JssInjectedProps {
+	name: string;
+	raw: string;
+}
+
+function ComplexTypeRenderer({ classes, name, raw }: ComplexTypeProps) {
+	return (
+		<Tooltip placement="right" content={raw}>
+			<span className={classes.complexType}>
+				<Text>{name}</Text>
+				<MdInfoOutline />
+			</span>
+		</Tooltip>
+	);
+}
+
+export default Styled<ComplexTypeProps>(styles)(ComplexTypeRenderer);

--- a/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
+++ b/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
@@ -8,12 +8,10 @@ import * as Rsg from '../../../typings';
 export const styles = ({ space }: Rsg.Theme) => ({
 	complexType: {
 		alignItems: 'center',
-		cursor: 'pointer',
 		display: 'inline-flex',
-		'& span': {
-			marginRight: space[0],
-			cursor: 'pointer',
-		},
+	},
+	icon: {
+		marginLeft: space[0],
 	},
 });
 
@@ -27,7 +25,7 @@ function ComplexTypeRenderer({ classes, name, raw }: ComplexTypeProps) {
 		<Tooltip placement="right" content={raw}>
 			<span className={classes.complexType}>
 				<Text>{name}</Text>
-				<MdInfoOutline />
+				<MdInfoOutline className={classes.icon} />
 			</span>
 		</Tooltip>
 	);

--- a/src/client/rsg-components/ComplexType/index.ts
+++ b/src/client/rsg-components/ComplexType/index.ts
@@ -1,0 +1,1 @@
+export { default } from 'rsg-components/ComplexType/ComplexTypeRenderder';

--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { parse } from 'react-docgen';
 import PropsRenderer, { columns, getRowKey } from './PropsRenderer';
 import { unquote, getType, showSpaces, PropDescriptor } from './util';
@@ -513,7 +513,7 @@ describe('props columns', () => {
 						{
 							name: 'Foo',
 							description: 'Converts foo to bar',
-							type: {type: 'NameExpression', name: 'Array' },
+							type: { type: 'NameExpression', name: 'Array' },
 						},
 					],
 					param: [
@@ -551,7 +551,7 @@ describe('props columns', () => {
 						{
 							title: 'Foo',
 							description: 'Returns foo from bar',
-							type: {type: 'NameExpression', name: 'Array' },
+							type: { type: 'NameExpression', name: 'Array' },
 						},
 					],
 				},
@@ -658,21 +658,27 @@ describe('props columns', () => {
 		});
 
 		test('should render object type with body in tooltip', () => {
-			const { getByText } = renderFn(['foo: { bar: string }']);
+			const { container, getByRole } = renderFn(['foo: { bar: string }']);
+			fireEvent.focus(getByRole('button'));
 
-			expect(getByText('object').title).toMatchInlineSnapshot(`"{ bar: string }"`);
+			expect(getByRole('button')).toHaveTextContent('object');
+			expect(container.querySelector('[data-tippy-root]')).toHaveTextContent('{ bar: string }');
 		});
 
 		test('should render function type with body in tooltip', () => {
-			const { getByText } = renderFn(['foo: () => void']);
+			const { container, getByRole } = renderFn(['foo: () => void']);
+			fireEvent.focus(getByRole('button'));
 
-			expect(getByText('function').title).toMatchInlineSnapshot(`"() => void"`);
+			expect(getByRole('button')).toHaveTextContent('function');
+			expect(container.querySelector('[data-tippy-root]')).toHaveTextContent('() => void');
 		});
 
 		test('should render union type with body in tooltip', () => {
-			const { getByText } = renderFn(['foo: "bar" | number']);
+			const { container, getByRole } = renderFn(['foo: "bar" | number']);
+			fireEvent.focus(getByRole('button'));
 
-			expect(getByText('union').title).toMatchInlineSnapshot(`"\\"bar\\" | number"`);
+			expect(getByRole('button')).toHaveTextContent('union');
+			expect(container.querySelector('[data-tippy-root]')).toHaveTextContent('"bar" | number');
 		});
 
 		test('should render enum type', () => {
@@ -696,9 +702,12 @@ describe('props columns', () => {
 		});
 
 		test('should render tuple type with body in tooltip', () => {
-			const { getByText } = renderFn(['foo: ["bar", number]']);
+			const { container, getByRole } = renderFn(['foo: ["bar", number]']);
 
-			expect(getByText('tuple').title).toMatchInlineSnapshot(`"[\\"bar\\", number]"`);
+			fireEvent.focus(getByRole('button'));
+
+			expect(getByRole('button')).toHaveTextContent('tuple');
+			expect(container.querySelector('[data-tippy-root]')).toHaveTextContent('["bar", number]');
 		});
 
 		test('should render custom class type', () => {

--- a/src/client/rsg-components/Props/Props.spec.tsx
+++ b/src/client/rsg-components/Props/Props.spec.tsx
@@ -731,6 +731,17 @@ describe('props columns', () => {
 			Description:"
 		`);
 		});
+
+		test('should render literal type', () => {
+			const { container } = renderFn(['foo: 1']);
+
+			expect(getText(container)).toMatchInlineSnapshot(`
+			"Prop name: foo 
+			Type: 1 
+			Default: Required 
+			Description:"
+		`);
+		});
 	});
 });
 

--- a/src/client/rsg-components/Props/renderType.tsx
+++ b/src/client/rsg-components/Props/renderType.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PropTypeDescriptor } from 'react-docgen';
 import Type from 'rsg-components/Type';
-import Text from 'rsg-components/Text';
+import ComplexType from 'rsg-components/ComplexType';
 
 import { getType, PropDescriptor, TypeDescriptor } from './util';
 
@@ -28,31 +28,23 @@ export function renderType(type: ExtendedPropTypeDescriptor): string {
 	}
 }
 
-function renderComplexType(name: string, title: string): React.ReactNode {
-	return (
-		<Text size="small" underlined title={title}>
-			{name}
-		</Text>
-	);
-}
-
 function renderAdvancedType(type: TypeDescriptor): React.ReactNode {
 	if (!type) {
-		return 'unknown';
+		return <Type>unknown</Type>;
 	}
 
 	switch (type.name) {
 		case 'enum':
-			return type.name;
+			return <Type>{type.name}</Type>;
 		case 'literal':
-			return type.value;
+			return <Type>{type.value}</Type>;
 		case 'signature':
-			return renderComplexType(type.type, type.raw);
+			return <ComplexType name={type.type} raw={type.raw} />;
 		case 'union':
 		case 'tuple':
-			return renderComplexType(type.name, type.raw);
+			return <ComplexType name={type.name} raw={type.raw} />;
 		default:
-			return (type as any).raw || (type as any).name;
+			return <Type>{(type as any).raw || (type as any).name}</Type>;
 	}
 }
 
@@ -62,7 +54,7 @@ export default function renderTypeColumn(prop: PropDescriptor): React.ReactNode 
 		return null;
 	}
 	if (prop.flowType || prop.tsType) {
-		return <Type>{renderAdvancedType(type as any)}</Type>;
+		return renderAdvancedType(type as any);
 	}
 	return <Type>{renderType(type)}</Type>;
 }

--- a/src/client/rsg-components/Props/renderType.tsx
+++ b/src/client/rsg-components/Props/renderType.tsx
@@ -29,10 +29,6 @@ export function renderType(type: ExtendedPropTypeDescriptor): string {
 }
 
 function renderAdvancedType(type: TypeDescriptor): React.ReactNode {
-	if (!type) {
-		return <Type>unknown</Type>;
-	}
-
 	switch (type.name) {
 		case 'enum':
 			return <Type>{type.name}</Type>;

--- a/src/client/rsg-components/Props/renderType.tsx
+++ b/src/client/rsg-components/Props/renderType.tsx
@@ -28,7 +28,7 @@ export function renderType(type: ExtendedPropTypeDescriptor): string {
 	}
 }
 
-function renderAdvancedType(type: TypeDescriptor): React.ReactNode {
+function renderAdvancedType(type: PropTypeDescriptor | TypeDescriptor): React.ReactNode {
 	switch (type.name) {
 		case 'enum':
 			return <Type>{type.name}</Type>;
@@ -50,7 +50,7 @@ export default function renderTypeColumn(prop: PropDescriptor): React.ReactNode 
 		return null;
 	}
 	if (prop.flowType || prop.tsType) {
-		return renderAdvancedType(type as any);
+		return renderAdvancedType(type);
 	}
 	return <Type>{renderType(type)}</Type>;
 }

--- a/src/client/rsg-components/Tooltip/Tooltip.spec.tsx
+++ b/src/client/rsg-components/Tooltip/Tooltip.spec.tsx
@@ -16,11 +16,6 @@ describe('Tooltip', () => {
 		expect(container).toContainElement(getByTestId('child'));
 	});
 
-	test('should the child component be wrapped by "role=button" element', () => {
-		const { getByTestId } = renderComponent();
-		expect(getByTestId('child').closest('span')).toHaveAttribute('role', 'button');
-	});
-
 	test('should render content in the tooltop body', () => {
 		const { container, getByRole } = renderComponent();
 		fireEvent.focus(getByRole('button'));
@@ -33,7 +28,6 @@ describe('Tooltip', () => {
 		await waitFor(() =>
 			expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
 		);
-		expect(container.querySelector('[data-state]')).toHaveAttribute('data-state', 'visible');
 	});
 
 	test('should show the tooltip by click', async () => {
@@ -42,7 +36,6 @@ describe('Tooltip', () => {
 		await waitFor(() =>
 			expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
 		);
-		expect(container.querySelector('[data-state]')).toHaveAttribute('data-state', 'visible');
 	});
 
 	test('should show the tooltip by mouse enter', async () => {
@@ -51,7 +44,6 @@ describe('Tooltip', () => {
 		await waitFor(() =>
 			expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
 		);
-		expect(container.querySelector('[data-state]')).toHaveAttribute('data-state', 'visible');
 	});
 
 	describe.each([['top'], ['right'], ['left'], ['bottom']])(

--- a/src/client/rsg-components/Tooltip/Tooltip.spec.tsx
+++ b/src/client/rsg-components/Tooltip/Tooltip.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import Tooltip, { TooltipPlacement } from './TooltipRenderer';
+
+function renderComponent(content = 'tooltip', placement?: TooltipPlacement) {
+	return render(
+		<Tooltip content={content} placement={placement}>
+			<div data-testid="child" />
+		</Tooltip>
+	);
+}
+
+describe('Tooltip', () => {
+	test('should render child component as is', () => {
+		const { container, getByTestId } = renderComponent();
+		expect(container).toContainElement(getByTestId('child'));
+	});
+
+	test('should the child component be wrapped by "role=button" element', () => {
+		const { getByTestId } = renderComponent();
+		expect(getByTestId('child').closest('span')).toHaveAttribute('role', 'button');
+	});
+
+	test('should render content in the tooltop body', () => {
+		const { container, getByRole } = renderComponent();
+		fireEvent.focus(getByRole('button'));
+		expect(container.querySelector('[data-tippy-root]')).toHaveTextContent('tooltip');
+	});
+
+	test('should show the tooltip by focus in', async () => {
+		const { container, getByRole } = renderComponent();
+		fireEvent.focus(getByRole('button'));
+		await waitFor(() =>
+			expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
+		);
+		expect(container.querySelector('[data-state]')).toHaveAttribute('data-state', 'visible');
+	});
+
+	test('should show the tooltip by click', async () => {
+		const { container, getByRole } = renderComponent();
+		fireEvent.click(getByRole('button'));
+		await waitFor(() =>
+			expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
+		);
+		expect(container.querySelector('[data-state]')).toHaveAttribute('data-state', 'visible');
+	});
+
+	test('should show the tooltip by mouse enter', async () => {
+		const { container, getByRole } = renderComponent();
+		fireEvent.mouseEnter(getByRole('button'));
+		await waitFor(() =>
+			expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
+		);
+		expect(container.querySelector('[data-state]')).toHaveAttribute('data-state', 'visible');
+	});
+
+	describe.each([['top'], ['right'], ['left'], ['bottom']])(
+		'Test placement attribute',
+		placement => {
+			test(`should have ${placement} in data-placement attribute`, async () => {
+				// @ts-ignore
+				const { container, getByRole } = renderComponent(undefined, placement);
+				fireEvent.focus(getByRole('button'));
+				await waitFor(() =>
+					expect(container.querySelector('[data-state="visible"]')).toBeInTheDocument()
+				);
+				expect(container.querySelector('[data-placement]')).toHaveAttribute(
+					'data-placement',
+					placement
+				);
+			});
+		}
+	);
+});

--- a/src/client/rsg-components/Tooltip/TooltipRenderer.tsx
+++ b/src/client/rsg-components/Tooltip/TooltipRenderer.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Tippy from '@tippyjs/react';
+import Styled, { JssInjectedProps } from 'rsg-components/Styled';
+import * as Rsg from '../../../typings';
+
+export const styles = ({ space, color, borderRadius, fontSize }: Rsg.Theme) => ({
+	tooltip: {
+		'&.tippy-box': {
+			transitionProperty: [['opacity']],
+			'&[data-state="hidden"]': {
+				opacity: 0,
+			},
+		},
+		'& .tippy-content': {
+			padding: space[0],
+			border: `1px ${color.border} solid`,
+			borderRadius,
+			background: color.baseBackground,
+			boxShadow: [[0, 2, 4, 'rgba(0,0,0,.15)']],
+			fontSize: fontSize.small,
+			color: color.type,
+		},
+	},
+});
+
+export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left';
+
+export interface TooltipProps extends JssInjectedProps {
+	children: React.ReactNode;
+	content: React.ReactNode;
+	placement?: TooltipPlacement;
+}
+
+function TooltipRenderer({ classes, children, content, placement = 'top' }: TooltipProps) {
+	return (
+		<Tippy
+			content={content}
+			className={classes.tooltip}
+			interactive
+			placement={placement}
+			trigger="click mouseenter focus"
+			arrow={false}
+		>
+			<span role="button" tabIndex={0}>
+				{children}
+			</span>
+		</Tippy>
+	);
+}
+
+export default Styled<TooltipProps>(styles)(TooltipRenderer);

--- a/src/client/rsg-components/Tooltip/index.ts
+++ b/src/client/rsg-components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from 'rsg-components/Tooltip/TooltipRenderer';

--- a/src/typings/dependencies/react-docgen.ts
+++ b/src/typings/dependencies/react-docgen.ts
@@ -58,7 +58,6 @@ declare module 'react-docgen' {
 			| 'objectOf'
 			| 'shape'
 			| 'exact'
-			| 'union'
 			| 'instanceOf'
 			| 'elementType';
 		value?: any;


### PR DESCRIPTION
Resolved:

- Wrong union description with TypeScript #1621

Main changes:
- Create a new component named `ComplexType` and `Tooltip` to show the complex type
- Introduce [tippyjs-react](https://github.com/atomiks/tippyjs-react) in the project
- ~~Add styleMock in the test assets to mock CSS import~~

Hover Actions:
![Jul-12-2020 22-42-08](https://user-images.githubusercontent.com/1703219/87248032-2f890680-c492-11ea-888d-06da52514caa.gif)

Keyboard Actions:
(use Tab key)
![Jul-12-2020 22-42-58](https://user-images.githubusercontent.com/1703219/87248038-3adc3200-c492-11ea-885b-48f87d63ee78.gif)
