### PR TITLE
Supports extra language highlignting

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -136,6 +136,22 @@ Defines the initial state of the example code tab:
 - `hide`: hide the tab and it can´t be toggled in the UI.
 - `expand`: expand the tab by default.
 
+## `extraLanguages`
+
+Type: `String[]`, default: `[]`
+
+Extra alias languages which can be rendered using syntax highlighter. By default, `styleguidist` only highlight web related languages.
+
+Internally it is rendered by [Prism](https://prismjs.com/). See the [supported languages](https://prismjs.com/#supported-languages) with their corresponding alias.
+
+For example, the following configuration will also highlight yaml and C++ syntax from Markdown code blocks.
+
+```javascript
+module.exports = {
+  extraLanguages: ['yaml', 'cpp']
+}
+```
+
 ## `getComponentPathLine`
 
 Type: `Function`, default: component filename

--- a/examples/sections/docs/One.md
+++ b/examples/sections/docs/One.md
@@ -65,6 +65,12 @@ const food = ['Pizza', 'Buger', 'Coffee']
 console.log(eatFood(food))
 ```
 
+```yaml
+- number: 4
+  string: 'A yaml file'
+  null: !!null
+```
+
 Some more text here.
 
 ## Details

--- a/examples/sections/styleguide.config.js
+++ b/examples/sections/styleguide.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	title: 'React Style Guide Example',
 	pagePerSection: true,
 	// tocMode: 'collapse',
+	extraLanguages: ['yaml'],
 	sections: [
 		{
 			name: 'Documentation',

--- a/src/loaders/__tests__/examples-loader.spec.ts
+++ b/src/loaders/__tests__/examples-loader.spec.ts
@@ -15,11 +15,8 @@ const subComponentQuery = {
 	shouldShowDefaultExample: false,
 };
 
-
 const getQuery = (options = {}) => encode({ ...query, ...options }, '?');
 const getSubComponentQuery = (options = {}) => encode({ ...subComponentQuery, ...options }, '?');
-
-
 
 it('should return valid, parsable JS', () => {
 	const exampleMarkdown = `
@@ -93,7 +90,7 @@ it('should pass updateExample function from config to chunkify', () => {
 <h1>Hello world!</h2>
 \`\`\`
 `;
-	const updateExample = jest.fn(props => props);
+	const updateExample = jest.fn((props) => props);
 	examplesLoader.call(
 		{
 			query: getQuery(),
@@ -270,4 +267,28 @@ it('should works for any Markdown file, without a current component', () => {
 		`const React$0 = require('react');\\nconst React = React$0.default || (React$0['React'] || React$0);`
 	);
 	expect(result).not.toMatch('undefined');
+});
+
+it('should format extra languages', () => {
+	const exampleMarkdown = `
+# header
+
+\`\`\`yaml
+- Hello: React
+  Is: !!null
+  There: 3
+  Somebody: 'out there'
+\`\`\`
+`;
+	const result = examplesLoader.call(
+		{
+			query: getQuery(),
+			_styleguidist: { extraLanguages: ['yaml'] },
+		} as any,
+		exampleMarkdown
+	);
+
+	expect(result).toBeTruthy();
+	expect(() => new Function(result)).not.toThrowError(SyntaxError);
+	expect(() => result.includes('<span class="token number">'));
 });

--- a/src/loaders/examples-loader.ts
+++ b/src/loaders/examples-loader.ts
@@ -29,6 +29,12 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 		source = expandDefaultComponent(source, displayName);
 	}
 
+	if (config.extraLanguages) {
+		config.extraLanguages.forEach((lang) => {
+			require('prismjs/components/prism-' + lang);
+		});
+	}
+
 	const updateExample = config.updateExample
 		? (props: Omit<Rsg.CodeExample, 'type'>) => config.updateExample(props, this.resourcePath)
 		: undefined;
@@ -80,7 +86,7 @@ export default function examplesLoader(this: Rsg.StyleguidistLoaderContext, sour
 
 	// Stringify examples object except the evalInContext function
 	const examplesWithEval: (Rsg.RuntimeCodeExample | Rsg.MarkdownExample)[] = examples.map(
-		example => {
+		(example) => {
 			if (example.type === 'code') {
 				return { ...example, evalInContext: { toAST: () => b.identifier('evalInContext') } as any };
 			} else {

--- a/src/scripts/schemas/config.ts
+++ b/src/scripts/schemas/config.ts
@@ -107,6 +107,11 @@ const configSchema: Record<StyleguidistConfigKey, ConfigSchemaOptions<Rsg.Styleg
 		},
 		default: 'collapse',
 	},
+	extraLanguages: {
+		type: 'array',
+		default: [],
+		example: ['yaml'],
+	},
 	getComponentPathLine: {
 		type: 'function',
 		default: (componentPath: string): string => componentPath,

--- a/src/typings/RsgStyleguidistConfig.ts
+++ b/src/typings/RsgStyleguidistConfig.ts
@@ -31,6 +31,7 @@ interface BaseStyleguidistConfig {
 	editorConfig: {
 		theme: string;
 	};
+	extraLanguages: string[];
 	getComponentPathLine(componentPath: string): string;
 	getExampleFilename(componentPath: string): string;
 	handlers: (componentPath: string) => Handler[];


### PR DESCRIPTION
This PR allows to define extra languages which can be highlighted as Markdown code block.

- It exposes a `extraLanguages` to the `styleguidist` configuration
- This config is used to import the required prismjs module
- As prismjs cache such import, the remaining code of `styleguidist` renders properly this extra language

Closes #1857
