### PR TITLE
Fix Warning in ArgumentRenderer #1667

### DIFF
--- a/src/client/rsg-components/Argument/ArgumentRenderer.tsx
+++ b/src/client/rsg-components/Argument/ArgumentRenderer.tsx
@@ -15,7 +15,7 @@ export const styles = ({ space }: Rsg.Theme) => ({
 });
 
 export interface ArgumentProps {
-	name: string;
+	name?: string;
 	type?: any;
 	default?: string;
 	description?: string;
@@ -70,7 +70,7 @@ export const ArgumentRenderer: React.FunctionComponent<ArgumentPropsWithClasses>
 
 ArgumentRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
-	name: PropTypes.string.isRequired,
+	name: PropTypes.string,
 	type: PropTypes.object,
 	default: PropTypes.string,
 	description: PropTypes.string,

--- a/src/loaders/utils/__tests__/getProps.spec.ts
+++ b/src/loaders/utils/__tests__/getProps.spec.ts
@@ -225,6 +225,40 @@ it("should not crash when using doctrine to parse a default prop that isn't in t
 	expect(result).toMatchSnapshot();
 });
 
+it('should not crash when using doctrine to parse a return method that does not have type in it', () => {
+	const result = getProps(
+		{
+			displayName: 'Button',
+			methods: [
+				{
+					docblock: `
+Public Method
+
+@public
+@returns {Boolean} return a Boolean Value
+`,
+					returns: {
+						description: 'return a Boolean Value',
+						type: { name: 'boolean' },
+					},
+				},
+			] as any,
+		},
+		__filename
+	);
+
+	// @ts-ignore
+	expect(result.methods[0].returns).toEqual(
+		expect.objectContaining({
+			description: 'return a Boolean Value',
+			type: {
+				name: 'boolean',
+				type: 'NameExpression',
+			},
+		})
+	);
+});
+
 it('should guess a displayName for components that react-docgen was not able to recognize', () => {
 	const result = getProps(
 		{

--- a/src/loaders/utils/getProps.ts
+++ b/src/loaders/utils/getProps.ts
@@ -94,7 +94,15 @@ export default function getProps(doc: DocumentationObject, filepath?: string): R
 			allTags as TagProps,
 			JS_DOC_METHOD_RETURN_TAG_SYNONYMS
 		) as TagParamObject[];
-		const returns = (method.returns || returnTags[0]) && { ...method.returns, ...returnTags[0] };
+		const returns = method.returns
+			? {
+					...method.returns,
+					type: {
+						type: 'NameExpression',
+						...method.returns.type,
+					},
+			  }
+			: returnTags[0];
 
 		if (returns) {
 			method.returns = returns;

--- a/src/loaders/utils/getProps.ts
+++ b/src/loaders/utils/getProps.ts
@@ -94,7 +94,7 @@ export default function getProps(doc: DocumentationObject, filepath?: string): R
 			allTags as TagProps,
 			JS_DOC_METHOD_RETURN_TAG_SYNONYMS
 		) as TagParamObject[];
-		const returns = method.returns || returnTags[0];
+		const returns = (method.returns || returnTags[0]) && { ...method.returns, ...returnTags[0] };
 
 		if (returns) {
 			method.returns = returns;


### PR DESCRIPTION
Resolved

- Warning in ArgumentRenderer #1667

I checked the behavior of the component of the original issue after I changed the `name` to optional and found that the following error occurred.

```
DoctrineError {name: "DoctrineError", message: "Unknown type undefined"}
```

What I have found in my research is that in the above cases, `type.type` in the `returns` is lost in `getProps` in this case.
`returns` should have `NameExpression` in `type.type` in my opinion.

```js
// I saw this shape.
{ 
  description: 'return a Boolean Value', 
  type: { name: 'boolean' } 
}

// but it should be this shape.
{
  title: 'returns',
  description: 'return a Boolean Value',
  type: { type: 'NameExpression', name: 'boolean' }
}
```