### PR TITLE
Fix Para components should use `theme.fontSize.text`

### DIFF
--- a/src/client/rsg-components/Para/ParaRenderer.tsx
+++ b/src/client/rsg-components/Para/ParaRenderer.tsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import Styled, { JssInjectedProps } from 'rsg-components/Styled';
 import * as Rsg from '../../../typings';
 
-export const styles = ({ space, color, fontFamily }: Rsg.Theme) => ({
+export const styles = ({ space, color, fontFamily, fontSize }: Rsg.Theme) => ({
 	para: {
 		marginTop: 0,
 		marginBottom: space[2],
 		color: color.base,
 		fontFamily: fontFamily.base,
-		fontSize: 'inherit',
+		fontSize: fontSize.text,
 		lineHeight: 1.5,
 	},
 });


### PR DESCRIPTION
Resolved:

- #1661 

This image shows that I've changed the `fontSize.text` in the config.

![React-Styleguidist-Style-Guide](https://user-images.githubusercontent.com/1703219/99527793-bae64b80-29e0-11eb-822f-117dcd28c621.png)

config

```
module.exports = {
  theme: {
    fontSize: {
      text: 36,
    },
  },
};
```

