### PR TITLE
Fix visibleName with dots

### DIFF
--- a/src/loaders/__tests__/examples-loader.spec.ts
+++ b/src/loaders/__tests__/examples-loader.spec.ts
@@ -9,7 +9,17 @@ const query = {
 	shouldShowDefaultExample: false,
 };
 
+const subComponentQuery = {
+	file: '../fooSub.js',
+	displayName: 'FooComponent.SubComponent',
+	shouldShowDefaultExample: false,
+};
+
+
 const getQuery = (options = {}) => encode({ ...query, ...options }, '?');
+const getSubComponentQuery = (options = {}) => encode({ ...subComponentQuery, ...options }, '?');
+
+
 
 it('should return valid, parsable JS', () => {
 	const exampleMarkdown = `
@@ -198,6 +208,23 @@ it('should prepend example code with component require()', () => {
 	expect(() => new Function(result)).not.toThrowError(SyntaxError);
 	expect(result).toMatch(
 		`const FooComponent$0 = require('../foo.js');\\nconst FooComponent = FooComponent$0.default || (FooComponent$0['FooComponent'] || FooComponent$0);`
+	);
+});
+
+it('should prepend example code with root component require() for sub components', () => {
+	const exampleMarkdown = `<X/>`;
+	const result = examplesLoader.call(
+		{
+			query: getSubComponentQuery(),
+			_styleguidist: {},
+		} as any,
+		exampleMarkdown
+	);
+
+	expect(result).toBeTruthy();
+	expect(() => new Function(result)).not.toThrowError(SyntaxError);
+	expect(result).toMatch(
+		`const FooComponentSubComponent$0 = require('../fooSub.js');\\nconst FooComponentSubComponent = FooComponentSubComponent$0.default || (FooComponentSubComponent$0['FooComponentSubComponent'] || FooComponentSubComponent$0);`
 	);
 });
 

--- a/src/loaders/examples-loader.ts
+++ b/src/loaders/examples-loader.ts
@@ -45,6 +45,13 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 		return requires.concat(getImports(example.content));
 	}, []);
 
+	// Do not import sub-components directly.
+	// e.g. <Dialog.Title> should not try `import Dialog.Title from './DialogTitle.tsx;'`
+	// since that is a syntax error. Instead, import it as "DialogTitle" even though
+	// that is probably not the component users want. Users would need to manually import
+	// "Dialog" to use "Dialog.Title" in their example code.
+	const safeComponentName = displayName ? displayName.replace('.') : displayName;
+
 	// Auto imported modules.
 	// We don't need to do anything here to support explicit imports: they will
 	// work because both imports (generated below and by rewrite-imports) will
@@ -58,7 +65,7 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 		// Append the current component module to make it accessible in examples
 		// without an explicit import
 		// TODO: Do not leak absolute path
-		...(displayName ? { [displayName]: file } : {}),
+		...(displayName ? { [safeComponentName]: file } : {}),
 	};
 
 	// All required or imported modules, either explicitly in examples code

--- a/src/loaders/examples-loader.ts
+++ b/src/loaders/examples-loader.ts
@@ -45,13 +45,6 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 		return requires.concat(getImports(example.content));
 	}, []);
 
-	// Do not import sub-components directly.
-	// e.g. <Dialog.Title> should not try `import Dialog.Title from './DialogTitle.tsx;'`
-	// since that is a syntax error. Instead, import it as "DialogTitle" even though
-	// that is probably not the component users want. Users would need to manually import
-	// "Dialog" to use "Dialog.Title" in their example code.
-	const safeComponentName = displayName ? displayName.replace('.', '') : displayName;
-
 	// Auto imported modules.
 	// We don't need to do anything here to support explicit imports: they will
 	// work because both imports (generated below and by rewrite-imports) will
@@ -65,7 +58,7 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 		// Append the current component module to make it accessible in examples
 		// without an explicit import
 		// TODO: Do not leak absolute path
-		...(displayName ? { [safeComponentName]: file } : {}),
+		...(displayName ? { [displayName]: file } : {}),
 	};
 
 	// All required or imported modules, either explicitly in examples code

--- a/src/loaders/examples-loader.ts
+++ b/src/loaders/examples-loader.ts
@@ -50,7 +50,7 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 	// since that is a syntax error. Instead, import it as "DialogTitle" even though
 	// that is probably not the component users want. Users would need to manually import
 	// "Dialog" to use "Dialog.Title" in their example code.
-	const safeComponentName = displayName ? displayName.replace('.') : displayName;
+	const safeComponentName = displayName ? displayName.replace('.', '') : displayName;
 
 	// Auto imported modules.
 	// We don't need to do anything here to support explicit imports: they will

--- a/src/loaders/utils/resolveESModule.ts
+++ b/src/loaders/utils/resolveESModule.ts
@@ -8,20 +8,26 @@ import requireIt from './requireIt';
  * @param name the name of the resulting variable
  * @returns AST
  */
-export default (requireRequest: string, name: string) => [
-	// const name$0 = require(path);
-	b.variableDeclaration('const', [
-		b.variableDeclarator(b.identifier(`${name}$0`), requireIt(requireRequest).toAST() as any),
-	]),
-	// const name = name$0.default || name$0[name] || name$0;
-	b.variableDeclaration('const', [
-		b.variableDeclarator(
-			b.identifier(name),
-			b.logicalExpression(
-				'||',
-				b.identifier(`${name}$0.default`),
-				b.logicalExpression('||', b.identifier(`${name}$0['${name}']`), b.identifier(`${name}$0`))
-			)
-		),
-	]),
-];
+export default (requireRequest: string, name: string) => {
+	// The name could possibly contain invalid characters for a JS variable name
+	// such as "." or "-". 
+	const safeName = name ? name.replace(/\W/, '') : name;
+
+	return [
+		// const safeName$0 = require(path);
+		b.variableDeclaration('const', [
+			b.variableDeclarator(b.identifier(`${safeName}$0`), requireIt(requireRequest).toAST() as any),
+		]),
+		// const safeName = safeName$0.default || safeName$0[safeName] || safeName$0;
+		b.variableDeclaration('const', [
+			b.variableDeclarator(
+				b.identifier(safeName),
+				b.logicalExpression(
+					'||',
+					b.identifier(`${safeName}$0.default`),
+					b.logicalExpression('||', b.identifier(`${safeName}$0['${safeName}']`), b.identifier(`${safeName}$0`))
+				)
+			),
+		]),
+	]
+};


### PR DESCRIPTION
Fixes: https://github.com/styleguidist/react-docgen-typescript/issues/292

With react-docgen-typescript's version 1.20.4, components with `@visibleName` JSDoc tags are working. However, it changes the react component's `displayName` to the one specified in `@visibleName`, and when it contains a `.`, the code examples were not working. This was because Styleguidist was trying to import the component with the dot in its name in the code example which resulted in the syntax error.

Example:
```tsx
// ===== DialogTitle.tsx ======
/**
 * @visibleName Dialog.Title
 */
export const DialogTitle = props => (<h2 {...props} />);

// ===== Dialog.tsx ======
import DialogTitle from './DialogTitle.tsx';
const Dialog = ({ children }) => <div>{children}</div>;
Dialog.Title = DialogTitle;
export default Dialog;
```
This caused Styleguidist to try 
```jsx
const Dialog.Title$0 = require('./DialogTitle.tsx');
```
in the example code renderer, which resulted in `SyntaxError: Missing initializer in const declaration`.
