### PR TITLE
Upgrade react-simple-code-editor to 0.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19995,9 +19995,9 @@
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
     "react-simple-code-editor": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz",
-      "integrity": "sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.11.2.tgz",
+      "integrity": "sha512-vLMEDj+qLrZ88zK/8bhRdqM2Mp0cQJCUbHPc/QIfxlIYHzAclaAzPX0TQ4ZI5LTYSP3hsYYOT3EciV2dCG4o0Q=="
     },
     "react-test-renderer": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-docgen-displayname-handler": "^3.0.0",
     "react-group": "^3.0.2",
     "react-icons": "^3.8.0",
-    "react-simple-code-editor": "^0.10.0",
+    "react-simple-code-editor": "^0.11.2",
     "recast": "~0.18.5",
     "remark": "^13.0.0",
     "strip-html-comments": "^1.0.0",


### PR DESCRIPTION
Using React 17 with styleguidist, I get following warning:

```
warning "react-styleguidist > react-simple-code-editor@0.10.0" has incorrect peer dependency "react@^16.0.0".
warning "react-styleguidist > react-simple-code-editor@0.10.0" has incorrect peer dependency "react-dom@^16.0.0".
```

`react-simple-code-editor` has shipped a new version with official React 17 support: https://github.com/satya164/react-simple-code-editor/releases/tag/v0.11.1

Let's fix the warning by upgrading.

Thanks!


