### PR TITLE
Added Next.js configuration info to docs

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -78,7 +78,7 @@ module.exports = {
 
 ## Next.js
 
-The [Next.js](https://nextjs.org/) framework abstracts away Webpack for you, but it still uses Webpack under the hood.
+The [Next.js](https://nextjs.org/) framework abstracts away webpack for you, but it still uses webpack under the hood.
 
 After configuring your webpack loaders in `styleguide.config.js` you will need to also configure Babel. First install all the required Babel dependencies:
 

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -76,6 +76,26 @@ module.exports = {
 
 [Create React App](https://github.com/facebook/create-react-app) is supported out of the box, you don’t even need to create a style guide config if your components could be found using a default pattern: all files with `.js` or `.jsx` extensions inside `src/components` or `src/Components` folders.
 
+## Next.js
+
+The [Next.js](https://nextjs.org/) framework abstracts away Webpack for you, but it still uses Webpack under the hood.
+
+After configuring your webpack loaders in `styleguide.config.js` you will need to also configure Babel. First install all the required Babel dependencies:
+
+```bash
+npm install --save-dev babel-loader @babel/core @babel/preset-react
+```
+
+Next, you'll want to configure Babel to use the appropriate presets, here is an example `.babelrc` file:
+
+```json
+{
+  "presets": ["@babel/preset-react"]
+}
+```
+
+That's it, notice that we don't need to install webpack as it's already included by Next.js.
+
 ## Non-webpack projects
 
 To use features, not supported by browsers, like JSX, you’ll need to compile your code with Babel or another tool.


### PR DESCRIPTION
Hi 👋🏽 

First off, thanks for all the work on this project, really love it!

I thought it would be helpful to add a section that addresses how to configure react-styleguidist with Next.js specifically. With the pre-existing information in the webpack docs it's possible to configure, but I thought given how popular Next.js is it warranted a reference to make it more accessible. I'd also be down to adding an example project if need be. Feel free to disregard otherwise

Cheers!