### PR TITLE
fix: generate typings directly in lib instead of lib/src

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -52,7 +52,7 @@ jobs:
       
       - name: Prepare styleguidist
         run: |
-          npm run ci
+          npm ci
           npm run compile
 
       - name: Run integration tests with Cypress

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,22 +33,19 @@ jobs:
       - run: |
           # Compile JS
           npm run compile
-
           # Build all examples
           npm run build:basic
           npm run build:customised
           npm run build:sections
-
           # Check that examples really works: no JS errors on load
           npm run test:browser:pre
           npm run test:browser:basic
           npm run test:browser:customised
           npm run test:browser:sections
-
-      - uses: cypress-io/github-action@v2
-        with: 
-          start: node test/run.server.js
-          wait-on: http://localhost:8082
+          # Run integration tests with Cypress
+          npm run test:cypress:startServer &
+          npm run test:cypress:startServer:post
+          npm run test:cypress:run
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,6 +43,7 @@ jobs:
 
   cypress:
     runs-on: ubuntu-latest
+    container: cypress/included:6.5.0
 
     steps:
       - name: Checkout

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,6 +43,7 @@ jobs:
           npm run test:browser:customised
           npm run test:browser:sections
           # Run integration tests with Cypress
+          npm i --no-save wait-on
           npm run test:cypress:startServer &
           npm run test:cypress:startServer:post
           npm run test:cypress:run

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,6 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    container: cypress/included:6.5.0
 
     steps:
       - uses: actions/checkout@v2
@@ -46,8 +45,10 @@ jobs:
 
       - name: Run Cypress tests
         run: |
+          npm run test:cypress:pre
           npm run test:cypress:startServer &
-          npm run test:cypress:run          
+          npm run test:cypress:startServer:post
+          npm run test:cypress:run      
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/setup-node@v1
 
       - run: npm ci
-      - run: |
+      - name: Test styleguides with puppeteer
+        run: |
           # Compile JS
           npm run compile
           # Build all examples

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     container:
-      image: cypress/included:3.0.2
+      image: cypress/included:3.2.0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,8 +22,6 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/included:6.6.0
 
     steps:
       - uses: actions/checkout@v2
@@ -43,11 +41,18 @@ jobs:
           npm run test:browser:customised
           npm run test:browser:sections
 
+  cypress:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Run integration tests with Cypress
         uses: cypress-io/github-action@v2
         with:
+          build: npm run compile
           start: npm run test:cypress:startServer
-          config-file: serve.json
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,37 +29,25 @@ jobs:
       - uses: actions/setup-node@v1
 
       - run: npm ci
-      - name: Test styleguides with puppeteer
+      - run: npm run compile
+
+      - name: Build all examples
         run: |
-          # Compile JS
-          npm run compile
-          # Build all examples
           npm run build:basic
           npm run build:customised
           npm run build:sections
-          # Check that examples really works: no JS errors on load
+
+      - name: Check that examples really works - no JS errors on load
+        run: |
           npm run test:browser:pre
           npm run test:browser:basic
           npm run test:browser:customised
           npm run test:browser:sections
 
-  cypress:
-    runs-on: ubuntu-latest
-    container: cypress/included:6.5.0
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      
-      - name: Prepare styleguidist
-        run: |
-          npm ci
-          npm run compile
-
-      - name: Run integration tests with Cypress
+      - name: Run Cypress tests
         run: |
           npm run test:cypress:startServer &
-          npm run test:cypress:run
+          npm run test:cypress:run          
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,20 +31,22 @@ jobs:
       - run: |
           # Compile JS
           npm run compile
+
           # Build all examples
           npm run build:basic
           npm run build:customised
           npm run build:sections
+
           # Check that examples really works: no JS errors on load
           npm run test:browser:pre
           npm run test:browser:basic
           npm run test:browser:customised
           npm run test:browser:sections
-          # Run integration tests with Cypress
-          npm run test:cypress:pre
-          npm run test:cypress:startServer &
-          npm run test:cypress:startServer:post
-          npm run test:cypress:run
+
+      - uses: cypress-io/github-action@v2
+        with: 
+          start: node test/run.server.js
+          wait-on: http://localhost:8082
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,6 +22,8 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
+    container:
+      image: cypress/included:3.0.2
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     container:
-      image: cypress/included:3.2.0
+      image: cypress/included:6.6.0
 
     steps:
       - uses: actions/checkout@v2
@@ -42,11 +42,12 @@ jobs:
           npm run test:browser:basic
           npm run test:browser:customised
           npm run test:browser:sections
-          # Run integration tests with Cypress
-          npm i --no-save wait-on
-          npm run test:cypress:startServer &
-          npm run test:cypress:startServer:post
-          npm run test:cypress:run
+
+      - name: Run integration tests with Cypress
+        uses: cypress-io/github-action@v2
+        with:
+          start: npm run test:cypress:startServer
+          config-file: serve.json
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,6 +22,7 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
+    container: cypress/included:6.5.0
 
     steps:
       - uses: actions/checkout@v2
@@ -48,12 +49,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      
+      - name: Prepare styleguidist
+        run: |
+          npm run ci
+          npm run compile
 
       - name: Run integration tests with Cypress
-        uses: cypress-io/github-action@v2
-        with:
-          build: npm run compile
-          start: npm run test:cypress:startServer
+        run: |
+          npm run test:cypress:startServer &
+          npm run test:cypress:run
 
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "test:browser:customised": "node test/browser.js examples/customised/styleguide/index.html",
     "test:browser:sections": "node test/browser.js examples/sections/styleguide/index.html",
     "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-    "test:cypress:pre": "npm i --no-save cypress@6.5.0 wait-on",
+    "test:cypress:pre": "npm i --no-save cypress@3.0.2 wait-on",
     "test:cypress:open": "cypress open",
     "test:cypress:run": "cypress run",
     "test:cypress:startServer": "node test/run.server.js",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "test:browser:customised": "node test/browser.js examples/customised/styleguide/index.html",
     "test:browser:sections": "node test/browser.js examples/sections/styleguide/index.html",
     "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-    "test:cypress:pre": "npm i --no-save cypress@3.0.2 wait-on",
+    "test:cypress:pre": "npm i --no-save cypress@6.5.0 wait-on",
     "test:cypress:open": "cypress open",
     "test:cypress:run": "cypress run",
     "test:cypress:startServer": "node test/run.server.js",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "test:browser:customised": "node test/browser.js examples/customised/styleguide/index.html",
     "test:browser:sections": "node test/browser.js examples/sections/styleguide/index.html",
     "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-    "test:cypress:pre": "npm i --no-save cypress@6.6.0 wait-on",
+    "test:cypress:pre": "npm i --no-save cypress@6.5.0 wait-on",
     "test:cypress:open": "cypress open",
     "test:cypress:run": "cypress run",
     "test:cypress:startServer": "node test/run.server.js",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "test:browser:customised": "node test/browser.js examples/customised/styleguide/index.html",
     "test:browser:sections": "node test/browser.js examples/sections/styleguide/index.html",
     "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-    "test:cypress:pre": "npm i --no-save cypress@3.2.0 wait-on",
+    "test:cypress:pre": "npm i --no-save cypress@6.6.0 wait-on",
     "test:cypress:open": "cypress open",
     "test:cypress:run": "cypress run",
     "test:cypress:startServer": "node test/run.server.js",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "test:browser:customised": "node test/browser.js examples/customised/styleguide/index.html",
     "test:browser:sections": "node test/browser.js examples/sections/styleguide/index.html",
     "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-    "test:cypress:pre": "npm i --no-save cypress@3.0.2 wait-on",
+    "test:cypress:pre": "npm i --no-save cypress@3.2.0 wait-on",
     "test:cypress:open": "cypress open",
     "test:cypress:run": "cypress run",
     "test:cypress:startServer": "node test/run.server.js",

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -4,6 +4,8 @@
 		// only generate typings when using this tsconfig
 		"declaration": true
 	},
+	// ignore the dangerfile in calculation of the root folder
+	"files": [],
 	// avoid generating typings for tests and mocks
 	"exclude": [
 		"dangerfile.ts",


### PR DESCRIPTION
in version 11.1.5 when we moved to Github Actions we added a dangerfile.ts to the tsconfig.json
This file, since it is outside the src folder, changed the reference rootFolder for typings to calculate.
This quick adjustment should fix the typings.

I also updated CI to have clearer action steps (where we can measure progress from a high level).
Cypress 3.0.2 does not seem to work well with the Linux version on the github action docker images.