### PR TITLE
Fix links to other pages on the Getting started page

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,8 +20,8 @@ npm install --save-dev react-styleguidist
 
 **If you’re using [Create React App](https://github.com/facebook/create-react-app) you can skip this step.**
 
-- [Point Styleguidist to your React components](Components.md)
-- [Tell Styleguidist how to load your app’s code](Webpack.md)
+- [Point Styleguidist to your React components](/docs/Components.md)
+- [Tell Styleguidist how to load your app’s code](/docs/Webpack.md)
 
 ## 3. Start your style guide
 
@@ -32,9 +32,9 @@ npm install --save-dev react-styleguidist
 
 ## 4. Start documenting your components
 
-See how to [document your components](Documenting.md).
+See how to [document your components](/docs/Documenting.md).
 
 ## Something isn’t working?
 
-- [Solutions for common problems and questions](Cookbook.md)
-- [Configuring Styleguidist with third-party tools](Thirdparties.md)
+- [Solutions for common problems and questions](/docs/Cookbook.md)
+- [Configuring Styleguidist with third-party tools](/docs/Thirdparties.md)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,8 +20,8 @@ npm install --save-dev react-styleguidist
 
 **If you’re using [Create React App](https://github.com/facebook/create-react-app) you can skip this step.**
 
-- [Point Styleguidist to your React components](/docs/Components.md)
-- [Tell Styleguidist how to load your app’s code](/docs/Webpack.md)
+- [Point Styleguidist to your React components](docs/Components.md)
+- [Tell Styleguidist how to load your app’s code](docs/Webpack.md)
 
 ## 3. Start your style guide
 
@@ -32,9 +32,9 @@ npm install --save-dev react-styleguidist
 
 ## 4. Start documenting your components
 
-See how to [document your components](/docs/Documenting.md).
+See how to [document your components](docs/Documenting.md).
 
 ## Something isn’t working?
 
-- [Solutions for common problems and questions](/docs/Cookbook.md)
-- [Configuring Styleguidist with third-party tools](/docs/Thirdparties.md)
+- [Solutions for common problems and questions](docs/Cookbook.md)
+- [Configuring Styleguidist with third-party tools](docs/Thirdparties.md)


### PR DESCRIPTION
## Description
Currently all the links (I think on all pages) are broken, this PR should fix the links on the Getting started page