### PR TITLE
fix: ensure devserver client options are configurable

### DIFF
--- a/src/scripts/create-server.ts
+++ b/src/scripts/create-server.ts
@@ -36,6 +36,10 @@ export default function createServer(
 	const webpackDevServerConfig: Configuration = {
 		...webpackConfig.devServer,
 		...baseConfig,
+		client: {
+			...webpackConfig.devServer.client,
+			...baseConfig.client,
+		},
 	};
 
 	const compiler = webpack(webpackConfig);


### PR DESCRIPTION
When a custom `webpackConfig.devServer.client` option is set, they are
currently being overridden by the `baseConfig.client` field.

Ensure that field is extendible by consumers while also ensuring the
base config values stay fixed.

https://github.com/styleguidist/react-styleguidist/issues/2033
