### PR TITLE
Fix Type description tooltip isn't spaced properly in Firefox

### DIFF
--- a/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
+++ b/src/client/rsg-components/ComplexType/ComplexTypeRenderder.tsx
@@ -10,8 +10,12 @@ export const styles = ({ space }: Rsg.Theme) => ({
 		alignItems: 'center',
 		display: 'inline-flex',
 	},
+	name: {
+		flexShrink: 0,
+	},
 	icon: {
 		marginLeft: space[0],
+		flexShrink: 0,
 	},
 });
 
@@ -24,7 +28,9 @@ function ComplexTypeRenderer({ classes, name, raw }: ComplexTypeProps) {
 	return (
 		<Tooltip placement="right" content={raw}>
 			<span className={classes.complexType}>
-				<Text>{name}</Text>
+				<span className={classes.name}>
+					<Text>{name}</Text>
+				</span>
 				<MdInfoOutline className={classes.icon} />
 			</span>
 		</Tooltip>


### PR DESCRIPTION
Resolved:

- #1723 

The steps to reproduce:
1. Use Firefox and TypeScript project
2. Run the styleguide and open the props & methods table
3. Open the dev-tool and modify the type name to something very long. (for example: `function` => `functionsdfakdshjaksdjfka`)
4. Reproduce 🎉 

Before the change:
<img width="828" alt="スクリーンショット 2020-12-03 21 50 56" src="https://user-images.githubusercontent.com/1703219/101020558-0b999f00-35b2-11eb-84c8-2174c9e2f535.png">

After the change:
<img width="859" alt="スクリーンショット 2020-12-03 21 51 25" src="https://user-images.githubusercontent.com/1703219/101020581-13594380-35b2-11eb-8bc6-d06c32be4516.png">


