### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "to-ast": "^1.0.0",
     "type-detect": "^4.0.8",
     "unist-util-visit": "^2.0.0",
-    "webpack-dev-server": "^3.11.2",
+    "webpack-dev-server": "^4.7.4",
     "webpack-merge": "^4.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
webpack-dev-server 3.11.2 -> 4.7.4
This resolve the issue with https://github.com/advisories/GHSA-8fr3-hfg3-gpgp

react-styleguidist@11.2.0 requires node-forge@^0.10.0 via a transitive dependency on selfsigned@1.10.14