### PR TITLE
Update ExamplesRenderer.tsx

### DIFF
--- a/src/client/rsg-components/Examples/ExamplesRenderer.tsx
+++ b/src/client/rsg-components/Examples/ExamplesRenderer.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Styled, { JssInjectedProps } from 'rsg-components/Styled';
+import * as Rsg from '../../../typings';
 
-const styles = () => ({
-	// Just default jss-isolate rules
-	root: {},
+const styles = ({ fontSize }: Rsg.Theme) => ({
+	article: {
+		fontSize: fontSize.text,
+	},
 });
 
 interface ExamplesRendererProps extends JssInjectedProps {
@@ -18,7 +20,7 @@ export const ExamplesRenderer: React.FunctionComponent<ExamplesRendererProps> = 
 	children,
 }) => {
 	return (
-		<article className={classes.root} data-testid={`${name}-examples`}>
+		<article className={classes.article} data-testid={`${name}-examples`}>
 			{children}
 		</article>
 	);


### PR DESCRIPTION
Fix issue #1661  with font size.
ExamplesRenderer.tsx is updated so that now paragraphs from Readme.md have the same font size as other text after the theme is set.