### PR TITLE
docs: fix link to webpack config

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -30,7 +30,7 @@ We use webpack loaders to hot reload the style guide on changes in user componen
 
 Styleguidist tries to load and reuse the user’s webpack config (`webpack.config.js` in project root folder). It works most of the time but has some restrictions: Styleguidist [ignores](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/utils/mergeWebpackConfig.js) some fields and plugins because they are already included (like `webpack.HotModuleReplacementPlugin`), don’t make sense for a style guide (like `output`) or may break Styleguidist (like `entry`).
 
-We’re trying to keep Styleguidist’s [webpack config](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/make-webpack-config.js) minimal to reduce clashes with the user’s configuration.
+We’re trying to keep Styleguidist’s [webpack config](https://github.com/styleguidist/react-styleguidist/blob/master/src/scripts/make-webpack-config.ts) minimal to reduce clashes with the user’s configuration.
 
 ## React components
 


### PR DESCRIPTION
The source code was migrated to typescript but this link wasn't updated so it is a 404 on this page:
https://react-styleguidist.js.org/docs/development/#webpack-loaders-and-webpack-configuration