### PR TITLE
Fix: Fix site links for adblock users

### DIFF
--- a/site/src/plugins/goatcounter-plugin.js
+++ b/site/src/plugins/goatcounter-plugin.js
@@ -7,9 +7,11 @@ module.exports = function() {
 					`<script>
 if ('history' in window) {
 	function trackView() {
-		window.goatcounter.count({
-			path: location.pathname + location.search,
-		});
+		if ('goatcounter' in window) {
+			window.goatcounter.count({
+				path: location.pathname + location.search,
+			});
+		}
 	}
 
 	// Monkey patch browser pushState


### PR DESCRIPTION
When using e.g. uBlock Origin, navigation in the styleguidist documentation is broken. This is because in that case "window.goatcounter" is undefined. I added a check that assures, goatcounter.count will only be called if goatcounter is defined. This way clicking on links and navigating the documentation still works when goatcounter is blocked.