### PR TITLE
Don't (only) rely on function names for custom styles

### DIFF
--- a/src/client/rsg-components/Argument/ArgumentRenderer.tsx
+++ b/src/client/rsg-components/Argument/ArgumentRenderer.tsx
@@ -77,5 +77,6 @@ ArgumentRenderer.propTypes = {
 	returns: PropTypes.bool,
 	block: PropTypes.bool,
 };
+ArgumentRenderer.displayName = 'ArgumentRenderer';
 
 export default Styled<ArgumentPropsWithClasses>(styles)(ArgumentRenderer);

--- a/src/client/rsg-components/Arguments/ArgumentsRenderer.tsx
+++ b/src/client/rsg-components/Arguments/ArgumentsRenderer.tsx
@@ -54,5 +54,6 @@ ArgumentsRenderer.propTypes = {
 	).isRequired,
 	heading: PropTypes.bool,
 };
+ArgumentsRenderer.displayName = 'ArgumentsRenderer';
 
 export default Styled<ArgumentsProps>(styles)(ArgumentsRenderer);

--- a/src/client/rsg-components/Code/CodeRenderer.tsx
+++ b/src/client/rsg-components/Code/CodeRenderer.tsx
@@ -24,5 +24,6 @@ CodeRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+CodeRenderer.displayName = 'CodeRenderer';
 
 export default Styled<CodeProps>(styles)(CodeRenderer);

--- a/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
+++ b/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
@@ -31,4 +31,6 @@ function ComplexTypeRenderer({ classes, name, raw }: ComplexTypeProps) {
 	);
 }
 
+ComplexTypeRenderer.displayName = 'ComplexTypeRenderer';
+
 export default Styled<ComplexTypeProps>(styles)(ComplexTypeRenderer);

--- a/src/client/rsg-components/ComponentsList/ComponentsListRenderer.tsx
+++ b/src/client/rsg-components/ComponentsList/ComponentsListRenderer.tsx
@@ -97,5 +97,6 @@ ComponentsListRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	items: PropTypes.array.isRequired,
 };
+ComponentsListRenderer.displayName = 'ComponentsListRenderer';
 
 export default Styled<ComponentsListRendererProps>(styles)(ComponentsListRenderer);

--- a/src/client/rsg-components/Editor/Editor.tsx
+++ b/src/client/rsg-components/Editor/Editor.tsx
@@ -47,6 +47,7 @@ interface EditorState {
 }
 
 export class Editor extends Component<EditorProps> {
+	public static displayName = 'Editor';
 	public static propTypes = {
 		code: PropTypes.string.isRequired,
 		onChange: PropTypes.func.isRequired,

--- a/src/client/rsg-components/Error/ErrorRenderer.tsx
+++ b/src/client/rsg-components/Error/ErrorRenderer.tsx
@@ -57,5 +57,6 @@ ErrorRenderer.propTypes = {
 	error: PropTypes.object.isRequired,
 	info: PropTypes.any.isRequired,
 };
+ErrorRenderer.displayName = 'ErrorRenderer';
 
 export default Styled<ErrorProps>(styles)(ErrorRenderer);

--- a/src/client/rsg-components/ExamplePlaceholder/ExamplePlaceholderRenderer.tsx
+++ b/src/client/rsg-components/ExamplePlaceholder/ExamplePlaceholderRenderer.tsx
@@ -27,6 +27,7 @@ interface ExamplePlaceholderProps extends JssInjectedProps {
 }
 
 export class ExamplePlaceholderRenderer extends Component<ExamplePlaceholderProps> {
+	public static displayName = 'ExamplePlaceholderProps';
 	public static propTypes = {
 		classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 		name: PropTypes.string,

--- a/src/client/rsg-components/Examples/ExamplesRenderer.tsx
+++ b/src/client/rsg-components/Examples/ExamplesRenderer.tsx
@@ -29,5 +29,6 @@ ExamplesRenderer.propTypes = {
 	name: PropTypes.string.isRequired,
 	children: PropTypes.node,
 };
+ExamplesRenderer.displayName = 'ExamplesRenderer';
 
 export default Styled<ExamplesRendererProps>(styles)(ExamplesRenderer);

--- a/src/client/rsg-components/Heading/HeadingRenderer.tsx
+++ b/src/client/rsg-components/Heading/HeadingRenderer.tsx
@@ -44,7 +44,7 @@ const HeadingRenderer: React.FunctionComponent<HeadingProps> = ({
 	children,
 	...props
 }) => {
-	const Tag = `h${level}` as ('h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6');
+	const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 	const headingClasses = cx(classes.heading, classes[`heading${level}`]);
 
 	return (
@@ -59,5 +59,6 @@ HeadingRenderer.propTypes = {
 	level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]).isRequired,
 	children: PropTypes.node,
 };
+HeadingRenderer.displayName = 'HeadingRenderer';
 
 export default Styled<HeadingProps>(styles)(HeadingRenderer);

--- a/src/client/rsg-components/Link/LinkRenderer.tsx
+++ b/src/client/rsg-components/Link/LinkRenderer.tsx
@@ -45,5 +45,6 @@ LinkRenderer.propTypes = {
 	className: PropTypes.string,
 	href: PropTypes.string,
 };
+LinkRenderer.displayName = 'LinkRenderer';
 
 export default Styled<LinkProps>(styles)(LinkRenderer);

--- a/src/client/rsg-components/Logo/LogoRenderer.tsx
+++ b/src/client/rsg-components/Logo/LogoRenderer.tsx
@@ -16,4 +16,6 @@ export const LogoRenderer: React.FunctionComponent<JssInjectedProps> = ({ classe
 	return <h1 className={classes.logo}>{children}</h1>;
 };
 
+LogoRenderer.displayName = 'LogoRenderer';
+
 export default Styled<JssInjectedProps>(styles)(LogoRenderer);

--- a/src/client/rsg-components/Markdown/Blockquote/BlockquoteRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Blockquote/BlockquoteRenderer.tsx
@@ -34,5 +34,6 @@ BlockquoteRenderer.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
+BlockquoteRenderer.displayName = 'BlockquoteRenderer';
 
 export default Styled<BlockquoteProps>(styles)(BlockquoteRenderer);

--- a/src/client/rsg-components/Markdown/Details/DetailsRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Details/DetailsRenderer.tsx
@@ -24,5 +24,6 @@ DetailsRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+DetailsRenderer.displayName = 'DetailsRenderer';
 
 export default Styled<DetailsProps>(styles)(DetailsRenderer);

--- a/src/client/rsg-components/Markdown/Details/DetailsSummaryRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Details/DetailsSummaryRenderer.tsx
@@ -33,5 +33,6 @@ DetailsSummaryRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+DetailsSummaryRenderer.displayName = 'DetailsSummaryRenderer';
 
 export default Styled<DetailsSummaryProps>(styles)(DetailsSummaryRenderer);

--- a/src/client/rsg-components/Markdown/Hr/HrRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Hr/HrRenderer.tsx
@@ -17,5 +17,6 @@ export const HrRenderer: React.FunctionComponent<JssInjectedProps> = ({ classes 
 HrRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 };
+HrRenderer.displayName = 'HrRenderer';
 
 export default Styled<JssInjectedProps>(styles)(HrRenderer);

--- a/src/client/rsg-components/Markdown/List/ListRenderer.tsx
+++ b/src/client/rsg-components/Markdown/List/ListRenderer.tsx
@@ -53,5 +53,6 @@ ListRenderer.propTypes = {
 ListRenderer.defaultProps = {
 	ordered: false,
 };
+ListRenderer.displayName = 'ListRenderer';
 
 export default Styled<ListProps>(styles)(ListRenderer);

--- a/src/client/rsg-components/Markdown/MarkdownHeading/MarkdownHeadingRenderer.tsx
+++ b/src/client/rsg-components/Markdown/MarkdownHeading/MarkdownHeadingRenderer.tsx
@@ -37,5 +37,6 @@ MarkdownHeadingRenderer.propTypes = {
 	children: PropTypes.node,
 	id: PropTypes.string,
 };
+MarkdownHeadingRenderer.displayName = 'MarkdownHeadingRenderer';
 
 export default Styled<MarkdownHeadingProps>(styles)(MarkdownHeadingRenderer);

--- a/src/client/rsg-components/Markdown/Pre/PreRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Pre/PreRenderer.tsx
@@ -52,5 +52,6 @@ PreRenderer.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
+PreRenderer.displayName = 'PreRenderer';
 
 export default Styled<PrePropsWithClasses>(styles)(PreRenderer);

--- a/src/client/rsg-components/Markdown/Table/TableCellRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Table/TableCellRenderer.tsx
@@ -42,5 +42,6 @@ TableCellRenderer.propTypes = {
 TableCellRenderer.defaultProps = {
 	header: false,
 };
+TableCellRenderer.displayName = 'TableCellRenderer';
 
 export default Styled<TableCellProps>(styles)(TableCellRenderer);

--- a/src/client/rsg-components/Markdown/Table/TableHeadRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Table/TableHeadRenderer.tsx
@@ -24,5 +24,6 @@ TableHeadRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+TableHeadRenderer.displayName = 'TableHeadRenderer';
 
 export default Styled<TableHeadProps>(styles)(TableHeadRenderer);

--- a/src/client/rsg-components/Markdown/Table/TableRenderer.tsx
+++ b/src/client/rsg-components/Markdown/Table/TableRenderer.tsx
@@ -23,5 +23,6 @@ TableRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+TableRenderer.displayName = 'TableRenderer';
 
 export default Styled<TableProps>(styles)(TableRenderer);

--- a/src/client/rsg-components/Message/MessageRenderer.tsx
+++ b/src/client/rsg-components/Message/MessageRenderer.tsx
@@ -34,5 +34,6 @@ MessageRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+MessageRenderer.displayName = 'MessageRenderer';
 
 export default Styled<MessageProps>(styles)(MessageRenderer);

--- a/src/client/rsg-components/Name/NameRenderer.tsx
+++ b/src/client/rsg-components/Name/NameRenderer.tsx
@@ -37,5 +37,6 @@ NameRenderer.propTypes = {
 	children: PropTypes.node.isRequired,
 	deprecated: PropTypes.bool,
 };
+NameRenderer.displayName = 'NameRenderer';
 
 export default Styled<NameProps>(styles)(NameRenderer);

--- a/src/client/rsg-components/Para/ParaRenderer.tsx
+++ b/src/client/rsg-components/Para/ParaRenderer.tsx
@@ -34,5 +34,6 @@ ParaRenderer.propTypes = {
 	semantic: PropTypes.oneOf(['p']),
 	children: PropTypes.node.isRequired,
 };
+ParaRenderer.displayName = 'ParaRenderer';
 
 export default Styled<ParaProps>(styles)(ParaRenderer);

--- a/src/client/rsg-components/Pathline/PathlineRenderer.tsx
+++ b/src/client/rsg-components/Pathline/PathlineRenderer.tsx
@@ -36,4 +36,6 @@ export const PathlineRenderer: React.FunctionComponent<JssInjectedProps> = ({
 	);
 };
 
+PathlineRenderer.displayName = 'PathlineRenderer';
+
 export default Styled<JssInjectedProps>(styles)(PathlineRenderer);

--- a/src/client/rsg-components/Playground/PlaygroundRenderer.tsx
+++ b/src/client/rsg-components/Playground/PlaygroundRenderer.tsx
@@ -90,5 +90,6 @@ PlaygroundRenderer.propTypes = {
 	tabBody: PropTypes.node.isRequired,
 	toolbar: PropTypes.node.isRequired,
 };
+PlaygroundRenderer.displayName = 'PlaygroundRenderer';
 
 export default Styled<PlaygroundRendererProps>(styles)(PlaygroundRenderer);

--- a/src/client/rsg-components/PlaygroundError/PlaygroundErrorRenderer.tsx
+++ b/src/client/rsg-components/PlaygroundError/PlaygroundErrorRenderer.tsx
@@ -27,5 +27,6 @@ PlaygroundErrorRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	message: PropTypes.string.isRequired,
 };
+PlaygroundErrorRenderer.displayName = 'PlaygroundErrorRenderer';
 
 export default Styled<PlaygroundErrorProps>(styles)(PlaygroundErrorRenderer);

--- a/src/client/rsg-components/ReactComponent/ReactComponentRenderer.tsx
+++ b/src/client/rsg-components/ReactComponent/ReactComponentRenderer.tsx
@@ -89,5 +89,6 @@ ReactComponentRenderer.propTypes = {
 	examples: PropTypes.node,
 	isolated: PropTypes.bool,
 };
+ReactComponentRenderer.displayName = 'ReactComponentRenderer';
 
 export default Styled<ReactComponentRendererProps>(styles)(ReactComponentRenderer);

--- a/src/client/rsg-components/Ribbon/RibbonRenderer.tsx
+++ b/src/client/rsg-components/Ribbon/RibbonRenderer.tsx
@@ -47,14 +47,14 @@ export const RibbonRenderer: React.FunctionComponent<RibbonProps> = ({ classes, 
 	);
 };
 
-RibbonRenderer.defaultProps = {
-	text: 'Fork me on GitHub',
-};
-
 RibbonRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	url: PropTypes.string.isRequired,
 	text: PropTypes.string,
 };
+RibbonRenderer.defaultProps = {
+	text: 'Fork me on GitHub',
+};
+RibbonRenderer.displayName = 'RibbonRenderer';
 
 export default Styled<RibbonProps>(styles)(RibbonRenderer);

--- a/src/client/rsg-components/Section/SectionRenderer.tsx
+++ b/src/client/rsg-components/Section/SectionRenderer.tsx
@@ -70,5 +70,6 @@ SectionRenderer.propTypes = {
 	depth: PropTypes.number.isRequired,
 	pagePerSection: PropTypes.bool,
 };
+SectionRenderer.displayName = 'SectionRenderer';
 
 export default Styled<SectionRendererProps>(styles)(SectionRenderer);

--- a/src/client/rsg-components/SectionHeading/SectionHeadingRenderer.tsx
+++ b/src/client/rsg-components/SectionHeading/SectionHeadingRenderer.tsx
@@ -74,5 +74,6 @@ SectionHeadingRenderer.propTypes = {
 	depth: PropTypes.number.isRequired,
 	deprecated: PropTypes.bool,
 };
+SectionHeadingRenderer.displayName = 'SectionHeadingRenderer';
 
 export default Styled<SectionHeadingRendererProps>(styles)(SectionHeadingRenderer);

--- a/src/client/rsg-components/Sections/SectionsRenderer.tsx
+++ b/src/client/rsg-components/Sections/SectionsRenderer.tsx
@@ -22,5 +22,6 @@ SectionsRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node,
 };
+SectionsRenderer.displayName = 'SectionsRenderer';
 
 export default Styled<SectionsRendererProps>(styles)(SectionsRenderer);

--- a/src/client/rsg-components/StyleGuide/StyleGuideRenderer.tsx
+++ b/src/client/rsg-components/StyleGuide/StyleGuideRenderer.tsx
@@ -107,5 +107,6 @@ StyleGuideRenderer.propTypes = {
 	toc: PropTypes.node.isRequired,
 	hasSidebar: PropTypes.bool,
 };
+StyleGuideRenderer.displayName = 'StyleGuideRenderer';
 
 export default Styled<StyleGuideRendererProps>(styles)(StyleGuideRenderer);

--- a/src/client/rsg-components/Styled/Styled.tsx
+++ b/src/client/rsg-components/Styled/Styled.tsx
@@ -12,7 +12,10 @@ export default function StyleHOC<P extends JssInjectedProps>(
 	styles: (t: Rsg.Theme) => Styles<string>
 ): (WrappedComponent: ComponentType<P>) => ComponentType<Omit<P, keyof JssInjectedProps>> {
 	return (WrappedComponent: ComponentType<P>) => {
-		const componentName = WrappedComponent.name.replace(/Renderer$/, '');
+		const componentName = (WrappedComponent.displayName || WrappedComponent.name).replace(
+			/Renderer$/,
+			''
+		);
 		return class extends Component<Omit<P, keyof JssInjectedProps>> {
 			public static displayName = `Styled(${componentName})`;
 			public static contextType = Context;

--- a/src/client/rsg-components/TabButton/TabButtonRenderer.tsx
+++ b/src/client/rsg-components/TabButton/TabButtonRenderer.tsx
@@ -79,5 +79,6 @@ TabButtonRenderer.propTypes = {
 TabButtonRenderer.defaultProps = {
 	active: false,
 };
+TabButtonRenderer.displayName = 'TabButtonRenderer';
 
 export default Styled<TabButtonProps>(styles)(TabButtonRenderer);

--- a/src/client/rsg-components/Table/TableRenderer.tsx
+++ b/src/client/rsg-components/Table/TableRenderer.tsx
@@ -94,5 +94,6 @@ TableRenderer.propTypes = {
 	rows: PropTypes.arrayOf(PropTypes.object).isRequired,
 	getRowKey: PropTypes.func.isRequired,
 };
+TableRenderer.displayName = 'TableRenderer';
 
 export default Styled<TableProps>(styles)(TableRenderer);

--- a/src/client/rsg-components/TableOfContents/TableOfContentsRenderer.tsx
+++ b/src/client/rsg-components/TableOfContents/TableOfContentsRenderer.tsx
@@ -74,5 +74,6 @@ TableOfContentsRenderer.propTypes = {
 	searchTerm: PropTypes.string.isRequired,
 	onSearchTermChange: PropTypes.func.isRequired,
 };
+TableOfContentsRenderer.displayName = 'TableOfContentsRenderer';
 
 export default Styled<TableOfContentsRendererProps>(styles)(TableOfContentsRenderer);

--- a/src/client/rsg-components/Text/TextRenderer.tsx
+++ b/src/client/rsg-components/Text/TextRenderer.tsx
@@ -82,5 +82,6 @@ TextRenderer.defaultProps = {
 	color: 'base',
 	underlined: false,
 };
+TextRenderer.displayName = 'TextRenderer';
 
 export default Styled<TextProps>(styles)(TextRenderer);

--- a/src/client/rsg-components/ToolbarButton/ToolbarButtonRenderer.tsx
+++ b/src/client/rsg-components/ToolbarButton/ToolbarButtonRenderer.tsx
@@ -89,5 +89,6 @@ ToolbarButtonRenderer.propTypes = {
 	testId: PropTypes.string,
 	children: PropTypes.node,
 };
+ToolbarButtonRenderer.displayName = 'ToolbarButtonRenderer';
 
 export default Styled<ToolbarButtonProps>(styles)(ToolbarButtonRenderer);

--- a/src/client/rsg-components/Tooltip/TooltipRenderer.tsx
+++ b/src/client/rsg-components/Tooltip/TooltipRenderer.tsx
@@ -48,4 +48,6 @@ function TooltipRenderer({ classes, children, content, placement = 'top' }: Tool
 	);
 }
 
+TooltipRenderer.displayName = 'TooltipRenderer';
+
 export default Styled<TooltipProps>(styles)(TooltipRenderer);

--- a/src/client/rsg-components/Type/TypeRenderer.tsx
+++ b/src/client/rsg-components/Type/TypeRenderer.tsx
@@ -23,5 +23,6 @@ TypeRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node.isRequired,
 };
+TypeRenderer.displayName = 'TypeRenderer';
 
 export default Styled<TypeProps>(styles)(TypeRenderer);

--- a/src/client/rsg-components/Version/VersionRenderer.tsx
+++ b/src/client/rsg-components/Version/VersionRenderer.tsx
@@ -29,5 +29,6 @@ VersionRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	children: PropTypes.node,
 };
+VersionRenderer.displayName = 'VersionRenderer';
 
 export default Styled<VersionProps>(styles)(VersionRenderer);

--- a/src/client/rsg-components/Welcome/WelcomeRenderer.tsx
+++ b/src/client/rsg-components/Welcome/WelcomeRenderer.tsx
@@ -45,5 +45,6 @@ WelcomeRenderer.propTypes = {
 	classes: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,
 	patterns: PropTypes.array.isRequired,
 };
+WelcomeRenderer.displayName = 'WelcomeRenderer';
 
 export default Styled<WelcomeProps>(styles)(WelcomeRenderer);


### PR DESCRIPTION
Fix https://github.com/styleguidist/react-styleguidist/issues/1525

This makes the `Styled` HOC aware of a static `displayName` which will survive code-minifying and therefore will apply custom styles even when the component function names are mangled. 



---

Re: https://github.com/styleguidist/react-styleguidist/issues/1525#issuecomment-695938069 I see how [my comment](https://github.com/styleguidist/react-styleguidist/issues/1525#issuecomment-695775762) was offending and am sorry! I don't take your work here for granted and am grateful for your contribution to the react eco-system 🙏 

I was salty because I offered submitting a PR [8 months ago](https://github.com/styleguidist/react-styleguidist/issues/1525#issuecomment-577207560) and have not gotten any feedback from maintainers but a bot closing down my attempt to start a conversation. 

Still this does not excuse me "demanding" your involvement. So again: I'm sorry and thanks for giving me the chance to learn. 