### PR TITLE
Fix the vulnerabiltiy issue discussed in #1880

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "to-ast": "^1.0.0",
     "type-detect": "^4.0.8",
     "unist-util-visit": "^2.0.0",
-    "webpack-dev-server": "^3.11.0",
+    "webpack-dev-server": "^4.0.0",
     "webpack-merge": "^4.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi @sapegin, this PR can fix the vulnerability  discussed in https://github.com/styleguidist/react-styleguidist/issues/1880.
It can update `webpack-dev-server ^3.11.0 ➔ ^4.0.0` to remove the  vulnerability [**CVE-2020-28469**](https://snyk.io/vuln/SNYK-JS-GLOBPARENT-1016905) introduced by **glob-parent**, since **webpack-dev-server@4.0.0**(>=4.0.0-beta.0) transitively depends on **glob-parent@5.1.2** which has fixed the vulnerability [**CVE-2020-28469**](https://snyk.io/vuln/SNYK-JS-GLOBPARENT-1016905).
It would be better if **react-styleguidist** can fix this issue in its **11.1.8** release.Then this vulnerbility patch version can be automatically propagated into a large amount of downstream projects :)
Please check it.
Thanks again.