### PR TITLE
Ensuring example re-renders always work

### DIFF
--- a/src/client/rsg-components/Preview/Preview.tsx
+++ b/src/client/rsg-components/Preview/Preview.tsx
@@ -1,138 +1,105 @@
-import React, { Component } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { createRoot, Root } from 'react-dom/client';
 import PropTypes from 'prop-types';
 import PlaygroundError from 'rsg-components/PlaygroundError';
 import ReactExample from 'rsg-components/ReactExample';
-import Context, { StyleGuideContextContents } from 'rsg-components/Context';
-import { createRoot, Root } from 'react-dom/client';
-
-const improveErrorMessage = (message: string) =>
-	message.replace(
-		'Check the render method of `StateHolder`.',
-		'Check the code of your example in a Markdown file or in the editor below.'
-	);
+import Context from 'rsg-components/Context';
 
 interface PreviewProps {
 	code: string;
 	evalInContext(code: string): () => any;
 }
 
-interface PreviewState {
-	error: string | null;
+export default function Preview({ code, evalInContext }: PreviewProps) {
+	const [error, setError] = useState('');
+	const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+	const { config, codeRevision } = useContext(Context);
+	const [root, setRoot] = useState<Root>();
+
+	const updateError = useCallback((err: Error) => {
+		const errMessage = err
+			.toString()
+			.replace(
+				'Check the render method of `StateHolder`.',
+				'Check the code of your example in a Markdown file or in the editor below.'
+			);
+		setError(errMessage);
+	}, []);
+
+	const handleError = useCallback(
+		(err: Error) => {
+			updateError(err);
+			console.error(err); // eslint-disable-line no-console
+		},
+		[updateError]
+	);
+
+	useEffect(
+		function clearConsoleWithNewCodeRevision() {
+			if (codeRevision > 0) {
+				console.clear();
+			}
+		},
+		[codeRevision]
+	);
+
+	useEffect(
+		function clearErrorWithNewCode() {
+			setError('');
+		},
+		[code]
+	);
+
+	useEffect(
+		function createRootWithMountNode() {
+			if (!mountNode) {
+				return () => {
+					// noop
+				};
+			}
+
+			const newRoot = createRoot(mountNode);
+			setRoot(newRoot);
+
+			return () => {
+				setTimeout(() => {
+					newRoot.unmount();
+				});
+				setRoot(undefined);
+			};
+		},
+		[mountNode]
+	);
+
+	useEffect(
+		function renderExample() {
+			if (!root) {
+				return;
+			}
+
+			root.render(
+				<ReactExample
+					{...{
+						code,
+						evalInContext,
+						onError: handleError,
+						compilerConfig: config.compilerConfig,
+					}}
+				/>
+			);
+		},
+		[evalInContext, config, handleError, code, root]
+	);
+
+	return (
+		<>
+			<div data-testid="mountNode" ref={setMountNode} />
+			{error ? <PlaygroundError message={error} /> : <></>}
+		</>
+	);
 }
 
-export default class Preview extends Component<PreviewProps, PreviewState> {
-	public static propTypes = {
-		code: PropTypes.string.isRequired,
-		evalInContext: PropTypes.func.isRequired,
-	};
-	public static contextType = Context;
-
-	private mountNode: Element | null = null;
-	private reactRoot: Root | null = null;
-	private timeoutId: number | null = null;
-
-	public state: PreviewState = {
-		error: null,
-	};
-
-	public componentDidMount() {
-		// Clear console after hot reload, do not clear on the first load
-		// to keep any warnings
-		if ((this.context as StyleGuideContextContents).codeRevision > 0) {
-			// eslint-disable-next-line no-console
-			console.clear();
-		}
-
-		this.executeCode();
-	}
-
-	public shouldComponentUpdate(nextProps: PreviewProps, nextState: PreviewState) {
-		return this.state.error !== nextState.error || this.props.code !== nextProps.code;
-	}
-
-	public componentDidUpdate(prevProps: PreviewProps) {
-		if (this.props.code !== prevProps.code) {
-			this.executeCode();
-		}
-	}
-
-	public componentWillUnmount() {
-		this.unmountPreview();
-	}
-
-	public unmountPreview() {
-		const self = this;
-		if (self.timeoutId) {
-			clearTimeout(self.timeoutId);
-		}
-		const id = setTimeout(() => {
-			if (self.reactRoot) {
-				self.reactRoot.unmount();
-				self.reactRoot = null;
-			}
-		});
-		self.timeoutId = id;
-	}
-
-	private executeCode() {
-		this.setState({
-			error: null,
-		});
-
-		const { code } = this.props;
-		if (!code) {
-			return;
-		}
-
-		const wrappedComponent: React.FunctionComponentElement<any> = (
-			<ReactExample
-				code={code}
-				evalInContext={this.props.evalInContext}
-				onError={this.handleError}
-				compilerConfig={(this.context as StyleGuideContextContents).config.compilerConfig}
-			/>
-		);
-
-		window.requestAnimationFrame(() => {
-			// this.unmountPreview();
-			try {
-				if (this.mountNode && this.reactRoot) {
-					this.reactRoot.render(wrappedComponent);
-				}
-			} catch (err) {
-				/* istanbul ignore next: it is near-impossible to trigger a sync error from ReactDOM.render */
-				if (err instanceof Error) {
-					/* istanbul ignore next */
-					this.handleError(err);
-				}
-			}
-		});
-	}
-
-	private handleError = (err: Error) => {
-		this.unmountPreview();
-
-		this.setState({
-			error: improveErrorMessage(err.toString()),
-		});
-
-		console.error(err); // eslint-disable-line no-console
-	};
-
-	private callbackRef = (ref: HTMLDivElement | null) => {
-		this.mountNode = ref;
-		if (!this.reactRoot && ref) {
-			this.reactRoot = createRoot(ref);
-		}
-	};
-
-	public render() {
-		const { error } = this.state;
-		return (
-			<>
-				<div data-testid="mountNode" ref={this.callbackRef} />
-				{error && <PlaygroundError message={error} />}
-			</>
-		);
-	}
-}
+FixedPreview.propTypes = {
+	code: PropTypes.string.isRequired,
+	evalInContext: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
Because the `mountNode` never changes in the previous version of the code, `this.callbackRef` would not get called after an error was thrown. After a second re-render with new code, the Example would simply be blank on the screen (not rendering either an Example or an error message).

https://github.com/styleguidist/react-styleguidist/blob/0802ffbe716fef22086f87f5c6a9caec2f9126d1/src/client/rsg-components/Preview/Preview.tsx#L131-L136

This code ensures that we always get an Example re-render when new code is present.