### PR TITLE
ci(node.js): add npm 'cache' to node.js workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
+          cache: npm
 
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
Reference: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies