### PR TITLE
Remove an example from the Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,6 @@ React Styleguidist is a component development environment with hot reloaded dev 
 
 Real projects using React Styleguidist:
 
-- [Rumble Charts](https://rumble-charts.github.io/rumble-charts/)
 - [better-react-spinkit](http://better-react-spinkit.benjamintatum.com/)
 - [Semantic UI Components for React](https://hallister.github.io/semantic-react/)
 - [Dialog Components](https://dialogs.github.io/dialog-web-components/)


### PR DESCRIPTION
Removed the example as it currently uses Storybook, not react-styleguidist.