### PR TITLE
feat:Added the language highlighter option to allow users to freely expand the list of hard-coded languages.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -78,6 +78,22 @@ module.exports = {
 }
 ```
 
+## `highlightCodeLanguages`
+
+Type: `String[]`, default: `[]`
+
+Array of languages that allow you to decide which syntax highlighter to add.
+
+By default the following languages are supported.
+
+> atom, bash, clike, css, diff, flow, graphql, html, javascript, js, json, jsx, less, markdown, markup, mathml, md, rss, scss, shell, ssml, svg, ts, tsx, typescript, webmanifest, xml
+
+```javascript
+module.exports = {
+  highlightCodeLanguages: ['java', 'ruby']
+}
+```
+
 ## `configureServer`
 
 Type: `Function`, optional

--- a/src/loaders/styleguide-loader.ts
+++ b/src/loaders/styleguide-loader.ts
@@ -13,6 +13,7 @@ import getSections from './utils/getSections';
 import filterComponentsWithExample from './utils/filterComponentsWithExample';
 import slugger from './utils/slugger';
 import resolveESModule from './utils/resolveESModule';
+import { getHighlightCodeLanguages } from './utils/highlightCode';
 import * as Rsg from '../typings';
 
 const logger = createLogger('rsg');
@@ -35,7 +36,7 @@ const CLIENT_CONFIG_OPTIONS = [
 const STYLE_VARIABLE_NAME = '__rsgStyles';
 const THEME_VARIABLE_NAME = '__rsgTheme';
 
-export default function() {}
+export default function () {}
 export function pitch(this: Rsg.StyleguidistLoaderContext) {
 	// Clear cache so it would detect new or renamed files
 	fileExistsCaseInsensitive.clearCache();
@@ -44,6 +45,9 @@ export function pitch(this: Rsg.StyleguidistLoaderContext) {
 	slugger.reset();
 
 	const config = this._styleguidist;
+
+	// get highlight code languages. Array of languages that allow you to decide which syntax highlighter to add
+	getHighlightCodeLanguages(config.highlightCodeLanguages);
 
 	let sections = getSections(config.sections, config);
 	if (config.skipComponentsWithoutExample) {

--- a/src/loaders/styleguide-loader.ts
+++ b/src/loaders/styleguide-loader.ts
@@ -36,7 +36,7 @@ const CLIENT_CONFIG_OPTIONS = [
 const STYLE_VARIABLE_NAME = '__rsgStyles';
 const THEME_VARIABLE_NAME = '__rsgTheme';
 
-export default function () {}
+export default function() {}
 export function pitch(this: Rsg.StyleguidistLoaderContext) {
 	// Clear cache so it would detect new or renamed files
 	fileExistsCaseInsensitive.clearCache();

--- a/src/loaders/utils/__tests__/__snapshots__/chunkify.spec.ts.snap
+++ b/src/loaders/utils/__tests__/__snapshots__/chunkify.spec.ts.snap
@@ -57,7 +57,7 @@ Array [
   },
   Object {
     "content": "\`\`\`jsx
-<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>h2</span><span class=\\"token punctuation\\">></span></span><span class=\\"token plain-text\\">This is Highlighted!</span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>h2</span><span class=\\"token punctuation\\">></span></span>
+<h2>This is Highlighted!</h2>
 \`\`\`",
     "type": "markdown",
   },
@@ -135,7 +135,7 @@ This code example should be rendered as a playground:",
     "content": "This should be just highlighted:
 
 \`\`\`jsx
-<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>h4</span><span class=\\"token punctuation\\">></span></span><span class=\\"token plain-text\\">Hello Markdown!</span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>h4</span><span class=\\"token punctuation\\">></span></span>
+<h4>Hello Markdown!</h4>
 \`\`\`
 
 This should be highlighted too:

--- a/src/loaders/utils/__tests__/highlightCode.spec.ts
+++ b/src/loaders/utils/__tests__/highlightCode.spec.ts
@@ -1,9 +1,12 @@
 import glogg from 'glogg';
-import highlightCode from '../highlightCode';
+import highlightCode, { getHighlightCodeLanguages, getLanguages } from '../highlightCode';
 
 const logger = glogg('rsg');
 
 const code = '<p>Hello React</p>';
+
+// run getHighlightCodeLanguages with ['java']
+getHighlightCodeLanguages(['java']);
 
 it('should highlight code with specified language', () => {
 	const actual = highlightCode(code, 'html');
@@ -17,11 +20,17 @@ it('should warn when language not found', () => {
 	const actual = highlightCode(code, 'pizza');
 	expect(actual).toBe(code);
 	expect(warn).toBeCalledWith(
-		'Syntax highlighting for “pizza” isn’t supported. Supported languages are: markup, html, mathml, svg, xml, ssml, atom, rss, css, clike, javascript, js, markdown, md, scss, less, flow, typescript, ts, jsx, tsx, graphql, json, webmanifest, bash, shell, diff.'
+		`Syntax highlighting for “pizza” isn’t supported. Supported languages are: ${getLanguages()
+			.sort()
+			.join(', ')}.`
 	);
 });
 
 it('should not highlight code without language', () => {
 	const actual = highlightCode(code);
 	expect(actual).toBe(code);
+});
+
+it('should includes language after run getHighlightCodeLanguages', () => {
+	expect(getLanguages().includes('java')).toBe(true);
 });

--- a/src/loaders/utils/highlightCode.ts
+++ b/src/loaders/utils/highlightCode.ts
@@ -1,6 +1,6 @@
 import createLogger from 'glogg';
 import * as Prism from 'prismjs';
-import loadLanguages from 'prismjs/components/index';
+import loadLanguages from 'prismjs/components/';
 
 const logger = createLogger('rsg');
 
@@ -59,5 +59,5 @@ export default function highlightCode(code: string, lang?: string): string {
  * @returns {void}
  */
 export function getHighlightCodeLanguages(langs: string[] = []): void {
-	(loadLanguages as any)([...DEFAULT_LANGUAGES, ...langs]);
+	loadLanguages([...DEFAULT_LANGUAGES, ...langs]);
 }

--- a/src/loaders/utils/highlightCode.ts
+++ b/src/loaders/utils/highlightCode.ts
@@ -1,6 +1,6 @@
 import createLogger from 'glogg';
 import * as Prism from 'prismjs';
-import loadLanguages from 'prismjs/components/';
+import loadLanguages from 'prismjs/components/index';
 
 const logger = createLogger('rsg');
 

--- a/src/loaders/utils/highlightCode.ts
+++ b/src/loaders/utils/highlightCode.ts
@@ -1,27 +1,30 @@
 import createLogger from 'glogg';
 import * as Prism from 'prismjs';
-
-import 'prismjs/components/prism-clike';
-import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-markdown';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-css-extras';
-import 'prismjs/components/prism-scss';
-import 'prismjs/components/prism-less';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-flow';
-import 'prismjs/components/prism-typescript';
-import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-tsx';
-import 'prismjs/components/prism-graphql';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-diff';
+import loadLanguages from 'prismjs/components/index';
 
 const logger = createLogger('rsg');
 
+const DEFAULT_LANGUAGES = [
+	'clike',
+	'markup',
+	'markdown',
+	'css',
+	'css',
+	'scss',
+	'less',
+	'javascript',
+	'flow',
+	'typescript',
+	'jsx',
+	'tsx',
+	'graphql',
+	'json',
+	'bash',
+	'diff',
+];
 const IGNORED_LANGUAGES = ['extend', 'insertBefore', 'DFS'];
-const getLanguages = () => Object.keys(Prism.languages).filter(x => !IGNORED_LANGUAGES.includes(x));
+export const getLanguages = () =>
+	Object.keys(Prism.languages).filter((x) => !IGNORED_LANGUAGES.includes(x));
 
 /**
  * Highlight code.
@@ -37,13 +40,24 @@ export default function highlightCode(code: string, lang?: string): string {
 
 	const grammar = Prism.languages[lang];
 	if (!grammar) {
+		// Sort by the first letter a to z to make it easier to find relevant language configurations
 		logger.warn(
-			`Syntax highlighting for “${lang}” isn’t supported. Supported languages are: ${getLanguages().join(
-				', '
-			)}.`
+			`Syntax highlighting for “${lang}” isn’t supported. Supported languages are: ${getLanguages()
+				.sort()
+				.join(', ')}.`
 		);
 		return code;
 	}
 
 	return Prism.highlight(code, grammar, lang);
+}
+
+/**
+ * Get highlight code languages.
+ *
+ * @param {Array<string>} languages
+ * @returns {void}
+ */
+export function getHighlightCodeLanguages(langs: string[] = []): void {
+	(loadLanguages as any)([...DEFAULT_LANGUAGES, ...langs]);
 }

--- a/src/loaders/utils/highlightCode.ts
+++ b/src/loaders/utils/highlightCode.ts
@@ -4,7 +4,7 @@ import loadLanguages from 'prismjs/components/index';
 
 const logger = createLogger('rsg');
 
-const DEFAULT_LANGUAGES = ['clike','markup','markdown','css','css','scss','less','javascript','flow','typescript','jsx','tsx','graphql','json','bash','diff'];
+const DEFAULT_LANGUAGES = ['clike', 'markup', 'markdown', 'css', 'css', 'scss', 'less', 'javascript', 'flow', 'typescript', 'jsx', 'tsx', 'graphql', 'json', 'bash', 'diff'];
 const IGNORED_LANGUAGES = ['extend', 'insertBefore', 'DFS'];
 export const getLanguages = () =>
 	Object.keys(Prism.languages).filter((x) => !IGNORED_LANGUAGES.includes(x));

--- a/src/loaders/utils/highlightCode.ts
+++ b/src/loaders/utils/highlightCode.ts
@@ -4,24 +4,7 @@ import loadLanguages from 'prismjs/components/index';
 
 const logger = createLogger('rsg');
 
-const DEFAULT_LANGUAGES = [
-	'clike',
-	'markup',
-	'markdown',
-	'css',
-	'css',
-	'scss',
-	'less',
-	'javascript',
-	'flow',
-	'typescript',
-	'jsx',
-	'tsx',
-	'graphql',
-	'json',
-	'bash',
-	'diff',
-];
+const DEFAULT_LANGUAGES = ['clike','markup','markdown','css','css','scss','less','javascript','flow','typescript','jsx','tsx','graphql','json','bash','diff'];
 const IGNORED_LANGUAGES = ['extend', 'insertBefore', 'DFS'];
 export const getLanguages = () =>
 	Object.keys(Prism.languages).filter((x) => !IGNORED_LANGUAGES.includes(x));

--- a/src/scripts/schemas/config.ts
+++ b/src/scripts/schemas/config.ts
@@ -88,6 +88,11 @@ const configSchema: Record<StyleguidistConfigKey, ConfigSchemaOptions<Rsg.Styleg
 	contextDependencies: {
 		type: 'array',
 	},
+	highlightCodeLanguages: {
+		type: 'array',
+		default: [],
+		example: ['java', 'ruby'],
+	},
 	configureServer: {
 		type: 'function',
 	},

--- a/src/typings/RsgStyleguidistConfig.ts
+++ b/src/typings/RsgStyleguidistConfig.ts
@@ -24,6 +24,7 @@ interface BaseStyleguidistConfig {
 	configDir: string;
 	context: Record<string, any>;
 	contextDependencies: string[];
+	highlightCodeLanguages: string[];
 	configureServer(server: WebpackDevServer, env: string): string;
 	dangerouslyUpdateWebpackConfig: (server: Configuration, env: string) => Configuration;
 	defaultExample: string | false;

--- a/src/typings/dependencies/load-languages.ts
+++ b/src/typings/dependencies/load-languages.ts
@@ -1,4 +1,0 @@
-declare module 'prism-load-languages' {
-	function loadLanguages(text: string[]): void;
-	export = loadLanguages;
-}

--- a/src/typings/dependencies/prismjs-components-index.ts
+++ b/src/typings/dependencies/prismjs-components-index.ts
@@ -1,0 +1,4 @@
+declare module 'prismjs/components/index' {
+	function LoadLanguages(languages: string | string[]): void;
+	export = LoadLanguages;
+}

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -14,6 +14,7 @@ import './dependencies/deepfreeze';
 import './dependencies/is-directory';
 import './dependencies/q-i';
 import './dependencies/to-ast';
+import './dependencies/prismjs-components-index';
 
 export * from './RsgComponent';
 export * from './RsgExample';

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -14,7 +14,6 @@ import './dependencies/deepfreeze';
 import './dependencies/is-directory';
 import './dependencies/q-i';
 import './dependencies/to-ast';
-import './dependencies/load-languages';
 
 export * from './RsgComponent';
 export * from './RsgExample';


### PR DESCRIPTION
what a excellent Styleguidist, and it is very convenient for component testing. I love it!

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[issues#1378](https://github.com/styleguidist/react-styleguidist/issues/1378)
[pull#1520](https://github.com/styleguidist/react-styleguidist/pull/1520)

### 💡 Background and solution
> languages other then the most common used in component development are not part of the default
> add highlightCodeLanguages option,so that user can decide which Prism highlighting to add to their bundle, instead of the current hardcoded list

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed