### PR TITLE
Fix Component Driven Domain

### DIFF
--- a/site/src/pages/learn.js
+++ b/site/src/pages/learn.js
@@ -34,7 +34,7 @@ const sections = [
 					Learn how to create resilient component libraries using React Styleguidist from its
 					maintainers at{' '}
 					<Link
-						href="https://component-driven.io/offerings"
+						href="https://component-driven.dev/offerings"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -43,7 +43,7 @@ const sections = [
 					.
 				</p>
 				<Link
-					href="https://component-driven.io/offerings"
+					href="https://component-driven.dev/offerings"
 					target="_blank"
 					rel="noopener noreferrer"
 					className={styles.componentDrivenHero}


### PR DESCRIPTION
Seems that Component-Driven have change the domain name from `.io` to `.dev`, and the original domain name is not accessible now.