### PR TITLE
fix broken links on the website

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,7 +35,7 @@ const styleguide = styleguidist({
 })
 ```
 
-> **Info:** Any output is disabled by default, you may need to define your own [logger](Configuration.md#logger).
+> **Info:** Any output is disabled by default, you may need to define your own [logger](.Configuration.md#logger).
 
 Using a config file:
 
@@ -51,7 +51,7 @@ import styleguidist from 'react-styleguidist'
 const styleguide = styleguidist()
 ```
 
-See all available [config options](Configuration.md).
+See all available [config options](.Configuration.md).
 
 ## Methods
 

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -29,9 +29,9 @@ module.exports = {
 
 > **Info:** All paths are relative to the config folder.
 
-> **Tip:** Use [ignore](Configuration.md#ignore) option to exclude some files from the style guide.
+> **Tip:** Use [ignore](.Configuration.md#ignore) option to exclude some files from the style guide.
 
-> **Tip:** Use [getComponentPathLine](Configuration.md#getcomponentpathline) option to change the path you see below a component name.
+> **Tip:** Use [getComponentPathLine](.Configuration.md#getcomponentpathline) option to change the path you see below a component name.
 
 ## Loading and exposing components
 
@@ -100,9 +100,9 @@ Each section consists of (all fields are optional):
 - `components` — a glob pattern string, an array of component paths or glob pattern strings, or a function returning a list of components or glob pattern strings. The same rules apply as for the root `components` option.
 - `sections` — array of subsections (can be nested).
 - `description` — A small description of this section.
-- `sectionDepth` — Number of subsections with single pages, only available with [pagePerSection](Configuration.md#pagepersection) is enabled.
-- `exampleMode` — Initial state of the code example tab, uses [exampleMode](Configuration.md#examplemode).
-- `usageMode` — Initial state of the props and methods tab, uses [usageMode](Configuration.md#usagemode).
+- `sectionDepth` — Number of subsections with single pages, only available with [pagePerSection](.Configuration.md#pagepersection) is enabled.
+- `exampleMode` — Initial state of the code example tab, uses [exampleMode](.Configuration.md#examplemode).
+- `usageMode` — Initial state of the props and methods tab, uses [usageMode](.Configuration.md#usagemode).
 - `ignore` — string/array of globs that should not be included in the section.
 - `href` - an URL to navigate to instead of navigating to the section content
 - `external` - if set, the link will open in a new window
@@ -150,4 +150,4 @@ module.exports = {
 
 ## Limitations
 
-In some cases Styleguidist may not understand your components, [see possible solutions](Thirdparties.md).
+In some cases Styleguidist may not understand your components, [see possible solutions](.Thirdparties.md).

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-By default, Styleguidist will look for `styleguide.config.js` file in your project’s root folder. You can change the location of the config file using `--config` [CLI](CLI.md) option.
+By default, Styleguidist will look for `styleguide.config.js` file in your project’s root folder. You can change the location of the config file using `--config` [CLI](.CLI.md) option.
 
 ## `assetsDir`
 
@@ -41,7 +41,7 @@ Type: `String`, `Function` or `Array`, default: `src/components/**/*.{js,jsx,ts,
 
 All paths are relative to config folder.
 
-See examples in the [Components section](Components.md).
+See examples in the [Components section](.Components.md).
 
 ## `context`
 
@@ -437,7 +437,7 @@ module.exports = {
 }
 ```
 
-See [Configuring webpack](Webpack.md) for mode details.
+See [Configuring webpack](.Webpack.md) for mode details.
 
 ## `resolver`
 
@@ -477,7 +477,7 @@ Type: `Array`, optional
 
 Allows components to be grouped into sections with a title and overview content. Sections can also be content only, with no associated components (for example, a textual introduction). Sections can be nested.
 
-See examples of [sections configuration](Components.md#sections).
+See examples of [sections configuration](.Components.md#sections).
 
 ## `serverHost`
 
@@ -501,7 +501,7 @@ Toggle sidebar visibility. The sidebar will be hidden when opening components or
 
 Type: `Boolean`, default: `false`
 
-Ignore components that don’t have an example file (as determined by [getExampleFilename](#getexamplefilename)). These components won’t be accessible from other examples unless you [manually `require` them](Cookbook.md#how-to-hide-some-components-in-style-guide-but-make-them-available-in-examples).
+Ignore components that don’t have an example file (as determined by [getExampleFilename](#getexamplefilename)). These components won’t be accessible from other examples unless you [manually `require` them](.Cookbook.md#how-to-hide-some-components-in-style-guide-but-make-them-available-in-examples).
 
 ## `sortProps`
 
@@ -553,7 +553,7 @@ Type: `Object`, `String` or `Function`, optional
 
 Customize styles of any Styleguidist’s component using an object, a function returning said object or a file path to a file exporting said styles.
 
-See examples in the [cookbook](Cookbook.md#how-to-change-styles-of-a-style-guide).
+See examples in the [cookbook](.Cookbook.md#how-to-change-styles-of-a-style-guide).
 
 > **Tip:** Using a function allows access to theme variables like in the example below. See available [theme variables](https://github.com/styleguidist/react-styleguidist/blob/master/src/client/styles/theme.ts). The returned object folows the same format as when configured as a litteral.
 
@@ -600,7 +600,7 @@ Customize style guide UI fonts, colors, etc. using a theme object or the path to
 
 The path is relative to the config file or absolute.
 
-See examples in the [cookbook](Cookbook.md#how-to-change-styles-of-a-style-guide).
+See examples in the [cookbook](.Cookbook.md#how-to-change-styles-of-a-style-guide).
 
 > **Info:** See available [theme variables](https://github.com/styleguidist/react-styleguidist/blob/master/src/client/styles/theme.ts).
 
@@ -696,7 +696,7 @@ Use it like this in your Markdown files:
     ```js { "file": "./some/file.js" }
     ```
 
-You can also use this function to dynamically update some of your fenced code blocks that you do not want to be interpreted as React components by using the [static modifier](Documenting.md#usage-examples-and-readme-files).
+You can also use this function to dynamically update some of your fenced code blocks that you do not want to be interpreted as React components by using the [static modifier](.Documenting.md#usage-examples-and-readme-files).
 
 ```javascript
 module.exports = {
@@ -777,7 +777,7 @@ module.exports = {
 }
 ```
 
-> **Caution:** This option disables config load from `webpack.config.js`, load your config [manually](Webpack.md#reusing-your-projects-webpack-config).
+> **Caution:** This option disables config load from `webpack.config.js`, load your config [manually](.Webpack.md#reusing-your-projects-webpack-config).
 
 > **Danger:** `entry`, `externals`, `output`, `watch`, and `stats` options will be ignored. For production builds, `devtool` will also be ignored.
 
@@ -785,4 +785,4 @@ module.exports = {
 
 > **Tip:** Run style guide in verbose mode to see the actual webpack config used by Styleguidist: `npx styleguidist server --verbose`.
 
-See [Configuring webpack](Webpack.md) for examples.
+See [Configuring webpack](.Webpack.md) for examples.

--- a/docs/Cookbook.md
+++ b/docs/Cookbook.md
@@ -23,7 +23,7 @@ let textarea
 
 Styleguidist will ignore tests (`__tests__` folder and filenames containing `.test.js` or `.spec.js`) by default.
 
-Use [ignore](Configuration.md#ignore) option to customize this behavior:
+Use [ignore](.Configuration.md#ignore) option to customize this behavior:
 
 ```javascript
 module.exports = {
@@ -35,7 +35,7 @@ module.exports = {
 
 ## How to hide some components in style guide but make them available in examples?
 
-Enable [skipComponentsWithoutExample](Configuration.md#skipcomponentswithoutexample) option and do not add an example file (`Readme.md` by default) to components you want to ignore.
+Enable [skipComponentsWithoutExample](.Configuration.md#skipcomponentswithoutexample) option and do not add an example file (`Readme.md` by default) to components you want to ignore.
 
 Import these components in your examples:
 
@@ -103,7 +103,7 @@ const iconElements = Object.keys(icons).map(iconName => {
 
 ## How to display the source code of any file?
 
-First, code examples can receive [props and settings](Documenting.md#usage-examples-and-readme-files):
+First, code examples can receive [props and settings](.Documenting.md#usage-examples-and-readme-files):
 
     ```js { "file": "../mySourceCode.js" }
     ```
@@ -193,11 +193,11 @@ See the [Preact example style guide](https://github.com/styleguidist/react-style
 
 ## How to change styles of a style guide?
 
-There are two config options to change your style guide UI: [theme](Configuration.md#theme) and [styles](Configuration.md#styles).
+There are two config options to change your style guide UI: [theme](.Configuration.md#theme) and [styles](.Configuration.md#styles).
 
-Use [theme](Configuration.md#theme) to change fonts, colors, etc.
+Use [theme](.Configuration.md#theme) to change fonts, colors, etc.
 
-Use [styles](Configuration.md#styles) to tweak the style of any particular Styleguidist component.
+Use [styles](.Configuration.md#styles) to tweak the style of any particular Styleguidist component.
 
 As an example:
 
@@ -233,7 +233,7 @@ module.exports = {
 
 > **Tip:** Use [React Developer Tools](https://github.com/facebook/react) to find component and style names. For example a component `<LogoRenderer><h1 className="rsg--logo-53">` corresponds to an example above.
 
-> **Tip:** Use a function instead of an object for [styles](Configuration.md#styles) to access all theme variables in your custom styles.
+> **Tip:** Use a function instead of an object for [styles](.Configuration.md#styles) to access all theme variables in your custom styles.
 
 You can store all styles in a separate file to allow hot module replacement (HMR). Same goes for theme variables.
 
@@ -378,7 +378,7 @@ We have [an example style guide](https://github.com/styleguidist/react-styleguid
 
 ## How to change syntax highlighting colors?
 
-Styleguidist uses [Prism](https://prismjs.com/) for code highlighting in static examples and inside the editor. You can change the colors using the [theme](Configuration.md#theme) config option:
+Styleguidist uses [Prism](https://prismjs.com/) for code highlighting in static examples and inside the editor. You can change the colors using the [theme](.Configuration.md#theme) config option:
 
 ```javascript
 // styleguide.config.js
@@ -480,7 +480,7 @@ Two options:
 
 1. Put a `favicon.ico` file into the root folder of your site.
 
-2. Use [template](Configuration.md#template) option:
+2. Use [template](.Configuration.md#template) option:
 
 ```javascript
 module.exports = {
@@ -492,7 +492,7 @@ module.exports = {
 
 ## How to add external JavaScript and CSS files?
 
-Use [template](Configuration.md#template) option:
+Use [template](.Configuration.md#template) option:
 
 ```javascript
 module.exports = {
@@ -515,11 +515,11 @@ module.exports = {
 }
 ```
 
-In comparison to [require](Configuration.md#require) option, these scripts and links are run in the browser, not during webpack build process. It can be useful for side effect-causing scripts in which your components, or in this case Babel output, need to function properly.
+In comparison to [require](.Configuration.md#require) option, these scripts and links are run in the browser, not during webpack build process. It can be useful for side effect-causing scripts in which your components, or in this case Babel output, need to function properly.
 
 ## How to add fonts from Google Fonts?
 
-Use [template](Configuration.md#template) and [theme](Configuration.md#theme) options:
+Use [template](.Configuration.md#template) and [theme](.Configuration.md#theme) options:
 
 ```javascript
 module.exports = {
@@ -543,11 +543,11 @@ module.exports = {
 
 ## How to reuse project’s webpack config?
 
-See in [configuring webpack](Webpack.md#reusing-your-projects-webpack-config).
+See in [configuring webpack](.Webpack.md#reusing-your-projects-webpack-config).
 
 ## How to use React Styleguidist with Redux, Relay or Styled Components?
 
-See [working with third-party libraries](Thirdparties.md).
+See [working with third-party libraries](.Thirdparties.md).
 
 ## How to use React-axe to test accessibility of components?
 
@@ -581,9 +581,9 @@ If you are using Jest for testing you can also use [jest-axe](https://github.com
 
 You might want to change your components’ names to be displayed differently, for example, for stylistic purposes or to give them more descriptive names in your style guide.
 
-This can be done by adding [@visibleName](Documenting.md#defining-custom-component-names) tag to your component documentation.
+This can be done by adding [@visibleName](.Documenting.md#defining-custom-component-names) tag to your component documentation.
 
-In case you want to change components’ names in bulk, for example, based on their current name, you can use [updateDocs](Configuration.md#updatedocs) config option:
+In case you want to change components’ names in bulk, for example, based on their current name, you can use [updateDocs](.Configuration.md#updatedocs) config option:
 
 ```javascript
 module.exports = {

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -34,7 +34,7 @@ We’re trying to keep Styleguidist’s [webpack config](https://github.com/styl
 
 ## React components
 
-Most of StyleGuidist UI components consist of two parts: `Foo/Foo.js` that contains all logic and `Foo/FooRenderer.js` that contains all markup and styles. This allows users to customize rendering by overriding `*Renderer` component using webpack aliases (or [styleguideComponents](Configuration.md#styleguidecomponents) config option):
+Most of StyleGuidist UI components consist of two parts: `Foo/Foo.js` that contains all logic and `Foo/FooRenderer.js` that contains all markup and styles. This allows users to customize rendering by overriding `*Renderer` component using webpack aliases (or [styleguideComponents](.Configuration.md#styleguidecomponents) config option):
 
 ```js
 // styleguide.config.js
@@ -68,7 +68,7 @@ For styles we use [JSS](http://cssinjs.org/), it allows users to customize their
 
 Use [clsx](https://github.com/lukeed/clsx) to merge several class names or for conditional class names, import it as `cx` (`import cx from 'clsx'`).
 
-We use `Styled` higher-order component to allow theming (see [theme](Configuration.md#theme) and [style](Configuration.md#style) style guide config options). Use it like this:
+We use `Styled` higher-order component to allow theming (see [theme](.Configuration.md#theme) and [style](.Configuration.md#style) style guide config options). Use it like this:
 
 ```jsx
 import React from 'react'

--- a/docs/Documenting.md
+++ b/docs/Documenting.md
@@ -36,9 +36,9 @@ export default class Button extends React.Component {
 
 > **Info:** [Flow](https://flowtype.org/) and [TypeScript](https://www.typescriptlang.org) type annotations are supported.
 
-> **Tip:** You can change its behavior using [propsParser](Configuration.md#propsparser) and [resolver](Configuration.md#resolver) options.
+> **Tip:** You can change its behavior using [propsParser](.Configuration.md#propsparser) and [resolver](.Configuration.md#resolver) options.
 
-> **Info:** Component’s `PropTypes` and documentation comments are parsed by the [react-docgen](https://github.com/reactjs/react-docgen) library. They can be modified using the [updateDocs](Configuration.md#updatedocs) function.
+> **Info:** Component’s `PropTypes` and documentation comments are parsed by the [react-docgen](https://github.com/reactjs/react-docgen) library. They can be modified using the [updateDocs](.Configuration.md#updatedocs) function.
 
 ## Usage examples and Readme files
 
@@ -84,7 +84,7 @@ Styleguidist will look for any `Readme.md` or `ComponentName.md` files in the co
 
     Any [Markdown](http://daringfireball.net/projects/markdown/) is **allowed** _here_.
 
-> **Tip:** You can configure examples file name with the [getExampleFilename](Configuration.md#getexamplefilename) option.
+> **Tip:** You can configure examples file name with the [getExampleFilename](.Configuration.md#getexamplefilename) option.
 
 > **Tip:** If you need to display some JavaScript code in your documentation that you don’t want to be rendered as an interactive playground you can use the `static` modifier with a language tag (e.g. `js static`).
 
@@ -105,7 +105,7 @@ export default class Button extends React.Component {
 }
 ```
 
-> **Note:** You’ll need a regular example file (like `Readme.md`) too when [skipComponentsWithoutExample](Configuration.md#skipcomponentswithoutexample) is `true`.
+> **Note:** You’ll need a regular example file (like `Readme.md`) too when [skipComponentsWithoutExample](.Configuration.md#skipcomponentswithoutexample) is `true`.
 
 ## Public methods
 
@@ -254,7 +254,7 @@ import Button from 'rsg-example/components/Button'
 import Placeholder from 'rsg-example/components/Placeholder'
 ````
 
-> **Info:** `rsg-example` module is an alias defined by the [moduleAliases](Configuration.md#modulealiases) config option.
+> **Info:** `rsg-example` module is an alias defined by the [moduleAliases](.Configuration.md#modulealiases) config option.
 
 > **Caution:** You can only use `import` by editing your Markdown files, not by editing the example code in the browser.
 
@@ -278,4 +278,4 @@ If a component uses React Context, you need a context provider in the example or
 
 ## Limitations
 
-In some cases Styleguidist may not understand your components, [see possible solutions](Thirdparties.md).
+In some cases Styleguidist may not understand your components, [see possible solutions](.Thirdparties.md).

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,21 +20,21 @@ npm install --save-dev react-styleguidist
 
 **If you’re using [Create React App](https://github.com/facebook/create-react-app) you can skip this step.**
 
-- [Point Styleguidist to your React components](Components.md)
-- [Tell Styleguidist how to load your app’s code](Webpack.md)
+- [Point Styleguidist to your React components](.Components.md)
+- [Tell Styleguidist how to load your app’s code](.Webpack.md)
 
 ## 3. Start your style guide
 
 - Run **`npx styleguidist server`** to start a style guide dev server.
 - Run **`npx styleguidist build`** to build a production HTML version.
 
-> **Tip:** We recommend [adding these commands to your `package.json`](CLI.md#usage).
+> **Tip:** We recommend [adding these commands to your `package.json`](.CLI.md#usage).
 
 ## 4. Start documenting your components
 
-See how to [document your components](Documenting.md).
+See how to [document your components](.Documenting.md).
 
 ## Something isn’t working?
 
-- [Solutions for common problems and questions](Cookbook.md)
-- [Configuring Styleguidist with third-party tools](Thirdparties.md)
+- [Solutions for common problems and questions](.Cookbook.md)
+- [Configuring Styleguidist with third-party tools](.Thirdparties.md)

--- a/docs/Maintenance.md
+++ b/docs/Maintenance.md
@@ -2,7 +2,7 @@
 
 # Maintainer guide
 
-_See also [Developer guide](Development.md)._
+_See also [Developer guide](.Development.md)._
 
 ## We need you!
 

--- a/docs/Thirdparties.md
+++ b/docs/Thirdparties.md
@@ -4,7 +4,7 @@
 
 ## How Styleguidist works
 
-Styleguidist _loads_ your components (see [Loading and exposing components](Components.md#loading-and-exposing-components) for more) but it uses [react-docgen](https://github.com/reactjs/react-docgen) to _generate documentation_ which may require changes in your code to work properly.
+Styleguidist _loads_ your components (see [Loading and exposing components](.Components.md#loading-and-exposing-components) for more) but it uses [react-docgen](https://github.com/reactjs/react-docgen) to _generate documentation_ which may require changes in your code to work properly.
 
 React-docgen reads your components as static text files and looks for patterns like class or function declarations that look like React components. It does not run any JavaScript code, so, if your component is dynamically generated, is wrapped in a higher-order component, or is split into several files, then react-docgen may not understand it.
 
@@ -51,7 +51,7 @@ export default Button
 Here we’re reexporting a third-party component from `node_modules`. Styleguidist won’t be able to render prop types of this component, unless we’re using `react-docgen-typescript`:
 
 1. Install [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript).
-2. Create a `styleguide.config.js`, see [configuration](Configuration.md) reference.
+2. Create a `styleguide.config.js`, see [configuration](.Configuration.md) reference.
 3. Update your `styleguide.config.js`:
 
    ```javascript

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -6,7 +6,7 @@ Styleguidist uses [webpack](https://webpack.js.org/) under the hood and it needs
 
 _Webpack is required to run Styleguidist but your project doesn’t have to use it._
 
-> **Note:** See [cookbook](Cookbook.md) for more examples.
+> **Note:** See [cookbook](.Cookbook.md) for more examples.
 
 ## Reusing your project’s webpack config
 
@@ -162,6 +162,6 @@ This will tell Babel (and some other tools) which browsers you support, so it wo
 
 ## When nothing else works
 
-In very rare cases, like using legacy or third-party libraries, you may need to change webpack options that Styleguidist doesn’t allow you to change via `webpackConfig` options. In this case, you can use [dangerouslyUpdateWebpackConfig](Configuration.md#dangerouslyupdatewebpackconfig) option.
+In very rare cases, like using legacy or third-party libraries, you may need to change webpack options that Styleguidist doesn’t allow you to change via `webpackConfig` options. In this case, you can use [dangerouslyUpdateWebpackConfig](.Configuration.md#dangerouslyupdatewebpackconfig) option.
 
 > **Danger:** You may break Styleguidist using this option, use it at your own risk.


### PR DESCRIPTION
Fix some broken links on the site.

For instance on the page:  https://react-styleguidist.js.org/docs/getting-started, 

there's a link for: https://react-styleguidist.js.org/components

but the correct link would be: https://react-styleguidist.js.org/docs/documenting